### PR TITLE
Track thread safety in NativeResource.

### DIFF
--- a/src/com/amazon/corretto/crypto/provider/EcUtils.java
+++ b/src/com/amazon/corretto/crypto/provider/EcUtils.java
@@ -141,16 +141,7 @@ final class EcUtils {
     }
 
     static final class ECInfo {
-        private final ThreadLocal<NativeGroup> group = new ThreadLocal<NativeGroup>() {
-          @Override
-          protected NativeGroup initialValue() {
-              if (nid != 0) {
-                  return new NativeGroup(buildGroup(nid));
-              } else {
-                  return null;
-              }
-          }
-        };
+        private final NativeGroup group;
         final String name;
         final ECParameterSpec spec;
         final int nid;
@@ -160,6 +151,7 @@ final class EcUtils {
             this.name = name;
             this.spec = spec;
             this.nid = nid;
+            this.group = nid != 0 ? new NativeGroup(buildGroup(nid)) : null;
         }
 
         @Override
@@ -189,7 +181,7 @@ final class EcUtils {
         }
 
         NativeGroup getGroup() {
-            return group.get();
+            return group;
         }
 
         @Override
@@ -201,7 +193,7 @@ final class EcUtils {
 
     static final class NativeGroup extends NativeResource {
         protected NativeGroup(long ptr) {
-            super(ptr, EcUtils::freeGroup);
+            super(ptr, EcUtils::freeGroup, true);
         }
     }
 }

--- a/src/com/amazon/corretto/crypto/provider/RsaCipher.java
+++ b/src/com/amazon/corretto/crypto/provider/RsaCipher.java
@@ -532,7 +532,7 @@ class RsaCipher extends CipherSpi {
 
     private static class NativeRsaKey extends NativeResource {
         protected NativeRsaKey(final long ptr) {
-            super(ptr, RsaCipher::releaseNativeKey);
+            super(ptr, RsaCipher::releaseNativeKey, true);
         }
     }
 


### PR DESCRIPTION
Some native objects can safely be used across multiple threads.
Track this and relax our locking on them for better efficiency.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
