### PR TITLE
Fix security properties file for #46.

### DIFF
--- a/etc/amazon-corretto-crypto-provider.security
+++ b/etc/amazon-corretto-crypto-provider.security
@@ -5,21 +5,45 @@
 # providers that are being shifted down to a different index (which is to say,
 # all of them).
 #
+# Also, JDK9+ handles this list very differently from JDK8.
+# JDK8 requires that providers be specified using fully-qualified class names.
+# JDK9+ supports fully-qualified class names if and only if the module containing the class exports it.
+# For modules which don't export the class in question, the provider must be specified used its "Provider Name".
+# Many of the providers which come as part of the JDK (e.g., SunEC) are not exported from their modules and
+# thus must be specified using their Provider Name rather than their class name.
+#
+# This means that for most of these providers there is no single way to specify them which works for both JDK8 and JDK9+.
+#
+# Rather than have two different copies of this file (one for JDK8 and one for JDK9+) which users must select between
+# depending on which JDK8 they are running, we have created a single merged listing.
+# ACCP is listed first as a fully-qualified class (because it is exported by the module and will work on all systems).
+# After that we alternate between the fully-qualified class (for JDK8) and the provider name for those which
+# are not exported by the module for JDK9+.
+# Each JDK will ignore entries it doesn't understand.
+# JDK8 will determine that there is no class with the short provider name and skip it.
+# JDK9+ will determine that the fully-qualified class is not visible and will skip it.
+#
+# This results in a single list with proper behavior on both JDK8 and JDK9+ systems.
+#
+
 security.provider.1=com.amazon.corretto.crypto.provider.AmazonCorrettoCryptoProvider
 security.provider.2=sun.security.provider.Sun
 security.provider.3=sun.security.rsa.SunRsaSign
 security.provider.4=sun.security.ec.SunEC
-security.provider.5=com.sun.net.ssl.internal.ssl.Provider
-security.provider.6=com.sun.crypto.provider.SunJCE
-security.provider.7=sun.security.jgss.SunProvider
-security.provider.8=com.sun.security.sasl.Provider
-security.provider.9=org.jcp.xml.dsig.internal.dom.XMLDSigRI
-security.provider.10=sun.security.smartcardio
-security.provider.11=sun.security.provider.certpath.ldap.JdkLDAP
-security.provider.12=com.sun.security.sasl.gsskerb.JdkSASL
-security.provider.13=apple.security.AppleProvider
-security.provider.14=sun.security.mscapi.SunMSCAPI
-security.provider.15=sun.security.pkcs11SunPKCS11
+security.provider.5=SunEC
+security.provider.6=com.sun.net.ssl.internal.ssl.Provider
+security.provider.7=com.sun.crypto.provider.SunJCE
+security.provider.8=sun.security.jgss.SunProvider
+security.provider.9=SunJGSS
+security.provider.10=com.sun.security.sasl.Provider
+security.provider.11=SunSASL
+security.provider.12=org.jcp.xml.dsig.internal.dom.XMLDSigRI
+security.provider.13=XMLDSig
+security.provider.14=sun.security.smartcardio.SunPCSC
+security.provider.15=SunPCSC
+security.provider.16=JdkLDAP
+security.provider.17=JdkSASL
+security.provider.18=SunPKCS11
 
 #
 # A list of known strong SecureRandom implementations.

--- a/tst/com/amazon/corretto/crypto/provider/test/SecurityPropertyTester.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/SecurityPropertyTester.java
@@ -5,8 +5,11 @@ package com.amazon.corretto.crypto.provider.test;
 
 import static org.junit.Assert.assertEquals;
 
+import java.security.KeyPairGenerator;
 import java.security.Provider;
 import java.security.Security;
+import java.util.HashSet;
+import java.util.Set;
 
 import com.amazon.corretto.crypto.provider.AmazonCorrettoCryptoProvider;
 
@@ -14,10 +17,22 @@ import com.amazon.corretto.crypto.provider.AmazonCorrettoCryptoProvider;
  * This is a special stand-alone test case which asserts that AmazonCorrettoCryptoProvider is installed as the highers priority provider and is functional.
  */
 public class SecurityPropertyTester {
-  public static void main(String[] args) {
+  public static void main(String[] args) throws Exception {
     final Provider provider = Security.getProviders()[0];
     assertEquals("AmazonCorrettoCryptoProvider", provider.getName());
     final AmazonCorrettoCryptoProvider njb = (AmazonCorrettoCryptoProvider) provider;
     njb.assertHealthy();
+
+    // We know that Java has the SunEC provider which can generate EC keys.
+    // We try to grab it to show that the nothing interfered with proper provider loading.
+    KeyPairGenerator kpg = KeyPairGenerator.getInstance("EC", "SunEC");
+
+    // Also ensure that nothing shows up twice
+    Set<String> names = new HashSet<>();
+    for (Provider p : Security.getProviders()) {
+        if (!names.add(p.getName())) {
+            throw new AssertionError("Duplicate found for " + p.getName());
+        }
+    }
   }
 }


### PR DESCRIPTION
JDK8 and JDK9+ specify providers in the properties files differently.
This modifies our .security file to work properly in both versions.
In addition to the new test I have manually verified this against Corretto 8 and Corretto 11.

Issue #46

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
