### PR TITLE
Initial attempt to fix heap space problems in unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
 ## 1.0.4
-No changes from 1.0.3. This version exists to be the official public release version.
+### Maintenance
+* Fix Java heap space issues in unit tests
 
 ## 1.0.3
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -583,6 +583,7 @@ add_custom_target(check-junit
         -Djava.library.path=$<TARGET_FILE_DIR:amazonCorrettoCryptoProvider>
         -Dcom.amazon.corretto.crypto.provider.inTestSuite=hunter2
         -Dtest.data.dir=${TEST_DATA_DIR}
+        -XX:+HeapDumpOnOutOfMemoryError
         ${TEST_JAVA_ARGS}
         com.amazon.corretto.crypto.provider.test.TestRunner --suite unit
 
@@ -595,7 +596,8 @@ add_custom_target(check-junit-extra-checks
         -Djava.library.path=$<TARGET_FILE_DIR:amazonCorrettoCryptoProvider>
         -Dcom.amazon.corretto.crypto.provider.inTestSuite=hunter2
         -Dtest.data.dir=${TEST_DATA_DIR}
-	-Dcom.amazon.corretto.crypto.provider.extrachecks=ALL
+        -Dcom.amazon.corretto.crypto.provider.extrachecks=ALL
+        -XX:+HeapDumpOnOutOfMemoryError
         ${TEST_JAVA_ARGS}
         com.amazon.corretto.crypto.provider.test.TestRunner --suite unit
 

--- a/tst/com/amazon/corretto/crypto/provider/test/AesTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/AesTest.java
@@ -45,6 +45,7 @@ import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 
 import com.amazon.corretto.crypto.provider.AmazonCorrettoCryptoProvider;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -78,6 +79,15 @@ public class AesTest {
         rnd.nextBytes(nonce);
         jceC = Cipher.getInstance(ALGO_NAME);
         amznC = Cipher.getInstance(ALGO_NAME, AmazonCorrettoCryptoProvider.INSTANCE);
+    }
+
+    @After
+    public void teardown() {
+        // It is unclear if JUnit always properly releases references to classes and thus we may have memory leaks
+        // if we do not properly null our references
+        key = null;
+        jceC = null;
+        amznC = null;
     }
 
     private Object getSpiInstance() throws Throwable {

--- a/tst/com/amazon/corretto/crypto/provider/test/EcGenTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/EcGenTest.java
@@ -36,6 +36,7 @@ import org.bouncycastle.asn1.ASN1Encodable;
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 import org.bouncycastle.asn1.ASN1Sequence;
 import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -122,6 +123,14 @@ public class EcGenTest {
     public void setup() throws GeneralSecurityException {
         nativeGen = KeyPairGenerator.getInstance("EC", "AmazonCorrettoCryptoProvider");
         jceGen = KeyPairGenerator.getInstance("EC", "SunEC");
+    }
+
+    @After
+    public void teardown() {
+        // It is unclear if JUnit always properly releases references to classes and thus we may have memory leaks
+        // if we do not properly null our references
+        nativeGen = null;
+        jceGen = null;
     }
 
     @Test

--- a/tst/com/amazon/corretto/crypto/provider/test/EvpKeyAgreementTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/EvpKeyAgreementTest.java
@@ -51,6 +51,7 @@ import org.bouncycastle.asn1.ASN1Sequence;
 import org.bouncycastle.asn1.DERBitString;
 import org.bouncycastle.asn1.DERSequence;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -133,6 +134,14 @@ public class EvpKeyAgreementTest {
     public void setup() throws GeneralSecurityException {
         nativeAgreement = KeyAgreement.getInstance(algorithm, nativeProvider);
         jceAgreement = KeyAgreement.getInstance(algorithm, jceProvider);
+    }
+
+    @After
+    public void teardown() {
+        // It is unclear if JUnit always properly releases references to classes and thus we may have memory leaks
+        // if we do not properly null our references
+        nativeAgreement = null;
+        jceAgreement = null;
     }
 
     private static Object[] buildDhParameters(final int keySize) throws GeneralSecurityException {

--- a/tst/com/amazon/corretto/crypto/provider/test/EvpSignatureTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/EvpSignatureTest.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import java.util.function.BiFunction;
 
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -150,6 +151,15 @@ public class EvpSignatureTest {
         verifier_.initVerify(keyPair_.getPublic());
         jceVerifier_ = getJceSigner();
         jceVerifier_.initVerify(keyPair_.getPublic());
+    }
+
+    @After
+    public void teardown() {
+        // It is unclear if JUnit always properly releases references to classes and thus we may have memory leaks
+        // if we do not properly null our references
+        signer_ = null;
+        verifier_ = null;
+        jceVerifier_ = null;
     }
 
     private Signature getNativeSigner() throws NoSuchAlgorithmException {

--- a/tst/com/amazon/corretto/crypto/provider/test/ServiceSelfTestMetaTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/ServiceSelfTestMetaTest.java
@@ -29,7 +29,7 @@ import com.amazon.corretto.crypto.provider.SelfTestResult;
 import com.amazon.corretto.crypto.provider.SelfTestStatus;
 
 public class ServiceSelfTestMetaTest {
-    AmazonCorrettoCryptoProvider aacp;
+    AmazonCorrettoCryptoProvider accp;
 
     @Before
     public void setUp() throws Throwable {
@@ -38,12 +38,15 @@ public class ServiceSelfTestMetaTest {
 
         // AACP instances cache the self-test status within each Service, so create a new instance to clear that cache.
         // This also makes sure the native library is loaded.
-        aacp = new AmazonCorrettoCryptoProvider();
+        accp = new AmazonCorrettoCryptoProvider();
     }
 
     @After
     public void reset() throws Throwable {
         sneakyInvoke(AmazonCorrettoCryptoProvider.INSTANCE, "resetAllSelfTests");
+        // It is unclear if JUnit always properly releases references to classes and thus we may have memory leaks
+        // if we do not properly null our references
+        accp = null;
     }
 
     @Test
@@ -54,7 +57,7 @@ public class ServiceSelfTestMetaTest {
 
         boolean drbgWasUsable = false;
 
-        for (Provider.Service service : aacp.getServices()) {
+        for (Provider.Service service : accp.getServices()) {
             try {
                 Object instance = service.newInstance(null);
 
@@ -76,7 +79,7 @@ public class ServiceSelfTestMetaTest {
         Object test = TestUtil.sneakyGetField(spi, "SELF_TEST");
         sneakyInvoke(test, "forceFailure");
 
-        for (Provider.Service service : aacp.getServices()) {
+        for (Provider.Service service : accp.getServices()) {
             try {
                 Object instance = service.newInstance(null);
 

--- a/tst/com/amazon/corretto/crypto/provider/test/integration/TestHTTPSServer.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/integration/TestHTTPSServer.java
@@ -218,7 +218,7 @@ public class TestHTTPSServer {
     }
 
     public static void main(String[] args) throws Exception {
-        if (Boolean.parseBoolean(System.getProperty("aacp"))) {
+        if (Boolean.parseBoolean(System.getProperty("accp"))) {
             AmazonCorrettoCryptoProvider.install();
         }
 
@@ -295,11 +295,11 @@ public class TestHTTPSServer {
         t.start();
     }
 
-    public static TestHTTPSServer launch(boolean aacp) throws Exception {
+    public static TestHTTPSServer launch(boolean accp) throws Exception {
         CompletableFuture<Integer> portCompletion = new CompletableFuture<>();
 
         Process process = launchSubJava(
-                "-Daacp=" + aacp,
+                "-Daccp=" + accp,
                 TestHTTPSServer.class.getCanonicalName()
         );
 


### PR DESCRIPTION
Initial attempt to fix heap space problems in unit tests.

JUnit does not properly release references to test cases and so allocated resource will leak unless explicitly nulled. Likewise we avoid creating large numbers of the `BouncyCastleProvider` which can consume significant amounts of memory. This new version has completed successfully using less than 128 MB of heap.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
