### PR TITLE
Yet more fixes to unit test heap errors.

### DIFF
--- a/tst/com/amazon/corretto/crypto/provider/test/AESGenerativeTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/AESGenerativeTest.java
@@ -38,6 +38,7 @@ import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 
 import com.amazon.corretto.crypto.provider.AmazonCorrettoCryptoProvider;
+import org.junit.After;
 import org.junit.Test;
 
 public class AESGenerativeTest {
@@ -52,6 +53,15 @@ public class AESGenerativeTest {
 
     public AESGenerativeTest() throws Exception {
         Security.addProvider(AmazonCorrettoCryptoProvider.INSTANCE);
+    }
+
+
+    @After
+    public void teardown() {
+        jceCipherEncrypt = null;
+        jceCipherDecrypt = null;
+        amzCipherEncrypt = null;
+        amzCipherDecrypt = null;
     }
 
     @Test

--- a/tst/com/amazon/corretto/crypto/provider/test/EvpKeyAgreementSpecificTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/EvpKeyAgreementSpecificTest.java
@@ -32,27 +32,25 @@ public class EvpKeyAgreementSpecificTest {
     private static final Class<?> SPI_CLASS;
     private static final int EC_TYPE = 408;
     private static final int DH_TYPE = 28;
-    private final KeyPair EC_KEYPAIR;
-    private final KeyPair DH_KEYPAIR;
+    private static final KeyPair EC_KEYPAIR;
+    private static final KeyPair DH_KEYPAIR;
 
     static {
       try {
           SPI_CLASS = Class.forName("com.amazon.corretto.crypto.provider.EvpKeyAgreement");
-      } catch (final ClassNotFoundException ex) {
+
+          // Force loading of native library
+          KeyAgreement.getInstance("ECDH", AmazonCorrettoCryptoProvider.INSTANCE);
+
+          KeyPairGenerator gen = KeyPairGenerator.getInstance("EC");
+          gen.initialize(new ECGenParameterSpec("NIST P-224"));
+          EC_KEYPAIR = gen.generateKeyPair();
+          gen = KeyPairGenerator.getInstance("DH");
+          gen.initialize(1024);
+          DH_KEYPAIR = gen.generateKeyPair();
+      } catch (final Exception ex) {
           throw new AssertionError(ex);
       }
-    }
-
-    public EvpKeyAgreementSpecificTest() throws GeneralSecurityException {
-        // Force loading of native library
-        KeyAgreement.getInstance("ECDH", AmazonCorrettoCryptoProvider.INSTANCE);
-
-        KeyPairGenerator gen = KeyPairGenerator.getInstance("EC");
-        gen.initialize(new ECGenParameterSpec("NIST P-224"));
-        EC_KEYPAIR = gen.generateKeyPair();
-        gen = KeyPairGenerator.getInstance("DH");
-        gen.initialize(1024);
-        DH_KEYPAIR = gen.generateKeyPair();
     }
 
     @Test

--- a/tst/com/amazon/corretto/crypto/provider/test/EvpKeyAgreementTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/EvpKeyAgreementTest.java
@@ -66,12 +66,12 @@ public class EvpKeyAgreementTest {
     @SuppressWarnings("unused")
     private final String displayName;
     @SuppressWarnings("unused")
-    private final KeyPairGenerator keyGen;
+    private KeyPairGenerator keyGen;
     // We test pairwise across lots of keypairs in an effort
     // to catch rarer edge-cases.
     private KeyPair[] pairs;
     private byte[][][] rawSecrets;
-    private final List<? extends PublicKey> invalidKeys;
+    private List<? extends PublicKey> invalidKeys;
     private final Provider nativeProvider;
     private final Provider jceProvider;
     private KeyAgreement nativeAgreement;
@@ -142,6 +142,8 @@ public class EvpKeyAgreementTest {
         jceAgreement = null;
         pairs = null;
         rawSecrets = null;
+        invalidKeys = null;
+        keyGen = null;
     }
 
     private static Object[] buildDhParameters(final int keySize) throws GeneralSecurityException {

--- a/tst/com/amazon/corretto/crypto/provider/test/SecurityManagerTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/SecurityManagerTest.java
@@ -41,6 +41,7 @@ public class SecurityManagerTest {
         System.setSecurityManager(null);
 
         Security.removeProvider("AmazonCorrettoCryptoProvider");
+        threadToDeny = null;
     }
 
     @Test(expected = SecurityException.class)


### PR DESCRIPTION
*Description of changes:*

This cleans up more instance variables in our unit tests to work around JUnit holding onto all test instances and exhausting our heap when running unit tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
