### PR TITLE
Specify the number of jobs to build OpenSSL and the native code of ACCP

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,7 @@ task buildOpenSsl {
         }
         exec {
             workingDir "${buildDir}/openssl/src"
-            commandLine 'make'
+            commandLine 'make', '-j', Runtime.runtime.availableProcessors()
         }
         exec {
             workingDir "${buildDir}/openssl/src"
@@ -114,7 +114,7 @@ task build_objects(type: Exec) {
     dependsOn executeCmake
     workingDir "${buildDir}/cmake"
 
-    commandLine 'make', 'accp-jar'
+    commandLine 'make', '-j', Runtime.runtime.availableProcessors(), 'accp-jar'
 }
 
 task build(overwrite:true) {


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*
Build OpenSSL and the native code for ACCP in parallel by specifying the number of jobs to run as the number of CPU cores. On my desktop running
```
./gradlew clean
time ./gradlew build
```
Went from:
```
real    2m24.751s
user    0m3.873s
sys     0m0.192s
```
to:
```
real    0m40.897s
user    0m3.916s
sys     0m0.176s
```
You can see real time (aka wall clock time) went from 2m24.s to 40s while user (time spent in user space) and sys (time spent in the kernal) stayed the same since the jobs ran in parallel.
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
