### PR TITLE
Move to Openssl 1.1.1f

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
-## 1.3.2 (Unreleased)
+## 1.4.0 (Unreleased)
+
+### Improvements
+* Now uses [OpenSSL 1.1.1f](https://www.openssl.org/source/openssl-1.1.1f.tar.gz). [PR #97](https://github.com/corretto/amazon-corretto-crypto-provider/pull/97)
 
 ### Maintenance
 * Test code reuses instances of `SecureRandom` for better efficiency on platforms with slow entropy. [PR #96](https://github.com/corretto/amazon-corretto-crypto-provider/pull/96)
@@ -24,7 +27,7 @@
 ## 1.2.0
 
 ### Improvements
-* Now uses [OpenSSL 1.1.1.d](https://www.openssl.org/source/openssl-1.1.1d.tar.gz). [PR #60](https://github.com/corretto/amazon-corretto-crypto-provider/pull/60)
+* Now uses [OpenSSL 1.1.1d](https://www.openssl.org/source/openssl-1.1.1d.tar.gz). [PR #60](https://github.com/corretto/amazon-corretto-crypto-provider/pull/60)
 
 ### Patches
 * Detects stuck AMD Ryzen RDRAND and correctly treats as an error [PR #67](https://github.com/corretto/amazon-corretto-crypto-provider/pull/67)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Amazon Corretto Crypto Provider
-The Amazon Corretto Crypto Provider (ACCP) is a collection of high-performance cryptographic implementations exposed via the standard [JCA/JCE](https://docs.oracle.com/en/java/javase/11/security/java-cryptography-architecture-jca-reference-guide.html) interfaces. This means that it can be used as a drop in replacement for many different Java applications. Currently algorithms are primarily backed by OpenSSL's implementations (1.1.1d) but this may change in the future.
+The Amazon Corretto Crypto Provider (ACCP) is a collection of high-performance cryptographic implementations exposed via the standard [JCA/JCE](https://docs.oracle.com/en/java/javase/11/security/java-cryptography-architecture-jca-reference-guide.html) interfaces.
+This means that it can be used as a drop in replacement for many different Java applications.
+Currently algorithms are primarily backed by OpenSSL's implementations (1.1.1f as of ACCP 1.4.0) but this may change in the future.
 
 ## Build Status
 Please be aware that "Overkill" tests are known to be flakey

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ task getOpensslSrc {
         mkdir "${buildDir}/openssl/bin"
         exec {
             workingDir "${buildDir}/openssl"
-            commandLine 'wget', 'https://www.openssl.org/source/openssl-1.1.1d.tar.gz'
+            commandLine 'wget', 'https://www.openssl.org/source/openssl-1.1.1f.tar.gz'
         }
         exec {
             workingDir "${buildDir}/openssl"
@@ -50,7 +50,7 @@ task getOpensslSrc {
         }
         exec {
             workingDir "${buildDir}/openssl/src"
-            commandLine 'tar', '-xzv', '-C', "${buildDir}/openssl/src", '--strip-components=1', '-f', "${buildDir}/openssl/openssl-1.1.1d.tar.gz"
+            commandLine 'tar', '-xzv', '-C', "${buildDir}/openssl/src", '--strip-components=1', '-f', "${buildDir}/openssl/openssl-1.1.1f.tar.gz"
         }
     }
 }

--- a/openssl.sha256
+++ b/openssl.sha256
@@ -1,1 +1,1 @@
-1e3a91bc1f9dfce01af26026f856e064eab4c8ee0a8f457b5ae30b40b8b711f2  openssl-1.1.1d.tar.gz
+186c6bfe6ecfba7a5b48c47f8a1673d0f3b0e5ba2e25602dd23b629975da3f35  openssl-1.1.1f.tar.gz


### PR DESCRIPTION
*Description of changes:*

Move to Openssl 1.1.1f

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
