### PR TITLE
Small fixups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 ### Maintenance
 * Upgrade tests to JUnit5. [PR #111](https://github.com/corretto/amazon-corretto-crypto-provider/pull/111)
 * Upgrade BouncyCastle test dependency 1.65. [PR #110](https://github.com/corretto/amazon-corretto-crypto-provider/pull/110)
+* Add version gating to P1363 Format tests. [PR #112](https://github.com/corretto/amazon-corretto-crypto-provider/pull/112)
+* Re-add support for very old x86_64 build-chains. [PR #112](https://github.com/corretto/amazon-corretto-crypto-provider/pull/112)
 
 ## 1.4.0
 ### Improvements

--- a/tst/com/amazon/corretto/crypto/provider/test/EvpSignatureTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/EvpSignatureTest.java
@@ -4,6 +4,7 @@
 package com.amazon.corretto.crypto.provider.test;
 
 import static com.amazon.corretto.crypto.provider.test.TestUtil.assertThrows;
+import static com.amazon.corretto.crypto.provider.test.TestUtil.versionCompare;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -200,12 +201,15 @@ public class EvpSignatureTest {
                     MASTER_PARAMS_LIST.add(new TestParams(base, algorithm, length, true, false, currentPair));
                     MASTER_PARAMS_LIST.add(new TestParams(base, algorithm, length, false, true, currentPair));
                     MASTER_PARAMS_LIST.add(new TestParams(base, algorithm, length, true, true, currentPair));
-                    if (base.equals("ECDSA") && !hash.equals("NONE")) {
-                        algorithm = algorithm + "inP1363Format";
-                        MASTER_PARAMS_LIST.add(new TestParams(base, algorithm, length, false, false, currentPair));
-                        MASTER_PARAMS_LIST.add(new TestParams(base, algorithm, length, true, false, currentPair));
-                        MASTER_PARAMS_LIST.add(new TestParams(base, algorithm, length, false, true, currentPair));
-                        MASTER_PARAMS_LIST.add(new TestParams(base, algorithm, length, true, true, currentPair));
+                    // These new algorithms were only added in 1.3.0
+                    if (versionCompare("1.3.0", NATIVE_PROVIDER) <= 0) {
+                        if (base.equals("ECDSA") && !hash.equals("NONE")) {
+                            algorithm = algorithm + "inP1363Format";
+                            MASTER_PARAMS_LIST.add(new TestParams(base, algorithm, length, false, false, currentPair));
+                            MASTER_PARAMS_LIST.add(new TestParams(base, algorithm, length, true, false, currentPair));
+                            MASTER_PARAMS_LIST.add(new TestParams(base, algorithm, length, false, true, currentPair));
+                            MASTER_PARAMS_LIST.add(new TestParams(base, algorithm, length, true, true, currentPair));
+                        }
                     }
                 }
             }


### PR DESCRIPTION
*Description of changes:*
* Adds proper version gating to Signature tests so that they can pass on old versions of the provider which doesn't implement the algorithms
* Restores explicit BSWAP implementation for ancient X86_64 build-chains

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
