### PR TITLE
Removed 'Unreleased' note from CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.3.0 (Unreleased)
+## 1.3.0
 
 ### Improvements
 * Now supports ECDSA signatures in IEEE P1363 Format. (Also known as "raw" or "plain".) [PR #75](https://github.com/corretto/amazon-corretto-crypto-provider/pull/75)


### PR DESCRIPTION
*Description of changes:* Removes "Unreleased" note from CHANGELOG in preparation to release version 1.3.0


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
