### PR TITLE
Make integ fixes more robust.

### DIFF
--- a/tst/com/amazon/corretto/crypto/provider/test/integration/ExternalHTTPSIntegrationTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/integration/ExternalHTTPSIntegrationTest.java
@@ -110,7 +110,10 @@ public class ExternalHTTPSIntegrationTest {
             connection = (HttpsURLConnection)url.openConnection();
             connection.setSSLSocketFactory(context.getSocketFactory());
             connection.connect();
-            assertTrue(connection.getResponseCode() < 500 && connection.getResponseCode() >= 200);
+            // We don't actually care what the response code is. Just receiving it means that we successfully
+            // negotiated a TLS session and are now speaking HTTP with the underlying server.
+            assertTrue("Retrieved non-sensical response code: " + connection.getResponseCode(),
+                       connection.getResponseCode() > 0);
         } finally {
             try {
                 connection.getInputStream().close();


### PR DESCRIPTION
Ignore HTTP response codes in integration tests.

Some external servers do not always response with a reasonable response code to our requests.
This might be because of anti-bot logic, but it is irrelevant to testing the actual TLS connection.
So, we now ignore the response code to avoid incorrect test failures

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
