### PR TITLE
Remove "unreleased" note from CHANGELOG for 1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.1.1 (Unreleased)
+## 1.1.1
 
 ### Patches
 * `amazon-corretto-crypto-provider.security` updated to work on both JDK8 and JDK9+


### PR DESCRIPTION
Remove "unreleased" note from CHANGELOG for 1.1.1

This is the final change prior to cutting the v1.1.1 release.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
