### PR TITLE
Upgrade BouncyCastle test dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,8 +24,8 @@ dependencies {
     jacocoAgent group: 'org.jacoco', name: 'org.jacoco.agent', version: '0.8.3', classifier: 'runtime'
 
     testDep 'junit:junit:4.12'
-    testDep 'org.bouncycastle:bcprov-jdk15on:1.61'
-    testDep 'org.bouncycastle:bcpkix-jdk15on:1.61'
+    testDep 'org.bouncycastle:bcprov-jdk15on:1.62'
+    testDep 'org.bouncycastle:bcpkix-jdk15on:1.62'
     testDep 'commons-codec:commons-codec:1.12'
     testDep 'org.hamcrest:hamcrest:2.1'
     testDep 'org.jacoco:org.jacoco.core:0.8.3'


### PR DESCRIPTION
Upgrade BouncyCastle test dependency to fix bug in TLS test.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
