### PR TITLE
Allow tests to not be parallel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 * Now supports ECDSA signatures in IEEE P1363 Format. (Also known as "raw" or "plain".) [PR #75](https://github.com/corretto/amazon-corretto-crypto-provider/pull/75)
 * Now allows cloning of `Mac` objects. [PR #78](https://github.com/corretto/amazon-corretto-crypto-provider/pull/78)
 
+### Maintenance
+* You can disable parallel execution of tests by setting the `ACCP_TEST_PARALLEL` environment variable to `false` 
+
 ## 1.2.0
 
 ### Improvements

--- a/tst/com/amazon/corretto/crypto/provider/test/TestRunner.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/TestRunner.java
@@ -4,6 +4,7 @@
 package com.amazon.corretto.crypto.provider.test;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -116,8 +117,8 @@ public class TestRunner {
         } else {
             printSystemInfo();
             final String suiteName = args[1];
-            final Class[] parallel_classes = SUITES_PARALLEL.get(suiteName);
-            final Class[] serial_classes = SUITES_SERIAL.get(suiteName);
+            Class[] parallel_classes = SUITES_PARALLEL.get(suiteName);
+            Class[] serial_classes = SUITES_SERIAL.get(suiteName);
             if (parallel_classes == null && serial_classes == null) {
                 Set<String> suiteNames = new HashSet<>();
                 suiteNames.addAll(SUITES_SERIAL.keySet());
@@ -135,6 +136,22 @@ public class TestRunner {
             final JUnitCore core = new JUnitCore();
             core.addListener(new BasicListener(suiteName, false));
 
+            if ("false".equalsIgnoreCase(System.getenv("ACCP_TEST_PARALLEL"))) {
+                System.out.println("Disabling parallel testing");
+                // Some systems really don't like parallel tests
+                if (parallel_classes != null) {
+                    if (serial_classes == null) {
+                        serial_classes = parallel_classes;
+                        parallel_classes = null;
+                    } else {
+                        Class[] tmp = Arrays.copyOf(parallel_classes, parallel_classes.length + serial_classes.length);
+                        System.arraycopy(serial_classes, 0, tmp, parallel_classes.length, serial_classes.length);
+                        serial_classes = tmp;
+                        parallel_classes = null;
+                    }
+                }
+
+            }
             // TODO: Capture STDOUT/STDERR to nicely bundle output with tests
             // TODO: Capture start and end of each class for bundling and summary
             if (parallel_classes != null) {


### PR DESCRIPTION
*Description of changes:*

You can now disable parallel execution of tests by setting the `ACCP_TEST_PARALLEL` environment variable to `false`.  This is necessary to work around some test framework bug in on the `overkill` tests which causes some `OutOfMemoryError`s. We're still trying to figure out the root-cause of these errors (which only occur in testing) but this should unblock us.

I have already modified the `overkill` CodeBuild project to have this environment variable.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
