### PR TITLE
Allow colorless output from tests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.1.2 (Unreleased)
 ### Maintenance
 * Add prefix to test output lines indicating if suite will fail.
+* Now colored output from tests can be disabled by setting the environment variable `ACCP_TEST_COLOR` to `false`
 
 ## 1.1.1
 

--- a/tst/com/amazon/corretto/crypto/provider/test/TestRunner.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/TestRunner.java
@@ -30,11 +30,23 @@ import com.amazon.corretto.crypto.provider.test.integration.LocalHTTPSIntegratio
 
 @SuppressWarnings({"rawtypes", "deprecation"})
 public class TestRunner {
-    private static final String BRIGHT_TEXT = (char)27 + "[1m";
-    private static final String BRIGHT_RED_TEXT = (char)27 + "[31;1m";
-    private static final String BRIGHT_GREEN_TEXT = (char)27 + "[32;1m";
-    private static final String BRIGHT_CYAN_TEXT = (char)27 + "[36;1m";
-    private static final String NORMAL_TEXT = (char)27 + "[0m";
+    /**
+     * Reads the ACCP_TEST_COLOR environment variable and if it is case-insensitive equal to "false",
+     * returns the empty string. Else, returns the proper control codes to set the color/font specified by {@code code}.
+     */
+    private static final String maybeColor(String code) {
+        final String envVarValue = System.getenv("ACCP_TEST_COLOR");
+        if ("false".equalsIgnoreCase(envVarValue)) {
+            return "";
+        }
+
+        return (char)27 + "[" + code + "m";
+    }
+    private static final String BRIGHT_TEXT = maybeColor("1");
+    private static final String BRIGHT_RED_TEXT = maybeColor("31;1");
+    private static final String BRIGHT_GREEN_TEXT = maybeColor("32;1");
+    private static final String BRIGHT_CYAN_TEXT = maybeColor("36;1");
+    private static final String NORMAL_TEXT = maybeColor("0");
     private static final String NOT_YET_FAILED_NOTICE = "  ";
     private static final String ALREADY_FAILED_NOTICE = BRIGHT_RED_TEXT + "!" + NORMAL_TEXT;
     private static final String STARTED_NOTICE = BRIGHT_TEXT +                "[STARTED]         " + NORMAL_TEXT;


### PR DESCRIPTION
Allow colorless output from tests. If the `ACCP_TEST_COLOR` environment variable is set to "false" then color is omitted from the test output. This is intended to make logs from CodeBuild more readable. (I've preemptively set this flag in CodeBuild.)  I did manual test on my build machine to check for proper behavior.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
