### PR TITLE
Add check for broken Ryzen RDRAND

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.2.1 (Unreleased)
+
+### Patches
+* Detects stuck AMD Ryzen RDRAND and correctly treats as an error
+
 ## 1.2.0
 
 ### Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,12 @@
 # Changelog
 
-## 1.2.1 (Unreleased)
-
-### Patches
-* Detects stuck AMD Ryzen RDRAND and correctly treats as an error
-
-## 1.2.0
+## 1.2.0 (Unreleased)
 
 ### Improvements
 * Now uses [OpenSSL 1.1.1.d](https://www.openssl.org/source/openssl-1.1.1d.tar.gz)
+
+### Patches
+* Detects stuck AMD Ryzen RDRAND and correctly treats as an error
 
 ### Maintenance
 * Add prefix to test output lines indicating if suite will fail.

--- a/csrc/env.h
+++ b/csrc/env.h
@@ -23,6 +23,10 @@
 #include <openssl/err.h>
 #endif
 
+#ifndef UINT64_MAX
+#define UINT64_MAX (~((uint64_t) 0))
+#endif
+
 namespace AmazonCorrettoCryptoProvider {
     void capture_trace(std::vector<void *> &trace) COLD;
     void format_trace(std::ostringstream &, const std::vector<void *> &trace) COLD;

--- a/csrc/rdrand.cpp
+++ b/csrc/rdrand.cpp
@@ -292,7 +292,7 @@ bool rng_retry_rdrand(uint64_t *dest) {
             // negligible (1/2^63). Finally, adding processor specific logic would greatly
             // increase the complexity and would cause us to "miss" any unknown processors with
             // similar bugs.
-            if (unlikely(*dest != UINT64_MAX || *dest != 0)) {
+            if (likely(*dest != UINT64_MAX && *dest != 0)) {
                 return true;
             }
         }

--- a/csrc/rdrand.cpp
+++ b/csrc/rdrand.cpp
@@ -144,7 +144,7 @@ bool rng_rdseed(uint64_t *out) {
 
     bool success;
     __asm__ __volatile__(
-	ASM_RDSEED_RCX
+        ASM_RDSEED_RCX
         "setc %%al\n" // rax = 1 if success, 0 if fail
         : "=c" (*out), "=a" (success)
         : "c" (0), "a" (0)

--- a/csrc/test_rdrand.cpp
+++ b/csrc/test_rdrand.cpp
@@ -10,6 +10,7 @@
 
 #undef NDEBUG
 
+#include "env.h"
 #include "rdrand.h"
 #include "config.h"
 #include <stdlib.h>
@@ -37,6 +38,16 @@ bool rng_alternating(uint64_t *out) {
     }
 
     *out = counter;
+    return true;
+}
+
+bool rng_stuck_zero(uint64_t *out) {
+    *out = 0;
+    return true;
+}
+
+bool rng_stuck_ff(uint64_t *out) {
+    *out = UINT64_MAX;
     return true;
 }
 
@@ -196,6 +207,25 @@ void when_rdseed_broken_rdrand_reduction_used() {
     TEST_ASSERT(!memcmp(expected, buf, sizeof(buf)));
 }
 
+void when_rdrand_stuck_failure_returned() {
+    static const uint8_t expected[32] = { 0 };
+    static uint8_t buf[32];
+
+    hook_rdrand = rng_stuck_zero;
+
+    memset(buf, 1, sizeof(buf));
+
+    TEST_ASSERT(!rdrand(buf, sizeof(buf)));
+    TEST_ASSERT(!memcmp(expected, buf, sizeof(buf)));
+
+    memset(buf, 1, sizeof(buf));
+
+    hook_rdrand = rng_stuck_ff;
+
+    TEST_ASSERT(!rdrand(buf, sizeof(buf)));
+    TEST_ASSERT(!memcmp(expected, buf, sizeof(buf)));
+}
+
 } // anon namespace
 
 #define RUNTEST(name) do { \
@@ -220,7 +250,7 @@ int main() {
     RUNTEST(when_rng_fails_late_buffer_is_still_cleared);
     RUNTEST(when_rdrand_broken_rdseed_works_eventually);
     RUNTEST(when_rdseed_broken_rdrand_reduction_used);
-
+    RUNTEST(when_rdrand_stuck_failure_returned);
     return success ? 0 : 1;
 }
 

--- a/csrc/test_rdrand.cpp
+++ b/csrc/test_rdrand.cpp
@@ -251,6 +251,7 @@ int main() {
     RUNTEST(when_rdrand_broken_rdseed_works_eventually);
     RUNTEST(when_rdseed_broken_rdrand_reduction_used);
     RUNTEST(when_rdrand_stuck_failure_returned);
+
     return success ? 0 : 1;
 }
 


### PR DESCRIPTION
**It is important that the `dieharder` acceptance test passes before this PR is merged.**

*Description of changes:*
Some AMD Ryzen CPUs get into a bad state where the output of RDRAND becomes "stuck" on a value of all 1s (e.g., every bit in the output is a one). Unfortunately, it doesn't correctly set the carry flag to indicate an RNG failure.

This change detects this case and handles it as a standard RNG error. It does this by watching for the suspicious value of `0xffffffffffffffff` and if it is seen, checks to see if the RNG is stuck on that value. We take this strategy rather than failing upon simply seeing a single instance of `0xffffffffffffffff` for two reasons:
1. We don't like the odds of a 1/2^64 false positive. It's low, but this library is used in masssively large scale systems.
2. We don't like the (negligible) bias introduced by rejecting any output with the value `0xffffffffffffffff`. This avoids all biased output.

We also check for the suspicious value of `0` using the same technique. While we believe all modern systems to correctly set the carry flag on failure, some old/non-standard systems used a `0` to indicate failure.

For more context please see this [Ars Technical article](https://arstechnica.com/gadgets/2019/10/how-a-months-old-amd-microcode-bug-destroyed-my-weekend/) and this [systemd patch](https://github.com/systemd/systemd/commit/b62bc66018fa1ada09554e7ee46abbbfc8e6b3ad).

To support some libraries which do not define `UINT64_MAX`, I also added a definition for this. As evidence that it is being correctly defined, here is the disassembled version of `rng_rdseed` which is correctly checking against the suspicious value of 64 bits of 1s.
```
00000000000419d0 <_ZN28AmazonCorrettoCryptoProvider10rng_rdrandEPm>:
   419d0:       31 d2                   xor    %edx,%edx
   419d2:       89 d1                   mov    %edx,%ecx
   419d4:       89 d0                   mov    %edx,%eax
   419d6:       48 0f c7 f1             rdrand %rcx
   419da:       0f 92 c0                setb   %al
   419dd:       84 c0                   test   %al,%al
   419df:       41 89 c0                mov    %eax,%r8d
   419e2:       48 89 ce                mov    %rcx,%rsi
   419e5:       48 89 0f                mov    %rcx,(%rdi)
   419e8:       74 0a                   je     419f4 <_ZN28AmazonCorrettoCryptoProvider10rng_rdrandEPm+0x24>
   419ea:       48 8d 49 ff             lea    -0x1(%rcx),%rcx
   419ee:       48 83 f9 fd             cmp    $0xfffffffffffffffd,%rcx
   419f2:       77 04                   ja     419f8 <_ZN28AmazonCorrettoCryptoProvider10rng_rdrandEPm+0x28>
   419f4:       44 89 c0                mov    %r8d,%eax
   419f7:       c3                      retq
   419f8:       89 d1                   mov    %edx,%ecx
   419fa:       89 d0                   mov    %edx,%eax
   419fc:       48 0f c7 f1             rdrand %rcx
   41a00:       0f 92 c0                setb   %al
   41a03:       48 39 ce                cmp    %rcx,%rsi
   41a06:       41 89 c0                mov    %eax,%r8d
   41a09:       75 e9                   jne    419f4 <_ZN28AmazonCorrettoCryptoProvider10rng_rdrandEPm+0x24>
   41a0b:       48 c7 07 00 00 00 00    movq   $0x0,(%rdi)
   41a12:       45 31 c0                xor    %r8d,%r8d
   41a15:       eb dd                   jmp    419f4 <_ZN28AmazonCorrettoCryptoProvider10rng_rdrandEPm+0x24>
   41a17:       66 0f 1f 84 00 00 00    nopw   0x0(%rax,%rax,1)
   41a1e:       00 00
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
