### PR TITLE
Adds support for IEEE P1363 formatted ECDSA signatures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Changelog
 
-## 1.3.0
+## 1.3.0 (Unreleased)
 
-### Improvements (Unreleased)
+### Improvements
+* Now supports ECDSA signatures in IEEE P1363 Format. (Also known as "raw" or "plain".) [PR #75](https://github.com/corretto/amazon-corretto-crypto-provider/pull/75)
 * Now allows cloning of `Mac` objects. [PR #78](https://github.com/corretto/amazon-corretto-crypto-provider/pull/78)
 
 ## 1.2.0

--- a/README.md
+++ b/README.md
@@ -45,10 +45,15 @@ Signature algorithms:
 * SHA384withDSA
 * NONEwithECDSA
 * SHA1withECDSA
+* SHA1withECDSAinP1363Format
 * SHA224withECDSA
+* SHA224withECDSAinP1363Format
 * SHA256withECDSA
+* SHA256withECDSAinP1363Format
 * SHA384withECDSA
+* SHA384withECDSAinP1363Format
 * SHA512withECDSA
+* SHA512withECDSAinP1363Format
 
 KeyPairGenerator algorithms:
 * EC

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ dependencies {
     jacocoAgent group: 'org.jacoco', name: 'org.jacoco.agent', version: '0.8.3', classifier: 'runtime'
 
     testDep 'junit:junit:4.12'
-    testDep 'org.bouncycastle:bcprov-jdk15on:1.61'
+    testDep 'org.bouncycastle:bcprov-debug-jdk15on:1.61'
     testDep 'org.bouncycastle:bcpkix-jdk15on:1.61'
     testDep 'commons-codec:commons-codec:1.12'
     testDep 'org.hamcrest:hamcrest:2.1'

--- a/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
+++ b/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
@@ -97,10 +97,10 @@ public final class AmazonCorrettoCryptoProvider extends java.security.Provider {
         for (final String base : bases) {
             for (final String hash : hashes) {
                 final String algorithm = format("%swith%s", hash, base);
-                final String className = String.format("EvpSignature$%s", algorithm);
+                final String className = format("EvpSignature$%s", algorithm);
                 addService("Signature", algorithm, className);
                 if (base.equals("ECDSA")) {
-                    addService("Signature", algorithm + "inP1363Format", className);
+                    addService("Signature", algorithm + EvpSignatureBase.P1363_FORMAT_SUFFIX, className);
                 }
             }
         }

--- a/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
+++ b/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
@@ -97,7 +97,11 @@ public final class AmazonCorrettoCryptoProvider extends java.security.Provider {
         for (final String base : bases) {
             for (final String hash : hashes) {
                 final String algorithm = format("%swith%s", hash, base);
-                addService("Signature", algorithm, String.format("EvpSignature$%s", algorithm));
+                final String className = String.format("EvpSignature$%s", algorithm);
+                addService("Signature", algorithm, className);
+                if (base.equals("ECDSA")) {
+                    addService("Signature", algorithm + "inP1363Format", className);
+                }
             }
         }
 
@@ -121,6 +125,7 @@ public final class AmazonCorrettoCryptoProvider extends java.security.Provider {
 
     private class ACCPService extends Service {
         private final MethodHandle ctor;
+        private final MethodHandle algorithmSetter;
 
         // @GuardedBy("this") // Restore once replacement for JSR-305 available
         private boolean failMessagePrinted = false;
@@ -148,9 +153,22 @@ public final class AmazonCorrettoCryptoProvider extends java.security.Provider {
                         .bindTo(AmazonCorrettoCryptoProvider.this);
                 }
                 ctor = tmpCtor;
+
+                MethodHandle tmpAlgSetter = null;
+                final MethodType setterSignature = MethodType.methodType(void.class, String.class);
+                try {
+                    tmpAlgSetter = LOOKUP.findVirtual(klass, "setAlgorithmName", setterSignature);
+                } catch (final NoSuchMethodException ex) {
+                    if (type.equals("Signature")) {
+                        throw ex;
+                    }
+                    // Just ignore this
+                }
+                algorithmSetter = tmpAlgSetter;
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }
+
         }
 
         @Override public Object newInstance(final Object constructorParameter) throws NoSuchAlgorithmException {
@@ -165,7 +183,11 @@ public final class AmazonCorrettoCryptoProvider extends java.security.Provider {
             }
 
             try {
-                return (Object) ctor.invokeExact();
+                Object result = (Object) ctor.invokeExact();
+                if (algorithmSetter != null) {
+                    algorithmSetter.invoke(result, getAlgorithm());
+                }
+                return result;
             } catch (RuntimeException | Error e) {
                 throw e;
             } catch (Throwable t) {

--- a/src/com/amazon/corretto/crypto/provider/EvpSignature.java
+++ b/src/com/amazon/corretto/crypto/provider/EvpSignature.java
@@ -7,7 +7,6 @@ import java.nio.ByteBuffer;
 import java.security.SignatureException;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.security.spec.X509EncodedKeySpec;
-import java.util.Arrays;
 
 class EvpSignature extends EvpSignatureBase {
     /** The number a times a key must be reused prior to keeping it in native memory rather than freeing it each time. **/

--- a/src/com/amazon/corretto/crypto/provider/EvpSignatureBase.java
+++ b/src/com/amazon/corretto/crypto/provider/EvpSignatureBase.java
@@ -14,7 +14,6 @@ import java.security.PublicKey;
 import java.security.SignatureException;
 import java.security.SignatureSpi;
 import java.security.interfaces.ECKey;
-import java.security.interfaces.ECPublicKey;
 import java.security.spec.AlgorithmParameterSpec;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.PKCS8EncodedKeySpec;
@@ -23,6 +22,8 @@ import java.util.Arrays;
 import java.util.Base64;
 
 abstract class EvpSignatureBase extends SignatureSpi {
+    // Package visible so main Provider can use it
+    static final String P1363_FORMAT_SUFFIX = "inP1363Format";
     protected static final int RSA_PKCS1_PADDING = 1;
     protected final EvpKeyType keyType_;
     protected final int paddingType_;
@@ -169,14 +170,14 @@ abstract class EvpSignatureBase extends SignatureSpi {
      * Converts and returns the modified signature to verify <em>only if necessary</em> and returns {@code null} otherwise.
      * If {@code null} is returned then the passed in parameters should be used for later verification.
      * Otherwise, the entire returned array should be used.
-     * This method has a somewhat odd API since we want to avoid unneccessary array copies/allocations and it is an
+     * This method has a somewhat odd API since we want to avoid unnecessary array copies/allocations and it is an
      * internal API anyway.
      *
      * @return the converted signature or {@code null} if no conversion is necessary
      * @throws SignatureException if the signature is badly malformed
      */
     protected byte[] maybeConvertSignatureToVerify(byte[] signature, int offset, int length) throws SignatureException {
-        if (algorithmName_ != null && algorithmName_.endsWith("withECDSAinP1363Format")) {
+        if (algorithmName_ != null && algorithmName_.endsWith(P1363_FORMAT_SUFFIX)) {
             final ECKey ecKey = (ECKey) key_;
             final int numLen = (ecKey.getParams().getOrder().bitLength() + 7) / 8;
             return ieeeP1363toAsn1(signature, offset, length, numLen);
@@ -190,7 +191,7 @@ abstract class EvpSignatureBase extends SignatureSpi {
      * <em>This methods may throw {@link AssertionError} on invalid input so should only be given trusted inputs.</em>.
      */
     protected byte[] maybeConvertSignatureToReturn(byte[] signature) throws SignatureException {
-        if (algorithmName_ != null && algorithmName_.endsWith("withECDSAinP1363Format")) {
+        if (algorithmName_ != null && algorithmName_.endsWith(P1363_FORMAT_SUFFIX)) {
             final ECKey ecKey = (ECKey) key_;
             final int numLen = (ecKey.getParams().getOrder().bitLength() + 7) / 8;
             return asn1ToiIeeeP1363(signature, numLen);

--- a/src/com/amazon/corretto/crypto/provider/EvpSignatureBase.java
+++ b/src/com/amazon/corretto/crypto/provider/EvpSignatureBase.java
@@ -3,6 +3,7 @@
 
 package com.amazon.corretto.crypto.provider;
 
+import java.math.BigInteger;
 import java.security.AlgorithmParameters;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
@@ -12,10 +13,14 @@ import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.SignatureException;
 import java.security.SignatureSpi;
+import java.security.interfaces.ECKey;
+import java.security.interfaces.ECPublicKey;
 import java.security.spec.AlgorithmParameterSpec;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.security.spec.X509EncodedKeySpec;
+import java.util.Arrays;
+import java.util.Base64;
 
 abstract class EvpSignatureBase extends SignatureSpi {
     protected static final int RSA_PKCS1_PADDING = 1;
@@ -26,6 +31,7 @@ abstract class EvpSignatureBase extends SignatureSpi {
     protected boolean signMode;
     protected int keyUsageCount_ = 0;
     protected EvpContext ctx_ = null;
+    protected String algorithmName_ = null;
 
     EvpSignatureBase(
             final EvpKeyType keyType,
@@ -36,6 +42,11 @@ abstract class EvpSignatureBase extends SignatureSpi {
     }
 
     protected abstract void engineReset();
+
+    // Called reflectively upon creation
+    void setAlgorithmName(String algorithmName) {
+        this.algorithmName_ = algorithmName;
+    }
 
     /**
      * Destroys the native context.
@@ -154,4 +165,139 @@ abstract class EvpSignatureBase extends SignatureSpi {
         }
     }
 
+    /**
+     * Converts and returns the modified signature to verify <em>only if necessary</em> and returns {@code null} otherwise.
+     * If {@code null} is returned then the passed in parameters should be used for later verification.
+     * Otherwise, the entire returned array should be used.
+     * This method has a somewhat odd API since we want to avoid unneccessary array copies/allocations and it is an
+     * internal API anyway.
+     *
+     * @return the converted signature or {@code null} if no conversion is necessary
+     * @throws SignatureException if the signature is badly malformed
+     */
+    protected byte[] maybeConvertSignatureToVerify(byte[] signature, int offset, int length) throws SignatureException {
+        if (algorithmName_ != null && algorithmName_.endsWith("withECDSAinP1363Format")) {
+            final ECKey ecKey = (ECKey) key_;
+            final int numLen = (ecKey.getParams().getOrder().bitLength() + 7) / 8;
+            return ieeeP1363toAsn1(signature, offset, length, numLen);
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * Determines if we need to convert the signature <em>we generated</em> and performs said conversion.
+     * <em>This methods may throw {@link AssertionError} on invalid input so should only be given trusted inputs.</em>.
+     */
+    protected byte[] maybeConvertSignatureToReturn(byte[] signature) throws SignatureException {
+        if (algorithmName_ != null && algorithmName_.endsWith("withECDSAinP1363Format")) {
+            final ECKey ecKey = (ECKey) key_;
+            final int numLen = (ecKey.getParams().getOrder().bitLength() + 7) / 8;
+            return asn1ToiIeeeP1363(signature, numLen);
+        } else {
+            return signature;
+        }
+    }
+
+    /**
+     * This is a trivial conversion from two equal-length concatenated integers to an ASN.1 sequence.
+     *
+     * Since the resulting structure is so simple, we do not need a full ASN.1 engine and can cover all cases by hand.
+     */
+    protected static byte[] ieeeP1363toAsn1(byte[] signature, final int offset, final int length, int numLen) throws SignatureException {
+        if (2 * numLen != length) {
+            throw new SignatureException();
+        }
+
+        // This is the easiest way to trim unneeded zero-bytes
+        final byte[] r = (new BigInteger(1, Arrays.copyOfRange(signature, offset, offset + numLen))).toByteArray();
+        final byte[] s = (new BigInteger(1, Arrays.copyOfRange(signature, offset + numLen, offset + 2 * numLen))).toByteArray();
+
+        if (r.length > 127 || s.length > 127) {
+            throw new SignatureException("R or S value is too large");
+        }
+
+        // Encode the total sequence length. This might be one or two bytes
+        final int seqLength = r.length + s.length + 4;
+        final byte[] encodedSeqLength;
+        if (seqLength <= 127) {
+            encodedSeqLength = new byte[]{ (byte) (seqLength & 0xFF) };
+        } else if (seqLength <= 256) {
+            encodedSeqLength = new byte[]{ (byte) 0x81, (byte) (seqLength & 0xFF)};
+        } else {
+            throw new SignatureException("R or S value is too large");
+        }
+
+        final byte[] result = new byte[1 + encodedSeqLength.length + seqLength];
+        int position = 0;
+        result[position++] = 0x30; // SEQUENCE
+        System.arraycopy(encodedSeqLength, 0, result, position, encodedSeqLength.length);
+        position += encodedSeqLength.length;
+        result[position++] = 0x02; // INTEGER
+        result[position++] = (byte) (r.length & 0xFF); // Length of R
+        System.arraycopy(r, 0, result, position, r.length);
+        position += r.length;
+        result[position++] = 0x02; // INTEGER
+        result[position++] = (byte) (s.length & 0xFF); // Length of S
+        System.arraycopy(s, 0, result, position, s.length);
+        position += s.length;
+        if (position != result.length) {
+            throw new AssertionError("Final position of " + position + " does not match expected value of " + result.length);
+        }
+
+        return result;
+    }
+
+    /** Note: This should only be used on trusted inputs **/
+    protected static byte[] asn1ToiIeeeP1363(byte[] signature, int numLen) throws SignatureException {
+        // Check the ASN.1 for correctness and extract offsets
+        int position = 0;
+        if (signature[position++] != 0x30) {
+            throw new AssertionError();
+        }
+
+        // Length may be one or two bytes
+        int seqLen = Byte.toUnsignedInt(signature[position++]);
+        if (seqLen == 0x81) {
+            // Two byte length with second byte being the length
+            seqLen = Byte.toUnsignedInt(signature[position++]);
+        } else if (seqLen > 127) {
+            // Unhandled long, reserved, or indefinite length
+            throw new AssertionError();
+        }
+        if (seqLen != signature.length - position) {
+            throw new AssertionError();
+        }
+
+        final int rOffset = position;
+        if (signature[rOffset] != 0x02) {
+            throw new AssertionError();
+        }
+        int rLen = Byte.toUnsignedInt(signature[rOffset + 1]);
+        int rStart = rOffset + 2;
+
+        final int sOffset = rStart + rLen;
+        if (signature[sOffset] != 0x02) {
+            throw new AssertionError(Base64.getEncoder().encodeToString(signature) + " : " +
+
+                    String.format("%x, %x, %x", signature[sOffset - 1], signature[sOffset], signature[sOffset + 1]));
+        }
+        int sLen = Byte.toUnsignedInt(signature[sOffset + 1]);
+        int sStart = sOffset + 2;
+
+        // Remove leading zero bytes
+        if (signature[rStart] == 0) {
+            rStart++;
+            rLen--;
+        }
+        if (signature[sStart] == 0) {
+            sStart++;
+            sLen--;
+        }
+
+        byte[] result = new byte[numLen * 2];
+        System.arraycopy(signature, rStart, result, numLen - rLen, rLen);
+        System.arraycopy(signature, sStart, result, numLen + numLen - sLen, sLen);
+        return result;
+    }
 }

--- a/tst/com/amazon/corretto/crypto/provider/test/EvpSignatureSpecificTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/EvpSignatureSpecificTest.java
@@ -11,10 +11,24 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.nio.charset.StandardCharsets;
-import java.security.*;
+import java.security.GeneralSecurityException;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidKeyException;
+import java.security.Key;
+import java.security.KeyFactory;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.PrivateKey;
+import java.security.Provider;
+import java.security.PublicKey;
+import java.security.Signature;
+import java.security.SignatureException;
 import java.security.interfaces.RSAPrivateKey;
-import java.security.spec.*;
-import java.util.Base64;
+import java.security.spec.AlgorithmParameterSpec;
+import java.security.spec.ECGenParameterSpec;
+import java.security.spec.PSSParameterSpec;
+import java.security.spec.RSAKeyGenParameterSpec;
+import java.security.spec.RSAPrivateKeySpec;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -23,8 +37,6 @@ import com.amazon.corretto.crypto.provider.AmazonCorrettoCryptoProvider;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.junit.Assert;
 import org.junit.Test;
-
-import com.amazon.corretto.crypto.provider.AmazonCorrettoCryptoProvider;
 
 import javax.crypto.AEADBadTagException;
 import javax.crypto.Cipher;
@@ -396,12 +408,6 @@ public class EvpSignatureSpecificTest {
                 nativeSig.update(message);
                 bcSig.update(message);
                 signature = bcSig.sign();
-                if (algorithm.equals("SHA224withECDSAinP1363Format")) {
-                    System.out.println(Base64.getEncoder().encodeToString(signature));
-                    Object spi = TestUtil.sneakyGetField(nativeSig, "sigSpi");
-                    System.out.println(Base64.getEncoder().encodeToString(TestUtil.sneakyInvoke(spi, "maybeConvertSignatureToVerify", signature)));
-
-                }
                 assertTrue("BC->Native: " + algorithm, nativeSig.verify(signature));
             } catch (SignatureException ex) {
                 throw new AssertionError(algorithm, ex);

--- a/tst/com/amazon/corretto/crypto/provider/test/TestUtil.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/TestUtil.java
@@ -4,6 +4,7 @@
 package com.amazon.corretto.crypto.provider.test;
 
 import com.amazon.corretto.crypto.provider.AmazonCorrettoCryptoProvider;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.junit.Assume;
 
 import static org.junit.Assert.fail;
@@ -22,6 +23,7 @@ import java.util.Arrays;
 
 @SuppressWarnings("unchecked")
 public class TestUtil {
+    public static final BouncyCastleProvider BC_PROVIDER = new BouncyCastleProvider();
     private static final File TEST_DIR = new File(System.getProperty("test.data.dir", "."));
     
     public static void assertThrows(Class<? extends Throwable> expected, ThrowingRunnable callable) {


### PR DESCRIPTION
*Description of changes:* Adds support for IEEE P1363 formatted ECDSA signatures. These signatures consist of a direct concatenation of the `r` and `s` values as opposed to the default ASN.1 encoding.  Correctness is checked by comparing them to the equivalent "withPLAIN-ECDSA" algorithms from BouncyCastle and Wycheproof.

The specific language from the IEEE specification follows:
> For DL/ECSSA, the output of the signature generation function (see Section 10.2.2) is a pair of integers (c, d). Let r denote the order of the generator (g or G) in the DL or EC settings (see Sections 6.1 and 7.1), and let l = ceil(log256 r) (i.e., l is the length of r in octets). The output (c, d) may be formatted as an octet string as follows: convert the integers c and d to octet strings C and D, respectively, of length l octets each, using the primitive I2OSP, and output the concatenation C || D. To parse the signature, split the octet string into two components C and D, of length l each, and convert them to integers c and d, respectively, using OS2IP. Note that it is essential that both C and D be of length l, even if it means that they have leading zero octets.
>
> NOTE— The output of DL/ECSSA may also be formatted according to the following method, described in more detail in X9.57 [ANS97c] and X9.62 [ANS98e]. Combine c and d into an ASN.1 structure [ISO98a] and encode the structure using some encoding rules, such as Basic Encoding Rules (BER) or Distinguished Encoding Rules (DER) [ISO98e].

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
