### PR TITLE
More test memory fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 * Now supports ECDSA signatures in IEEE P1363 Format. (Also known as "raw" or "plain".) [PR #75](https://github.com/corretto/amazon-corretto-crypto-provider/pull/75)
 * Now allows cloning of `Mac` objects. [PR #78](https://github.com/corretto/amazon-corretto-crypto-provider/pull/78)
 
+### Maintenance
+* Fix Java heap space issues in unit tests
+
 ## 1.2.0
 
 ### Improvements

--- a/tst/com/amazon/corretto/crypto/provider/test/EvpSignatureTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/EvpSignatureTest.java
@@ -124,7 +124,7 @@ public class EvpSignatureTest {
     private Signature jceVerifier_;
     private byte[] goodSignature_;
 
-    public EvpSignatureTest(final String base, final String algorithm, final int length, boolean readOnly, boolean slice) throws GeneralSecurityException {
+    public EvpSignatureTest(final String base, final String algorithm, final int length, boolean readOnly, boolean slice) {
         base_ = base;
         readOnly_ = readOnly;
         slice_ = slice;

--- a/tst/com/amazon/corretto/crypto/provider/test/TestRunner.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/TestRunner.java
@@ -246,6 +246,10 @@ public class TestRunner {
                     !(exception instanceof AssertionError)) {
                   System.out.println(failure.getTrace());
               }
+            if (exception instanceof OutOfMemoryError) {
+                // just rethrow this
+                throw (OutOfMemoryError) exception;
+            }
               statusOutput_ = true;
         }
 


### PR DESCRIPTION
*Description of changes:*

Yet another attempt to reduce the memory footprint of our tests. It looks like JUnit holds onto all the parameters as well, so this reduces the size of some of them.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
