### PR TITLE
Support running a single test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 ## 1.5.0 (Unreleased)
 ### Improvements
 * Now uses [OpenSSL 1.1.1g](https://www.openssl.org/source/openssl-1.1.1g.tar.gz). [PR #108](https://github.com/corretto/amazon-corretto-crypto-provider/pull/108)
+* Adds support for running a single test from the command line with the following syntax: [PR #113](https://github.com/corretto/amazon-corretto-crypto-provider/pull/113)
+
+  `./gradlew single_test -DSINGLE_TEST=<Fully Qualified Classname>`
+
+  For example: `./gradlew single_test -DSINGLE_TEST=com.amazon.corretto.crypto.provider.test.EcGenTest`
+
+  You may need to do a clean build when changing tests.
 
 ### Maintenance
 * Upgrade tests to JUnit5. [PR #111](https://github.com/corretto/amazon-corretto-crypto-provider/pull/111)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,7 @@ if (NOT DEFINED TEST_JAVA_HOME)
 else()
   set(TEST_JAVA_EXECUTABLE ${TEST_JAVA_HOME}/bin/java)
 endif()
+
 # Translate from the java colon-delimited paths to cmake ';' delimited lists
 string(REPLACE ":" ";" BUILD_CLASSPATH_LIST "${BUILD_CLASSPATH}")
 string(REPLACE ":" ";" TEST_CLASSPATH_LIST "${TEST_CLASSPATH}")
@@ -615,6 +616,15 @@ add_custom_target(check-junit
         --exclude-classname=com.amazon.corretto.crypto.provider.test.SecurityManagerTest
 
     DEPENDS accp-jar tests-jar)
+
+if (DEFINED SINGLE_TEST)
+    add_custom_target(check-junit-single
+        COMMAND ${TEST_JAVA_EXECUTABLE}
+            ${TEST_RUNNER_ARGUMENTS}
+            --select-class=${SINGLE_TEST}
+
+        DEPENDS accp-jar tests-jar)
+endif() # SINGLE_TEST
 
 add_custom_target(check-junit-SecurityManager
     COMMAND ${TEST_JAVA_EXECUTABLE}

--- a/build.gradle
+++ b/build.gradle
@@ -117,6 +117,10 @@ task executeCmake(type: Exec) {
         args '-DTEST_JAVA_HOME=' + System.properties['TEST_JAVA_HOME']
     }
 
+    if (System.properties['SINGLE_TEST'] != null) {
+        args '-DSINGLE_TEST=' + System.properties['SINGLE_TEST']
+
+    }
     args projectDir
 }
 
@@ -203,6 +207,12 @@ task test(type: Exec) {
     commandLine 'make', 'check'
 }
 
+task single_test(type: Exec) {
+    dependsOn executeCmake
+    workingDir "${buildDir}/cmake"
+    commandLine 'make', 'check-junit-single'
+}
+
 task test_integration(type: Exec) {
     dependsOn executeCmake
     workingDir "${buildDir}/cmake"
@@ -254,6 +264,12 @@ task coverage_cmake(type: Exec) {
     args '-DCMAKE_BUILD_TYPE=Coverage', '-DCOVERAGE=ON', '-DENABLE_NATIVE_TEST_HOOKS=ON'
     args '-DPROVIDER_VERSION_STRING=' + version, projectDir
     args "-DTEST_RUNNER_JAR=${configurations.testRunner.singleFile}"
+
+    if (System.properties['SINGLE_TEST'] != null) {
+        args '-DSINGLE_TEST=' + System.properties['SINGLE_TEST']
+
+    }
+
 }
 
 task coverage_exec(type: Exec) {


### PR DESCRIPTION
Adds support for running a single test from the command line with the following syntax

  `./gradlew single_test -DSINGLE_TEST=<Fully Qualified Classname>`

  For example: `./gradlew single_test -DSINGLE_TEST=com.amazon.corretto.crypto.provider.test.EcGenTest`

  You may need to do a clean build when changing tests.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
