### PR TITLE
Improve the ThreadGroup of the Janitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Maintenance
 * Add timestamping to signed jars.
+* Create the `Janitor` in the `Loader` so that it gets a more logical and consistent `ThreadGroup`.
 
 ## 1.3.0
 

--- a/src/com/amazon/corretto/crypto/provider/Loader.java
+++ b/src/com/amazon/corretto/crypto/provider/Loader.java
@@ -165,10 +165,15 @@ final class Loader {
         } else {
             LOG.log(Level.CONFIG, "Unable to load native library", error);
         }
+
+        // Finally start up a cleaning thread if necessary
+        RESOURCE_JANITOR = new Janitor();
     }
 
     static final boolean IS_AVAILABLE;
     static final Throwable LOADING_ERROR;
+
+    static final Janitor RESOURCE_JANITOR;
 
     static void load() {
         // no-op - but we run the static block as a side effect

--- a/src/com/amazon/corretto/crypto/provider/NativeResource.java
+++ b/src/com/amazon/corretto/crypto/provider/NativeResource.java
@@ -3,13 +3,13 @@
 
 package com.amazon.corretto.crypto.provider;
 
+import static com.amazon.corretto.crypto.provider.Loader.RESOURCE_JANITOR;
+
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.LongConsumer;
 import java.util.function.LongFunction;
 
 class NativeResource {
-    private static final Janitor RESOURCE_JANITOR = new Janitor();
-
     /**
      * For tests. Makes a best-effort attempt to awaken any sleeping cleaner threads.
      */


### PR DESCRIPTION
*Issue #, if available:* #86 

*Description of changes:*
This moves creation of the `Janitor` thread to the `Loader` which causes it to exist in a more logical `ThreadGroup` rather than associated with whatever `ThreadGroup` first needs to use a native resource.

When Java threads are created they (by default) belong to the ThreadGroup of the creating thread. This can cause problems for ACCP and our customers if the ThreadGroup belongs to a tracked thread pool or similar structure. Previously the Janitor (and associated cleaning threads) was created lazily upon first use. This meant that its thread(s) would be associated with whatever customer ThreadGroup first used aspects of ACCP. The change in this PR moves Janitor creation to our main installation/loading logic which will generally be done by threads/ThreadGroups responsible for general system startup and running and thus more appropriate to own the resulting Janitor cleaning thread.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
