### PR TITLE
Allow version of java for testing to be overridden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.1.1 (Unreleased)
+
+### Patches
+* `amazon-corretto-crypto-provider.security` updated to work on both JDK8 and JDK9+
+
+### Maintenance
+* Support using a different JDK for testing via the `TEST_JAVA_HOME` JVM property
+
 ## 1.1.0
 
 ### Improvements

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = 'software.amazon.cryptools'
-version = '1.1.0'
+version = '1.1.1'
 
 configurations {
     jacocoAgent
@@ -95,11 +95,19 @@ task executeCmake(type: Exec) {
         prebuiltJar = "${projectDir}/" + System.properties['prebuiltJar']
     }
 
+    executable 'cmake'
+    args 'cmake', "-DTEST_CLASSPATH=${configurations.testDep.asPath}", "-DJACOCO_AGENT_JAR=${configurations.jacocoAgent.singleFile}"
+    args "-DOPENSSL_ROOT_DIR=${buildDir}/openssl/bin", '-DCMAKE_BUILD_TYPE=Release', '-DPROVIDER_VERSION_STRING=' + version
+
     if (prebuiltJar != null) {
-        commandLine 'cmake', "-DTEST_CLASSPATH=${configurations.testDep.asPath}", "-DJACOCO_AGENT_JAR=${configurations.jacocoAgent.singleFile}", "-DOPENSSL_ROOT_DIR=${buildDir}/openssl/bin", '-DCMAKE_BUILD_TYPE=Release', '-DSIGNED_JAR=' + prebuiltJar, '-DPROVIDER_VERSION_STRING=' + version, projectDir
-    } else {
-        commandLine 'cmake', "-DTEST_CLASSPATH=${configurations.testDep.asPath}", "-DJACOCO_AGENT_JAR=${configurations.jacocoAgent.singleFile}", "-DOPENSSL_ROOT_DIR=${buildDir}/openssl/bin", '-DCMAKE_BUILD_TYPE=Release', '-DPROVIDER_VERSION_STRING=' + version, projectDir
+       args '-DSIGNED_JAR=' + prebuiltJar
     }
+
+    if (System.properties['TEST_JAVA_HOME'] != null) {
+        args '-DTEST_JAVA_HOME=' + System.properties['TEST_JAVA_HOME']
+    }
+
+    args projectDir
 }
 
 task build_objects(type: Exec) {


### PR DESCRIPTION
Permits overriding the version of Java used to run all tests. This can be done by passing the correct *JAVA_HOME* to the JVM property `TEST_JAVA_HOME` when running gradle.  For example: `./gradlew -DTEST_JAVA_HOME=/usr/lib/jvm/amazon-corretto-8 test`

This is a followup to #46 and #49.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
