### PR TITLE
Remove unused broken CMakeLists target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,10 +146,6 @@ create_javadoc(
     VERSION TRUE
 )
 
-add_jar(
-    AmazonCorrettoCryptoProvider-javadoc
-    SOURCE
-)
 add_custom_target(javadoc DEPENDS ${JNI_HEADER_DIR}/generated-headers.h ${GENERATED_JAVA_SRC} AmazonCorrettoCryptoProvider_javadoc)
 
 # All subsequent Java targets are compatible with Java 8


### PR DESCRIPTION
The `AmazonCorrettoCryptoProvider-javadoc` target is unused and broken. It doesn't impact these builds but variant uses of cmake will encounter this bug and fail the build. This just removes it.

I have confirmed that javadoc generation (as driven by both gradle and the target `javadoc`) both continue to work properly.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
