### PR TITLE
Add timestamping to signed jars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.3.1 (Unreleased)
+
+### Maintenance
+* Add timestamping to signed jars.
+
 ## 1.3.0
 
 ### Improvements

--- a/build.gradle
+++ b/build.gradle
@@ -128,7 +128,8 @@ task build(overwrite:true) {
                 jar: "${buildDir}/cmake/AmazonCorrettoCryptoProvider.jar",
                 destDir: "${buildDir}/lib",
                 storepass: jcecertPassword,
-                keystore: "${project.gradle.gradleUserHomeDir}/${jcecertJks}"
+                keystore: "${project.gradle.gradleUserHomeDir}/${jcecertJks}",
+                tsaurl: "http://timestamp.digicert.com"
             )
         } else {
             copy {


### PR DESCRIPTION
*Description of changes:*
Add timestamping to signed jars. I selected DigiCert as it is the same TSA as used by the BouncyCastle project.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
