### PR TITLE
Replace deprecated call EC_GROUP_clear_free with EC_GROUP_free

### DIFF
--- a/csrc/util.h
+++ b/csrc/util.h
@@ -82,7 +82,7 @@ public:
         group = EC_GROUP_new_by_curve_name(nid);
     }
     ~EC_GROUP_auto() {
-        EC_GROUP_clear_free(group);
+        EC_GROUP_free(group);
     }
     operator EC_GROUP*() {return group; }
     operator const EC_GROUP*() const { return group; }


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* [EC_GROUP_clear_free is deprecated](https://github.com/openssl/openssl/blob/579422c85cf606c0ae1d4baf414010dc21da657a/include/openssl/ec.h#L134) since the `EC_GROUP` structure never contains anything confidential. The recommendation is to use `EC_GROUP_free` instead. See related [OpenSSL issue](https://github.com/openssl/openssl/issues/9822) for additional details.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
