### PR TITLE
Stop using custom ThreadLocals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.3.2 (Unreleased)
+
+### Patch
+* Stop using custom instances of ThreadLocal to improve memory management under custom classloaders. [PR #94](https://github.com/corretto/amazon-corretto-crypto-provider/pull/94)
+
 ## 1.3.1
 
 ### Maintenance

--- a/src/com/amazon/corretto/crypto/provider/AesCtrDrbg.java
+++ b/src/com/amazon/corretto/crypto/provider/AesCtrDrbg.java
@@ -98,12 +98,7 @@ public class AesCtrDrbg extends SecureRandom {
             return sb.toString();
         }
 
-        private static final ThreadLocal<NativeDrgbState> state_ = new ThreadLocal<NativeDrgbState>() {
-            @Override
-            protected NativeDrgbState initialValue() {
-                return new NativeDrgbState(instantiate(null, null));
-            }
-        };
+        private static final ThreadLocal<NativeDrgbState> state_ = ThreadLocal.withInitial( () ->  new NativeDrgbState(instantiate(null, null)) );
 
         private final NativeDrgbState testState_;
 

--- a/src/com/amazon/corretto/crypto/provider/EcGen.java
+++ b/src/com/amazon/corretto/crypto/provider/EcGen.java
@@ -30,14 +30,8 @@ import com.amazon.corretto.crypto.provider.EcUtils.NativeGroup;
 class EcGen extends KeyPairGeneratorSpi {
     private static final ECGenParameterSpec DEFAULT_SPEC = new ECGenParameterSpec("secp384r1");
     private static final ConcurrentHashMap<ECInfo, ThreadLocal<NativeParams>> PARAM_CACHE = new ConcurrentHashMap<>();
-    private static final Function<ECInfo, ThreadLocal<NativeParams>> CACHE_LOADER = t -> {
-            return new ThreadLocal<EcGen.NativeParams>() {
-                @Override
-                protected NativeParams initialValue() {
-                    return new NativeParams(buildEcParams(t.nid));
-                }
-            };
-    };
+    private static final Function<ECInfo, ThreadLocal<NativeParams>> CACHE_LOADER = t ->
+        ThreadLocal.withInitial( () -> new NativeParams(buildEcParams(t.nid)) );
 
     private static native long buildEcParams(int nid);
     private static native void freeEcParams(long ptr);

--- a/src/com/amazon/corretto/crypto/provider/EcUtils.java
+++ b/src/com/amazon/corretto/crypto/provider/EcUtils.java
@@ -141,16 +141,8 @@ final class EcUtils {
     }
 
     static final class ECInfo {
-        private final ThreadLocal<NativeGroup> group = new ThreadLocal<NativeGroup>() {
-          @Override
-          protected NativeGroup initialValue() {
-              if (nid != 0) {
-                  return new NativeGroup(buildGroup(nid));
-              } else {
-                  return null;
-              }
-          }
-        };
+        private final ThreadLocal<NativeGroup> group;
+
         final String name;
         final ECParameterSpec spec;
         final int nid;
@@ -160,6 +152,14 @@ final class EcUtils {
             this.name = name;
             this.spec = spec;
             this.nid = nid;
+
+            this.group = ThreadLocal.withInitial( () -> {
+              if (nid != 0) {
+                  return new NativeGroup(buildGroup(nid));
+              } else {
+                  return null;
+              }
+            });
         }
 
         @Override


### PR DESCRIPTION
*Issue #, if available:* #93 

*Description of changes:*
Tomcat appears to have a memory leak when static thread locals use subclasses of `ThreadLocal` for their handling. Looking at Tomcat's [MemoryLeakProtection](https://cwiki.apache.org/confluence/display/TOMCAT/MemoryLeakProtection) page suggests that we may be able to prevent this leak by eliminating these custom classes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
