### PR TITLE
Only support explicitly configured keysizes for EC Key generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
   This change removes possible disagreeing behavior between ACCP and SunEC.
   Previously, ACCP would _always_ select the corresponding "secp*r1" curve while SunEC would use undefined behavior to select the curves for any key sizes _not_ on the following list.
   **This changes behavior for keysize values  *other* than the following to throwing an `InvalidParameterException`.**
+  [PR #114](https://github.com/corretto/amazon-corretto-crypto-provider/pull/114)
   * 192
   * 224
   * 256

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@
 ### Improvements
 * Now uses [OpenSSL 1.1.1g](https://www.openssl.org/source/openssl-1.1.1g.tar.gz). [PR #108](https://github.com/corretto/amazon-corretto-crypto-provider/pull/108)
 
+### Patches
+* When initialized with an `int`,`KeyPairGenerator` for "EC" keys now only accepts the following explicit values.
+  For these values it will always select the corresponding NIST Prime Curve.
+  This change removes possible disagreeing behavior between ACCP and SunEC.
+  Previously, ACCP would _always_ select the corresponding "secp*r1" curve while SunEC would use undefined behavior to select the curves for any key sizes _not_ on the following list.
+  **This changes behavior for keysize values  *other* than the following to throwing an `InvalidParameterException`.**
+  * 192
+  * 224
+  * 256
+  * 384
+  * 521
+
 ### Maintenance
 * Upgrade tests to JUnit5. [PR #111](https://github.com/corretto/amazon-corretto-crypto-provider/pull/111)
 * Upgrade BouncyCastle test dependency 1.65. [PR #110](https://github.com/corretto/amazon-corretto-crypto-provider/pull/110)

--- a/src/com/amazon/corretto/crypto/provider/EcGen.java
+++ b/src/com/amazon/corretto/crypto/provider/EcGen.java
@@ -166,7 +166,28 @@ class EcGen extends KeyPairGeneratorSpi {
     public void initialize(final int keysize, final SecureRandom random)
             throws InvalidParameterException {
         try {
-            final String curveName = "secp" + keysize + "r1";
+            // Explicitly list default curves
+            // Mapping from OpenJDK
+            final String curveName;
+            switch (keysize) {
+                case 192:
+                    curveName = "secp192r1"; // NIST P-192
+                    break;
+                case 224:
+                    curveName = "secp224r1"; // NIST P-224
+                    break;
+                case 256:
+                    curveName = "secp256r1"; // NIST P-256
+                    break;
+                case 384:
+                    curveName = "secp384r1"; // NIST P-384
+                    break;
+                case 521:
+                    curveName = "secp521r1"; // NIST P-521
+                    break;
+                default:
+                    throw new InvalidParameterException("No default NIST prime curve for keysize " + keysize);
+            }
             initialize(new ECGenParameterSpec(curveName), random);
         } catch (final InvalidAlgorithmParameterException ex) {
             throw new InvalidParameterException(ex.getMessage());

--- a/tst/com/amazon/corretto/crypto/provider/test/EcGenTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/EcGenTest.java
@@ -3,8 +3,8 @@
 
 package com.amazon.corretto.crypto.provider.test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.math.BigInteger;
 import java.security.GeneralSecurityException;
@@ -35,13 +35,17 @@ import org.bouncycastle.asn1.ASN1Encodable;
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 import org.bouncycastle.asn1.ASN1Sequence;
 import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.aggregator.ArgumentsAccessor;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class EcGenTest {
-    public static final int[] KNOWN_SIZES = {192, 224, 256, 384, 521};
     public static final String[][] KNOWN_CURVES = new String[][] {
             // Prime Curves
             new String[]{"secp112r1", "1.3.132.0.6"},
@@ -114,18 +118,19 @@ public class EcGenTest {
     private KeyPairGenerator nativeGen;
     private KeyPairGenerator jceGen;
 
-    @BeforeClass
-    public static void setUpBeforeClass() throws Exception {
+    @BeforeAll
+    public void setUpBeforeClass() throws Exception {
         Security.addProvider(AmazonCorrettoCryptoProvider.INSTANCE);
     }
 
-    @Before
+    @BeforeEach
     public void setup() throws GeneralSecurityException {
         nativeGen = KeyPairGenerator.getInstance("EC", "AmazonCorrettoCryptoProvider");
         jceGen = KeyPairGenerator.getInstance("EC", "SunEC");
+
     }
 
-    @After
+    @AfterEach
     public void teardown() {
         // It is unclear if JUnit always properly releases references to classes and thus we may have memory leaks
         // if we do not properly null our references
@@ -133,57 +138,59 @@ public class EcGenTest {
         jceGen = null;
     }
 
-    @Test
-    public void knownCurves() throws GeneralSecurityException {
-        for (final String[] names : KNOWN_CURVES) {
-            for (final String name : names) {
-                ECGenParameterSpec spec = new ECGenParameterSpec(name);
-                nativeGen.initialize(spec);
-                KeyPair nativePair = nativeGen.generateKeyPair();
-                jceGen.initialize(spec);
-                KeyPair jcePair = jceGen.generateKeyPair();
-                final ECParameterSpec jceParams = ((ECPublicKey) jcePair.getPublic()).getParams();
-                final ECParameterSpec nativeParams = ((ECPublicKey) nativePair.getPublic()).getParams();
-                assertECEquals(name, jceParams, nativeParams);
+    private String[][] knownCurveParams() {
+        return KNOWN_CURVES;
+    }
 
-                // Ensure we can construct the curve using raw numbers rather than the name
-                nativeGen.initialize(jceParams);
-                nativePair = nativeGen.generateKeyPair();
-                assertECEquals(name + "-explicit", jceParams, nativeParams);
+    @ParameterizedTest
+    @MethodSource("knownCurveParams")
+    public void knownCurves(ArgumentsAccessor arguments) throws GeneralSecurityException {
+        for (final Object name : arguments.toArray()) {
+            ECGenParameterSpec spec = new ECGenParameterSpec((String) name);
+            nativeGen.initialize(spec);
+            KeyPair nativePair = nativeGen.generateKeyPair();
+            jceGen.initialize(spec);
+            KeyPair jcePair = jceGen.generateKeyPair();
+            final ECParameterSpec jceParams = ((ECPublicKey) jcePair.getPublic()).getParams();
+            final ECParameterSpec nativeParams = ((ECPublicKey) nativePair.getPublic()).getParams();
+            assertECEquals((String) name, jceParams, nativeParams);
 
-                final SubjectPublicKeyInfo publicKeyInfo = SubjectPublicKeyInfo.getInstance(nativePair.getPublic().getEncoded());
-                ASN1Encodable algorithmParameters = publicKeyInfo.getAlgorithm().getParameters();
-                assertTrue("Public key uses named curve", algorithmParameters instanceof ASN1ObjectIdentifier);
+            // Ensure we can construct the curve using raw numbers rather than the name
+            nativeGen.initialize(jceParams);
+            nativePair = nativeGen.generateKeyPair();
+            assertECEquals(name + "-explicit", jceParams, nativeParams);
 
-                // PKCS #8 = SEQ [ Integer, AlgorithmIdentifier, Octet String, ???]
-                // AlgorithmIdentifier = SEQ [ OID, {OID | SEQ}]
-                final ASN1Sequence p8 = ASN1Sequence.getInstance(nativePair.getPrivate().getEncoded());
-                final ASN1Sequence algIdentifier = (ASN1Sequence) p8.getObjectAt(1);
-                assertTrue("Private key uses named curve", algIdentifier.getObjectAt(1) instanceof ASN1ObjectIdentifier);
+            final SubjectPublicKeyInfo publicKeyInfo = SubjectPublicKeyInfo.getInstance(nativePair.getPublic().getEncoded());
+            ASN1Encodable algorithmParameters = publicKeyInfo.getAlgorithm().getParameters();
+            assertTrue(algorithmParameters instanceof ASN1ObjectIdentifier, "Public key uses named curve");
 
-                // Check encoding/decoding
-                Key bouncedKey = KEY_FACTORY.generatePublic(new X509EncodedKeySpec(nativePair.getPublic().getEncoded()));
-                assertEquals("Public key survives encoding", nativePair.getPublic(), bouncedKey);
-                bouncedKey = KEY_FACTORY.generatePrivate(new PKCS8EncodedKeySpec(nativePair.getPrivate().getEncoded()));
-                assertEquals("Private key survives encoding", nativePair.getPrivate(), bouncedKey);
-            }
+            // PKCS #8 = SEQ [ Integer, AlgorithmIdentifier, Octet String, ???]
+            // AlgorithmIdentifier = SEQ [ OID, {OID | SEQ}]
+            final ASN1Sequence p8 = ASN1Sequence.getInstance(nativePair.getPrivate().getEncoded());
+            final ASN1Sequence algIdentifier = (ASN1Sequence) p8.getObjectAt(1);
+            assertTrue(algIdentifier.getObjectAt(1) instanceof ASN1ObjectIdentifier, "Private key uses named curve");
+
+            // Check encoding/decoding
+            Key bouncedKey = KEY_FACTORY.generatePublic(new X509EncodedKeySpec(nativePair.getPublic().getEncoded()));
+            assertEquals(nativePair.getPublic(), bouncedKey, "Public key survives encoding");
+            bouncedKey = KEY_FACTORY.generatePrivate(new PKCS8EncodedKeySpec(nativePair.getPrivate().getEncoded()));
+            assertEquals(nativePair.getPrivate(), bouncedKey, "Private key survives encoding");
         }
     }
 
-    @Test
-    public void knownSizes() throws GeneralSecurityException {
+    @ParameterizedTest
+    @ValueSource(ints = {192, 224, 256, 384, 521})
+    public void knownSizes(int keysize) throws GeneralSecurityException {
         TestUtil.assumeMinimumVersion("1.2.0", nativeGen.getProvider());
-        for (int keysize : KNOWN_SIZES) {
-            nativeGen.initialize(keysize);
-            jceGen.initialize(keysize);
+        nativeGen.initialize(keysize);
+        jceGen.initialize(keysize);
 
-            final KeyPair nativePair = nativeGen.generateKeyPair();
-            final KeyPair jcePair = jceGen.generateKeyPair();
+        final KeyPair nativePair = nativeGen.generateKeyPair();
+        final KeyPair jcePair = jceGen.generateKeyPair();
 
-            final ECParameterSpec jceParams = ((ECPublicKey) jcePair.getPublic()).getParams();
-            final ECParameterSpec nativeParams = ((ECPublicKey) nativePair.getPublic()).getParams();
-            assertECEquals(Integer.toString(keysize), jceParams, nativeParams);
-        }
+        final ECParameterSpec jceParams = ((ECPublicKey) jcePair.getPublic()).getParams();
+        final ECParameterSpec nativeParams = ((ECPublicKey) nativePair.getPublic()).getParams();
+        assertECEquals(Integer.toString(keysize), jceParams, nativeParams);
     }
 
     @Test
@@ -251,7 +258,7 @@ public class EcGenTest {
 
                 ecdsa.initVerify(keyPair.getPublic());
                 ecdsa.update(message);
-                assertTrue(name, ecdsa.verify(signature));
+                assertTrue(ecdsa.verify(signature), name);
             }
         }
     }
@@ -259,15 +266,6 @@ public class EcGenTest {
     @Test
     public void defaultParams() throws GeneralSecurityException {
         nativeGen.generateKeyPair();
-    }
-
-    @Test
-    public void keyLength() throws GeneralSecurityException {
-        final int[] lengths = new int[] { 112, 128, 160, 192, 256, 384, 521 };
-        for (final int length : lengths) {
-            nativeGen.initialize(length);
-            nativeGen.generateKeyPair();
-        }
     }
 
     @Test
@@ -316,10 +314,10 @@ public class EcGenTest {
 
     private static void assertECEquals(final String message, final ECParameterSpec expected,
             final ECParameterSpec actual) {
-        assertEquals(message, expected.getCofactor(), actual.getCofactor());
-        assertEquals(message, expected.getOrder(), actual.getOrder());
-        assertEquals(message, expected.getGenerator(), actual.getGenerator());
-        assertEquals(message, expected.getCurve(), actual.getCurve());
+        assertEquals(expected.getCofactor(), actual.getCofactor(), message);
+        assertEquals(expected.getOrder(), actual.getOrder(), message);
+        assertEquals(expected.getGenerator(), actual.getGenerator(), message);
+        assertEquals(expected.getCurve(), actual.getCurve(), message);
     }
 
     private static class TestThread extends Thread {


### PR DESCRIPTION
When initialized with an `int`,`KeyPairGenerator` for "EC" keys now only accepts the following explicit values.
  For these values it will always select the corresponding NIST Prime Curve.
  This change removes possible disagreeing behavior between ACCP and SunEC.
  Previously, ACCP would _always_ select the corresponding "secp*r1" curve while SunEC would use undefined behavior to select the curves for any key sizes _not_ on the following list.
  **This changes behavior for keysize values  *other* than the following to throwing an `InvalidParameterException`.**

  * 192
  * 224
  * 256
  * 384
  * 521

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
