### PR TITLE
Add support for 3+ way DH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 1.1.0
 
+### Improvements
+* Now supports DH key agreement for more than two parties.
+
 ### Patches
 * Reject RSA key generation shorter than 512 bits
 * Fix incorrect exception when SunJSSE validates RSA signatures backed by ACCP RSA

--- a/src/com/amazon/corretto/crypto/provider/EvpKeyAgreement.java
+++ b/src/com/amazon/corretto/crypto/provider/EvpKeyAgreement.java
@@ -3,6 +3,7 @@
 
 package com.amazon.corretto.crypto.provider;
 
+import java.math.BigInteger;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.Key;
@@ -17,9 +18,12 @@ import java.util.Arrays;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import javax.crypto.interfaces.DHKey;
 import javax.crypto.KeyAgreementSpi;
 import javax.crypto.SecretKey;
 import javax.crypto.ShortBufferException;
+import javax.crypto.spec.DHParameterSpec;
+import javax.crypto.spec.DHPublicKeySpec;
 import javax.crypto.spec.SecretKeySpec;
 
 class EvpKeyAgreement extends KeyAgreementSpi {
@@ -49,9 +53,7 @@ class EvpKeyAgreement extends KeyAgreementSpi {
         if (privKey == null) {
             throw new IllegalStateException("KeyAgreement has not been initialized");
         }
-        if (!lastPhase) {
-            throw new IllegalStateException("Only single phase agreement is supported");
-        }
+
         if (!keyType_.publicKeyClass.isAssignableFrom(key.getClass())) {
             throw new InvalidKeyException("Expected key of type " + keyType_.publicKeyClass + " not " + key.getClass());
         }
@@ -61,12 +63,33 @@ class EvpKeyAgreement extends KeyAgreementSpi {
         } catch (final InvalidKeySpecException | NullPointerException ex) {
             throw new InvalidKeyException(ex);
         }
-        // We do the actual agreement here because that is where key validation and thus exceptions
-        // get thrown.
-        secret = agree(privKeyDer, pubKeyDer, keyType_.nativeValue,
-            provider_.hasExtraCheck(ExtraCheck.PRIVATE_KEY_CONSISTENCY)
-            );
-        return null;
+
+        if (lastPhase) {
+            // We do the actual agreement here because that is where key validation and thus exceptions
+            // get thrown.
+            secret = agree(privKeyDer, pubKeyDer, keyType_.nativeValue,
+                provider_.hasExtraCheck(ExtraCheck.PRIVATE_KEY_CONSISTENCY)
+                );
+            return null;
+        } else if ("DH".equals(algorithm_)) {
+            final DHParameterSpec dhParams = ((DHKey) privKey).getParams();
+            try {
+                final Key result = keyType_.getKeyFactory().generatePublic(new DHPublicKeySpec(
+                    new BigInteger(1,
+                        agree(privKeyDer, pubKeyDer, keyType_.nativeValue,
+                            provider_.hasExtraCheck(ExtraCheck.PRIVATE_KEY_CONSISTENCY)
+                            )), // y
+                    dhParams.getP(),
+                    dhParams.getG()
+                ));
+                return result;
+            } catch (final InvalidKeySpecException ex) {
+                throw new RuntimeCryptoException(ex);
+            }
+        } else {
+            secret = null;
+            throw new IllegalStateException("Only single phase agreement is supported");
+        }
     }
 
     @Override

--- a/tst/com/amazon/corretto/crypto/provider/test/EvpKeyAgreementTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/EvpKeyAgreementTest.java
@@ -407,8 +407,11 @@ public class EvpKeyAgreementTest {
 
         agree.init(pairs[0].getPrivate(), (AlgorithmParameterSpec) null);
 
-        assertThrows(IllegalStateException.class, "Only single phase agreement is supported",
-                () -> agree.doPhase(pairs[0].getPublic(), false));
+        // This test doesn't apply to DH
+        if (!algorithm.equals("DH")) {
+            assertThrows(IllegalStateException.class, "Only single phase agreement is supported",
+                    () -> agree.doPhase(pairs[0].getPublic(), false));
+        }
         assertThrows(IllegalStateException.class, "KeyAgreement has not been completed", () -> agree.generateSecret());
 
         assertThrows(InvalidKeyException.class,


### PR DESCRIPTION
Adds DH support for more than just two parties. This was discovered by and now passes [this jtreg test](https://github.com/corretto/corretto-8/blob/develop/src/jdk/test/com/sun/crypto/provider/KeyAgreement/DHKeyAgreement3.java).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
