### PR TITLE
Reuse SecureRandom in testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.3.2 (Unreleased)
+
+### Maintenance
+* Test code reuses instances of `SecureRandom` for better efficiency on platforms with slow entropy. [PR #96](https://github.com/corretto/amazon-corretto-crypto-provider/pull/96)
+
 ## 1.3.1
 
 ### Maintenance

--- a/tst/com/amazon/corretto/crypto/provider/test/AESBench.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/AESBench.java
@@ -1,4 +1,4 @@
-// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package com.amazon.corretto.crypto.provider.test;
@@ -20,13 +20,10 @@ import javax.crypto.spec.SecretKeySpec;
 import com.amazon.corretto.crypto.provider.AmazonCorrettoCryptoProvider;
 
 public class AESBench {
-    private static final SecureRandom rnd = new SecureRandom();
-
     public static void main(String[] args) throws Throwable {
         Security.addProvider(AmazonCorrettoCryptoProvider.INSTANCE);
 
-        byte[] rawKey = new byte[16];
-        rnd.nextBytes(rawKey);
+        byte[] rawKey = TestUtil.getRandomBytes(16);
         SecretKeySpec key = new SecretKeySpec(rawKey, "AES");
         Cipher jce = Cipher.getInstance("AES/GCM/NoPadding");
         Cipher amzn = Cipher.getInstance("AES/GCM/NoPadding", "AmazonCorrettoCryptoProvider");
@@ -38,8 +35,7 @@ public class AESBench {
         bench(jce, key);
         bench(amzn, key);
 
-        rawKey = new byte[32];
-        rnd.nextBytes(rawKey);
+        rawKey = TestUtil.getRandomBytes(32);
         key = new SecretKeySpec(rawKey, "AES");
         bench(jce, key);
         bench(amzn, key);
@@ -58,15 +54,13 @@ public class AESBench {
 
     private static void runBench(Cipher cipher, Key key, int seconds, int size) throws InvalidKeyException,
         InvalidAlgorithmParameterException, IllegalBlockSizeException, BadPaddingException {
-        byte[] iv = new byte[12];
-        rnd.nextBytes(iv);
+        byte[] iv = TestUtil.getRandomBytes(12);
 
         NumberFormat fmt = NumberFormat.getIntegerInstance();
         fmt.setGroupingUsed(true);
 
         byte[] ciphertext = new byte[0];
-        byte[] data = new byte[size];
-        rnd.nextBytes(data);
+        byte[] data = TestUtil.getRandomBytes(size);
         long encCycles = 0;
 
         long startTime = System.nanoTime();

--- a/tst/com/amazon/corretto/crypto/provider/test/EcGenTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/EcGenTest.java
@@ -1,4 +1,4 @@
-// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package com.amazon.corretto.crypto.provider.test;
@@ -272,7 +272,7 @@ public class EcGenTest {
 
     @Test
     public void threadStorm() throws Throwable {
-        final byte[] rngSeed = SecureRandom.getSeed(20);
+        final byte[] rngSeed = TestUtil.getRandomBytes(20);
         System.out.println("RNG Seed: " + Arrays.toString(rngSeed));
         final SecureRandom rng = SecureRandom.getInstance("SHA1PRNG");
         rng.setSeed(rngSeed);

--- a/tst/com/amazon/corretto/crypto/provider/test/RsaCipherTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/RsaCipherTest.java
@@ -1,4 +1,4 @@
-// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package com.amazon.corretto.crypto.provider.test;
@@ -45,7 +45,6 @@ import org.junit.Test;
 import com.amazon.corretto.crypto.provider.ExtraCheck;
 
 public class RsaCipherTest {
-    private static final SecureRandom RND = new SecureRandom();
     private static final String OAEP_PADDING = "RSA/ECB/OAEPWithSHA-1AndMGF1Padding";
     private static final String PKCS1_PADDING = "RSA/ECB/Pkcs1Padding";
     private static final String NO_PADDING = "RSA/ECB/NoPadding";
@@ -583,8 +582,7 @@ public class RsaCipherTest {
 
     @Test
     public void pkcs1WrapAes() throws GeneralSecurityException {
-        final byte[] rawKey = new byte[32];
-        RND.nextBytes(rawKey);
+        final byte[] rawKey = TestUtil.getRandomBytes(32);
         final SecretKeySpec original = new SecretKeySpec(rawKey, "AES");
         final Cipher wrap = Cipher.getInstance(PKCS1_PADDING, NATIVE_PROVIDER);
         final Cipher unwrap = Cipher.getInstance(PKCS1_PADDING, NATIVE_PROVIDER);
@@ -598,8 +596,7 @@ public class RsaCipherTest {
 
     @Test
     public void jce2nativePkcs1WrapAes() throws GeneralSecurityException {
-        final byte[] rawKey = new byte[32];
-        RND.nextBytes(rawKey);
+        final byte[] rawKey = TestUtil.getRandomBytes(32);
         final SecretKeySpec original = new SecretKeySpec(rawKey, "AES");
         final Cipher jceC = Cipher.getInstance(PKCS1_PADDING);
         final Cipher nativeC = Cipher.getInstance(PKCS1_PADDING, NATIVE_PROVIDER);
@@ -613,8 +610,7 @@ public class RsaCipherTest {
 
     @Test
     public void native2JcePkcs1WrapAes() throws GeneralSecurityException {
-        final byte[] rawKey = new byte[32];
-        RND.nextBytes(rawKey);
+        final byte[] rawKey = TestUtil.getRandomBytes(32);
         final SecretKeySpec original = new SecretKeySpec(rawKey, "AES");
         final Cipher jceC = Cipher.getInstance(PKCS1_PADDING);
         final Cipher nativeC = Cipher.getInstance(PKCS1_PADDING, NATIVE_PROVIDER);
@@ -628,8 +624,7 @@ public class RsaCipherTest {
 
     @Test
     public void oaepWrapAes() throws GeneralSecurityException {
-        final byte[] rawKey = new byte[32];
-        RND.nextBytes(rawKey);
+        final byte[] rawKey = TestUtil.getRandomBytes(32);
         final SecretKeySpec original = new SecretKeySpec(rawKey, "AES");
         final Cipher wrap = Cipher.getInstance(OAEP_PADDING, NATIVE_PROVIDER);
         final Cipher unwrap = Cipher.getInstance(OAEP_PADDING, NATIVE_PROVIDER);
@@ -643,8 +638,7 @@ public class RsaCipherTest {
 
     @Test
     public void jce2nativeOaepWrapAes() throws GeneralSecurityException {
-        final byte[] rawKey = new byte[32];
-        RND.nextBytes(rawKey);
+        final byte[] rawKey = TestUtil.getRandomBytes(32);
         final SecretKeySpec original = new SecretKeySpec(rawKey, "AES");
         final Cipher jceC = Cipher.getInstance(OAEP_PADDING);
         final Cipher nativeC = Cipher.getInstance(OAEP_PADDING, NATIVE_PROVIDER);
@@ -658,8 +652,7 @@ public class RsaCipherTest {
 
     @Test
     public void native2JceOaepWrapAes() throws GeneralSecurityException {
-        final byte[] rawKey = new byte[32];
-        RND.nextBytes(rawKey);
+        final byte[] rawKey = TestUtil.getRandomBytes(32);
         final SecretKeySpec original = new SecretKeySpec(rawKey, "AES");
         final Cipher jceC = Cipher.getInstance(OAEP_PADDING);
         final Cipher nativeC = Cipher.getInstance(OAEP_PADDING, NATIVE_PROVIDER);
@@ -820,7 +813,7 @@ public class RsaCipherTest {
 
     @Test
     public void threadStorm() throws Throwable {
-        final byte[] rngSeed = SecureRandom.getSeed(20);
+        final byte[] rngSeed = TestUtil.getRandomBytes(20);
         System.out.println("RNG Seed: " + Arrays.toString(rngSeed));
         final SecureRandom rng = SecureRandom.getInstance("SHA1PRNG");
         rng.setSeed(rngSeed);

--- a/tst/com/amazon/corretto/crypto/provider/test/RsaGenTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/RsaGenTest.java
@@ -1,4 +1,4 @@
-// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package com.amazon.corretto.crypto.provider.test;
@@ -134,7 +134,7 @@ public class RsaGenTest {
 
     @Test
     public void threadStorm() throws Throwable {
-        final byte[] rngSeed = SecureRandom.getSeed(20);
+        final byte[] rngSeed = TestUtil.getRandomBytes(20);
         System.out.println("RNG Seed: " + Hex.toHexString(rngSeed));
         final SecureRandom rng = SecureRandom.getInstance("SHA1PRNG");
         rng.setSeed(rngSeed);


### PR DESCRIPTION
*Issue #, if available:*
Reuse SecureRandom in testing for better performance on systems with slow entropy.

*Description of changes:*
* Passes tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
