### PR TITLE
 Improve handling of single byte in TemplateHashSpi 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Patches
 * `amazon-corretto-crypto-provider.security` updated to work on both JDK8 and JDK9+
+* Improve performance of single-byte handling in message digests.
 
 ### Maintenance
 * Support using a different JDK for testing via the `TEST_JAVA_HOME` JVM property

--- a/template-src/com/amazon/corretto/crypto/provider/TemplateHashSpi.java
+++ b/template-src/com/amazon/corretto/crypto/provider/TemplateHashSpi.java
@@ -28,6 +28,7 @@ public final class TemplateHashSpi extends MessageDigestSpi implements Cloneable
     private static final int HASH_SIZE;
     private static final byte[] INITIAL_CONTEXT;
 
+    private byte[] oneByteArray = null;
     private InputBuffer<byte[], byte[]> buffer;
 
     static {
@@ -117,7 +118,11 @@ public final class TemplateHashSpi extends MessageDigestSpi implements Cloneable
 
     @Override
     protected void engineUpdate(byte input) {
-        engineUpdate(new byte[] { input }, 0, 1);
+        if (oneByteArray == null) {
+            oneByteArray = new byte[1];
+        }
+        oneByteArray[0] = input;
+        engineUpdate(oneByteArray, 0, 1);
     }
 
     // Note that routines that interact with the native buffer need to be synchronized, to ensure that we don't cause

--- a/tst/com/amazon/corretto/crypto/provider/test/AesCtrDrbgTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/AesCtrDrbgTest.java
@@ -28,6 +28,7 @@ import java.util.Scanner;
 import com.amazon.corretto.crypto.provider.AmazonCorrettoCryptoProvider;
 import org.apache.commons.codec.DecoderException;
 import org.apache.commons.codec.binary.Hex;
+import org.junit.After;
 import org.junit.Assume;
 import org.junit.AssumptionViolatedException;
 import org.junit.Before;
@@ -45,6 +46,11 @@ public class AesCtrDrbgTest {
         Assume.assumeTrue("RDRand must be supported", AmazonCorrettoCryptoProvider.isRdRandSupported());
 
         rnd = new AesCtrDrbg();
+    }
+
+    @After
+    public void teardown() {
+        rnd = null;
     }
 
     @Test

--- a/tst/com/amazon/corretto/crypto/provider/test/AesTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/AesTest.java
@@ -56,7 +56,7 @@ public class AesTest {
     private static final String ALGO_NAME = "AES/GCM/NoPadding";
     private static final String PROVIDER_SUN = "SunJCE";
     private static final String PROVIDER_AMAZON = "AmazonCorrettoCryptoProvider";
-    private final byte[] nonce = new byte[12];
+    private byte[] nonce;
     private SecretKeySpec key;
     private Cipher jceC;
     private Cipher amznC;
@@ -76,6 +76,7 @@ public class AesTest {
         byte[] foo = new byte[16];
         rnd.nextBytes(foo);
         key = new SecretKeySpec(foo, "AES");
+        nonce = new byte[12];
         rnd.nextBytes(nonce);
         jceC = Cipher.getInstance(ALGO_NAME);
         amznC = Cipher.getInstance(ALGO_NAME, AmazonCorrettoCryptoProvider.INSTANCE);
@@ -88,6 +89,7 @@ public class AesTest {
         key = null;
         jceC = null;
         amznC = null;
+        nonce = null;
     }
 
     private Object getSpiInstance() throws Throwable {

--- a/tst/com/amazon/corretto/crypto/provider/test/EvpSignatureTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/EvpSignatureTest.java
@@ -55,8 +55,6 @@ public class EvpSignatureTest {
     private static final int[] MESSAGE_LENGTHS = new int[] { 0, 1, 16, 32, 2047, 2048, 2049, 4100 };
     private static Map<String, KeyPair> KEY_PAIRS;
 
-    private final byte[] message_;
-
     static {
         try {
             final Map<String, KeyPair> tmpMap = new HashMap<>();
@@ -120,32 +118,27 @@ public class EvpSignatureTest {
     private final boolean readOnly_;
     private final boolean slice_;
     private final KeyPair keyPair_;
-    private final byte[] goodSignature_;
+    private final int length_;
 
+    private byte[] message_;
     private Signature signer_;
     private Signature verifier_;
     private Signature jceVerifier_;
+    private byte[] goodSignature_;
 
     public EvpSignatureTest(final String base, final String hash, final int length, boolean readOnly, boolean slice) throws GeneralSecurityException {
         base_ = base;
         hash_ = hash;
         readOnly_ = readOnly;
         slice_ = slice;
-        message_ = new byte[length];
+        length_ = length;
 
-        for (int x = 0; x < message_.length; x++) {
-            message_[x] = (byte) ((x % 256) - 128);
-        }
         if (base_.startsWith("RSA")) {
             keyPair_ = KEY_PAIRS.get("RSA");
         } else {
             keyPair_ = KEY_PAIRS.get(base_);
         }
         algorithm_ = format("%swith%s", hash_, base_);
-        final Signature jceSigner = getJceSigner();
-        jceSigner.initSign(keyPair_.getPrivate());
-        jceSigner.update(message_);
-        goodSignature_ = jceSigner.sign();
     }
 
     @Before
@@ -156,6 +149,17 @@ public class EvpSignatureTest {
         verifier_.initVerify(keyPair_.getPublic());
         jceVerifier_ = getJceSigner();
         jceVerifier_.initVerify(keyPair_.getPublic());
+
+        message_ = new byte[length_];
+
+        for (int x = 0; x < message_.length; x++) {
+            message_[x] = (byte) ((x % 256) - 128);
+        }
+
+        final Signature jceSigner = getJceSigner();
+        jceSigner.initSign(keyPair_.getPrivate());
+        jceSigner.update(message_);
+        goodSignature_ = jceSigner.sign();
     }
 
     @After
@@ -165,6 +169,8 @@ public class EvpSignatureTest {
         signer_ = null;
         verifier_ = null;
         jceVerifier_ = null;
+        message_ = null;
+        goodSignature_ = null;
     }
 
     private Signature getNativeSigner() throws NoSuchAlgorithmException {


### PR DESCRIPTION
This is to fix #52 and improve performance of single-byte handling in our message digest implementations. It also includes yet another fix to our tests to lower testing heap usage.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
