### PR TITLE
Add CHANGELOG warning about EC generation with keysize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,43 @@
 # Changelog
 
 ## 1.5.0 (Unreleased)
+### Breaking Change Warning
+In accordance with our [versioning policy](https://github.com/corretto/amazon-corretto-crypto-provider/blob/master/VERSIONING.rst),
+we post warnings of upcoming changes which may cause compatibility issues.
+As always, we expect that these changes will not impact the vast majority of consumers and can be picked up automatically provided you have good unit and integration changes.
+
+Starting in ACCP vesion 1.6.0, EC key pair generation will throw an `InvalidParameterException` if initialized to a keysize not on the following list.
+For these explicit sizes (only), the behavior will remain unchanged with ACCP selecting the corresponding "secp*r1" curve
+(which, in these cases, is also the corresponding NIST Prime Curve).
+
+**Supported keysize values:**
+* 192
+* 224
+* 256
+* 384
+* 521
+
+This means that the following code will start failing.
+```java
+KeyPairGenerator kg = KeyPairGenerator.getInstance("EC");
+kg.initialize(160); // Throws an InvalidParameterException
+```
+
+We are making this change because the "SunEC" provider does not document its curve selection process for sizes other than those listed above and does not promise that the curve selected will remain consistent.
+With no consistency guarantees, it is not possible for developers to use
+[KeyPairGenerator.initialize(int keysize)](https://docs.oracle.com/javase/8/docs/api/java/security/KeyPairGenerator.html#initialize-int-)
+safely (regardless of whether ACCP is used or not).
+
+**We strongly recommend using**
+**[KeyPairGenerator.initialize(AlgorithmParameterSpec params)](https://docs.oracle.com/javase/8/docs/api/java/security/KeyPairGenerator.html#initialize-java.security.spec.AlgorithmParameterSpec-)**
+**with**
+**[ECGenParameterSpec](https://docs.oracle.com/javase/8/docs/api/java/security/spec/ECGenParameterSpec.html)**
+**to generate EC keys.**
+
+From versions 1.2.0 through 1.5.0, ACCP *always* selects the corresponding "secp*r1" curve.
+For the explicit sizes listed above this matches the SunEC behavior.
+For other sizes, there are no documented guarantees of the SunEC behavior.
+
 ### Improvements
 * Now uses [OpenSSL 1.1.1g](https://www.openssl.org/source/openssl-1.1.1g.tar.gz). [PR #108](https://github.com/corretto/amazon-corretto-crypto-provider/pull/108)
 * Adds support for running a single test from the command line with the following syntax: [PR #113](https://github.com/corretto/amazon-corretto-crypto-provider/pull/113)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,11 @@
 ## 1.5.0 (Unreleased)
 ### Breaking Change Warning
 In accordance with our [versioning policy](https://github.com/corretto/amazon-corretto-crypto-provider/blob/master/VERSIONING.rst),
-we post warnings of upcoming changes which may cause compatibility issues.
+we post warnings of upcoming changes that might cause compatibility issues.
 As always, we expect that these changes will not impact the vast majority of consumers and can be picked up automatically provided you have good unit and integration changes.
 
-Starting in ACCP vesion 1.6.0, EC key pair generation will throw an `InvalidParameterException` if initialized to a keysize not on the following list.
-For these explicit sizes (only), the behavior will remain unchanged with ACCP selecting the corresponding "secp*r1" curve
-(which, in these cases, is also the corresponding NIST Prime Curve).
+Starting in ACCP vesion 1.6.0, EC key pair generation will throw an `InvalidParameterException` if initialized to a keysize that is not in the following list.
+For these explicit sizes (only), ACCP behavior is unchanged. ACCP selects the the "secp*r1" curve that corresponds to the value. (For these values, its also the corresponding NIST prime curve).
 
 **Supported keysize values:**
 * 192
@@ -17,14 +16,14 @@ For these explicit sizes (only), the behavior will remain unchanged with ACCP se
 * 384
 * 521
 
-This means that the following code will start failing.
+This means that the following code will start failing because it requests a keysize that is not on the list.
 ```java
 KeyPairGenerator kg = KeyPairGenerator.getInstance("EC");
 kg.initialize(160); // Throws an InvalidParameterException
 ```
 
-We are making this change because the "SunEC" provider does not document its curve selection process for sizes other than those listed above and does not promise that the curve selected will remain consistent.
-With no consistency guarantees, it is not possible for developers to use
+We are making this change because the "SunEC" provider does not document its curve selection process for sizes other than those listed above and does not promise that it will continue to use the same curve selection process.
+Without a consistency guarantee, developers can't use
 [KeyPairGenerator.initialize(int keysize)](https://docs.oracle.com/javase/8/docs/api/java/security/KeyPairGenerator.html#initialize-int-)
 safely (regardless of whether ACCP is used or not).
 
@@ -34,7 +33,7 @@ safely (regardless of whether ACCP is used or not).
 **[ECGenParameterSpec](https://docs.oracle.com/javase/8/docs/api/java/security/spec/ECGenParameterSpec.html)**
 **to generate EC keys.**
 
-From versions 1.2.0 through 1.5.0, ACCP *always* selects the corresponding "secp*r1" curve.
+From versions 1.2.0 through 1.5.0, ACCP selects the corresponding "secp*r1" curve for any keysize requested.
 For the explicit sizes listed above this matches the SunEC behavior.
 For other sizes, there are no documented guarantees of the SunEC behavior.
 

--- a/src/com/amazon/corretto/crypto/provider/EcGen.java
+++ b/src/com/amazon/corretto/crypto/provider/EcGen.java
@@ -167,6 +167,29 @@ class EcGen extends KeyPairGeneratorSpi {
             throws InvalidParameterException {
         try {
             final String curveName = "secp" + keysize + "r1";
+            // Explicitly list default curves
+            // Mapping from OpenJDK
+            // TODO: Uncomment following code at version 1.6.0
+//            final String curveName;
+//            switch (keysize) {
+//                case 192:
+//                    curveName = "secp192r1"; // NIST P-192
+//                    break;
+//                case 224:
+//                    curveName = "secp224r1"; // NIST P-224
+//                    break;
+//                case 256:
+//                    curveName = "secp256r1"; // NIST P-256
+//                    break;
+//                case 384:
+//                    curveName = "secp384r1"; // NIST P-384
+//                    break;
+//                case 521:
+//                    curveName = "secp521r1"; // NIST P-521
+//                    break;
+//                default:
+//                    throw new InvalidParameterException("No default NIST prime curve for keysize " + keysize);
+//            }
             initialize(new ECGenParameterSpec(curveName), random);
         } catch (final InvalidAlgorithmParameterException ex) {
             throw new InvalidParameterException(ex.getMessage());

--- a/tst/com/amazon/corretto/crypto/provider/test/EcGenTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/EcGenTest.java
@@ -3,8 +3,8 @@
 
 package com.amazon.corretto.crypto.provider.test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.math.BigInteger;
 import java.security.GeneralSecurityException;
@@ -35,13 +35,17 @@ import org.bouncycastle.asn1.ASN1Encodable;
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 import org.bouncycastle.asn1.ASN1Sequence;
 import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.aggregator.ArgumentsAccessor;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class EcGenTest {
-    public static final int[] KNOWN_SIZES = {192, 224, 256, 384, 521};
     public static final String[][] KNOWN_CURVES = new String[][] {
             // Prime Curves
             new String[]{"secp112r1", "1.3.132.0.6"},
@@ -114,18 +118,19 @@ public class EcGenTest {
     private KeyPairGenerator nativeGen;
     private KeyPairGenerator jceGen;
 
-    @BeforeClass
-    public static void setUpBeforeClass() throws Exception {
+    @BeforeAll
+    public void setUpBeforeClass() throws Exception {
         Security.addProvider(AmazonCorrettoCryptoProvider.INSTANCE);
     }
 
-    @Before
+    @BeforeEach
     public void setup() throws GeneralSecurityException {
         nativeGen = KeyPairGenerator.getInstance("EC", "AmazonCorrettoCryptoProvider");
         jceGen = KeyPairGenerator.getInstance("EC", "SunEC");
+
     }
 
-    @After
+    @AfterEach
     public void teardown() {
         // It is unclear if JUnit always properly releases references to classes and thus we may have memory leaks
         // if we do not properly null our references
@@ -133,57 +138,65 @@ public class EcGenTest {
         jceGen = null;
     }
 
-    @Test
-    public void knownCurves() throws GeneralSecurityException {
-        for (final String[] names : KNOWN_CURVES) {
-            for (final String name : names) {
-                ECGenParameterSpec spec = new ECGenParameterSpec(name);
-                nativeGen.initialize(spec);
-                KeyPair nativePair = nativeGen.generateKeyPair();
-                jceGen.initialize(spec);
-                KeyPair jcePair = jceGen.generateKeyPair();
-                final ECParameterSpec jceParams = ((ECPublicKey) jcePair.getPublic()).getParams();
-                final ECParameterSpec nativeParams = ((ECPublicKey) nativePair.getPublic()).getParams();
-                assertECEquals(name, jceParams, nativeParams);
+    private String[][] knownCurveParams() {
+        return KNOWN_CURVES;
+    }
 
-                // Ensure we can construct the curve using raw numbers rather than the name
-                nativeGen.initialize(jceParams);
-                nativePair = nativeGen.generateKeyPair();
-                assertECEquals(name + "-explicit", jceParams, nativeParams);
+    @ParameterizedTest
+    @MethodSource("knownCurveParams")
+    public void knownCurves(ArgumentsAccessor arguments) throws GeneralSecurityException {
+        for (final Object name : arguments.toArray()) {
+            ECGenParameterSpec spec = new ECGenParameterSpec((String) name);
+            nativeGen.initialize(spec);
+            KeyPair nativePair = nativeGen.generateKeyPair();
+            jceGen.initialize(spec);
+            KeyPair jcePair = jceGen.generateKeyPair();
+            final ECParameterSpec jceParams = ((ECPublicKey) jcePair.getPublic()).getParams();
+            final ECParameterSpec nativeParams = ((ECPublicKey) nativePair.getPublic()).getParams();
+            assertECEquals((String) name, jceParams, nativeParams);
 
-                final SubjectPublicKeyInfo publicKeyInfo = SubjectPublicKeyInfo.getInstance(nativePair.getPublic().getEncoded());
-                ASN1Encodable algorithmParameters = publicKeyInfo.getAlgorithm().getParameters();
-                assertTrue("Public key uses named curve", algorithmParameters instanceof ASN1ObjectIdentifier);
+            // Ensure we can construct the curve using raw numbers rather than the name
+            nativeGen.initialize(jceParams);
+            nativePair = nativeGen.generateKeyPair();
+            assertECEquals(name + "-explicit", jceParams, nativeParams);
 
-                // PKCS #8 = SEQ [ Integer, AlgorithmIdentifier, Octet String, ???]
-                // AlgorithmIdentifier = SEQ [ OID, {OID | SEQ}]
-                final ASN1Sequence p8 = ASN1Sequence.getInstance(nativePair.getPrivate().getEncoded());
-                final ASN1Sequence algIdentifier = (ASN1Sequence) p8.getObjectAt(1);
-                assertTrue("Private key uses named curve", algIdentifier.getObjectAt(1) instanceof ASN1ObjectIdentifier);
+            final SubjectPublicKeyInfo publicKeyInfo = SubjectPublicKeyInfo.getInstance(nativePair.getPublic().getEncoded());
+            ASN1Encodable algorithmParameters = publicKeyInfo.getAlgorithm().getParameters();
+            assertTrue(algorithmParameters instanceof ASN1ObjectIdentifier, "Public key uses named curve");
 
-                // Check encoding/decoding
-                Key bouncedKey = KEY_FACTORY.generatePublic(new X509EncodedKeySpec(nativePair.getPublic().getEncoded()));
-                assertEquals("Public key survives encoding", nativePair.getPublic(), bouncedKey);
-                bouncedKey = KEY_FACTORY.generatePrivate(new PKCS8EncodedKeySpec(nativePair.getPrivate().getEncoded()));
-                assertEquals("Private key survives encoding", nativePair.getPrivate(), bouncedKey);
-            }
+            // PKCS #8 = SEQ [ Integer, AlgorithmIdentifier, Octet String, ???]
+            // AlgorithmIdentifier = SEQ [ OID, {OID | SEQ}]
+            final ASN1Sequence p8 = ASN1Sequence.getInstance(nativePair.getPrivate().getEncoded());
+            final ASN1Sequence algIdentifier = (ASN1Sequence) p8.getObjectAt(1);
+            assertTrue(algIdentifier.getObjectAt(1) instanceof ASN1ObjectIdentifier, "Private key uses named curve");
+
+            // Check encoding/decoding
+            Key bouncedKey = KEY_FACTORY.generatePublic(new X509EncodedKeySpec(nativePair.getPublic().getEncoded()));
+            assertEquals(nativePair.getPublic(), bouncedKey, "Public key survives encoding");
+            bouncedKey = KEY_FACTORY.generatePrivate(new PKCS8EncodedKeySpec(nativePair.getPrivate().getEncoded()));
+            assertEquals(nativePair.getPrivate(), bouncedKey, "Private key survives encoding");
         }
     }
 
-    @Test
-    public void knownSizes() throws GeneralSecurityException {
+    @ParameterizedTest
+    @ValueSource(ints = {192, 224, 256, 384, 521})
+    public void knownSizes(int keysize) throws GeneralSecurityException {
         TestUtil.assumeMinimumVersion("1.2.0", nativeGen.getProvider());
-        for (int keysize : KNOWN_SIZES) {
-            nativeGen.initialize(keysize);
-            jceGen.initialize(keysize);
+        nativeGen.initialize(keysize);
+        jceGen.initialize(keysize);
 
-            final KeyPair nativePair = nativeGen.generateKeyPair();
-            final KeyPair jcePair = jceGen.generateKeyPair();
+        final KeyPair nativePair = nativeGen.generateKeyPair();
+        final KeyPair jcePair = jceGen.generateKeyPair();
 
-            final ECParameterSpec jceParams = ((ECPublicKey) jcePair.getPublic()).getParams();
-            final ECParameterSpec nativeParams = ((ECPublicKey) nativePair.getPublic()).getParams();
-            assertECEquals(Integer.toString(keysize), jceParams, nativeParams);
-        }
+        final ECParameterSpec jceParams = ((ECPublicKey) jcePair.getPublic()).getParams();
+        final ECParameterSpec nativeParams = ((ECPublicKey) nativePair.getPublic()).getParams();
+        assertECEquals(Integer.toString(keysize), jceParams, nativeParams);
+    }
+
+    @Test
+    public void explicitSizesOnly() throws GeneralSecurityException {
+        TestUtil.assumeMinimumVersion("1.6.0", nativeGen.getProvider());
+        TestUtil.assertThrows(InvalidParameterException.class, () -> nativeGen.initialize(128));
     }
 
     @Test
@@ -251,7 +264,7 @@ public class EcGenTest {
 
                 ecdsa.initVerify(keyPair.getPublic());
                 ecdsa.update(message);
-                assertTrue(name, ecdsa.verify(signature));
+                assertTrue(ecdsa.verify(signature), name);
             }
         }
     }
@@ -259,15 +272,6 @@ public class EcGenTest {
     @Test
     public void defaultParams() throws GeneralSecurityException {
         nativeGen.generateKeyPair();
-    }
-
-    @Test
-    public void keyLength() throws GeneralSecurityException {
-        final int[] lengths = new int[] { 112, 128, 160, 192, 256, 384, 521 };
-        for (final int length : lengths) {
-            nativeGen.initialize(length);
-            nativeGen.generateKeyPair();
-        }
     }
 
     @Test
@@ -316,10 +320,10 @@ public class EcGenTest {
 
     private static void assertECEquals(final String message, final ECParameterSpec expected,
             final ECParameterSpec actual) {
-        assertEquals(message, expected.getCofactor(), actual.getCofactor());
-        assertEquals(message, expected.getOrder(), actual.getOrder());
-        assertEquals(message, expected.getGenerator(), actual.getGenerator());
-        assertEquals(message, expected.getCurve(), actual.getCurve());
+        assertEquals(expected.getCofactor(), actual.getCofactor(), message);
+        assertEquals(expected.getOrder(), actual.getOrder(), message);
+        assertEquals(expected.getGenerator(), actual.getGenerator(), message);
+        assertEquals(expected.getCurve(), actual.getCurve(), message);
     }
 
     private static class TestThread extends Thread {


### PR DESCRIPTION
Add CHANGELOG warning about EC generation with keysize.

Also adds test ensuring correct behavior in version 1.6.0 and stubs code for version 1.6.0.

Also upgrades corresponding test to use JUnit5.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
