### PR TITLE
Complete initial JUnit5 migration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -554,6 +554,7 @@ add_jar(
         tst/com/amazon/corretto/crypto/provider/test/SelfTestSuiteTest.java
         tst/com/amazon/corretto/crypto/provider/test/ServiceSelfTestMetaTest.java
         tst/com/amazon/corretto/crypto/provider/test/TestProviderInstallation.java
+        tst/com/amazon/corretto/crypto/provider/test/TestResultLogger.java
         tst/com/amazon/corretto/crypto/provider/test/TestUtil.java
         tst/com/amazon/corretto/crypto/provider/test/ThrowingRunnable.java
         tst/com/amazon/corretto/crypto/provider/test/UtilsTest.java
@@ -592,12 +593,14 @@ set(TEST_RUNNER_ARGUMENTS
     -Djava.library.path=$<TARGET_FILE_DIR:amazonCorrettoCryptoProvider>
     -Dcom.amazon.corretto.crypto.provider.inTestSuite=hunter2
     -Dtest.data.dir=${TEST_DATA_DIR}
-    -Djunit.jupiter.testinstance.lifecycle.default=per_class
+    -Djunit.jupiter.execution.parallel.enabled=true
+    -Djunit.jupiter.execution.parallel.mode.default=concurrent
+    -Djunit.jupiter.execution.parallel.mode.classes.default=concurrent
     -XX:+HeapDumpOnOutOfMemoryError
     ${TEST_JAVA_ARGS}
     -jar ${TEST_RUNNER_JAR}
     -cp $<TARGET_PROPERTY:accp-jar,JAR_FILE>:$<TARGET_PROPERTY:tests-jar,JAR_FILE>:${TEST_CLASSPATH}
-    --details=verbose
+    --details=summary
     --details-theme=ascii
     --fail-if-no-tests
 )

--- a/tst/com/amazon/corretto/crypto/provider/test/AESGenerativeTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/AESGenerativeTest.java
@@ -4,9 +4,10 @@
 package com.amazon.corretto.crypto.provider.test;
 
 import static com.amazon.corretto.crypto.provider.test.TestUtil.versionCompare;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static com.amazon.corretto.crypto.provider.test.TestUtil.NATIVE_PROVIDER;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -22,7 +23,6 @@ import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
 import java.security.PrivateKey;
 import java.security.PublicKey;
-import java.security.Security;
 import java.util.Arrays;
 import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
@@ -37,9 +37,17 @@ import javax.crypto.spec.GCMParameterSpec;
 import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 
-import com.amazon.corretto.crypto.provider.AmazonCorrettoCryptoProvider;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
+
+@ExtendWith(TestResultLogger.class)
+@Execution(ExecutionMode.CONCURRENT)
+@ResourceLock(value = TestUtil.RESOURCE_GLOBAL, mode = ResourceAccessMode.READ)
 
 public class AESGenerativeTest {
     private static final int[] KEY_SIZES = new int[] {128, 192, 256};
@@ -51,12 +59,8 @@ public class AESGenerativeTest {
     Cipher jceCipherEncrypt, jceCipherDecrypt;
     Cipher amzCipherEncrypt, amzCipherDecrypt;
 
-    public AESGenerativeTest() throws Exception {
-        Security.addProvider(AmazonCorrettoCryptoProvider.INSTANCE);
-    }
 
-
-    @After
+    @AfterEach
     public void teardown() {
         jceCipherEncrypt = null;
         jceCipherDecrypt = null;
@@ -109,7 +113,7 @@ public class AESGenerativeTest {
             // For speed, we'll try to get a native copy, but we don't require it
             KeyPairGenerator kg;
             try {
-                kg = KeyPairGenerator.getInstance("RSA", "AmazonCorrettoCryptoProvider");
+                kg = KeyPairGenerator.getInstance("RSA", NATIVE_PROVIDER);
             } catch (final Exception ex) {
                 kg = KeyPairGenerator.getInstance("RSA");
             }
@@ -162,8 +166,8 @@ public class AESGenerativeTest {
                 // Allocate new cipher objects
                 jceCipherEncrypt = Cipher.getInstance(algorithm, "SunJCE");
                 jceCipherDecrypt = Cipher.getInstance(algorithm, "SunJCE");
-                amzCipherEncrypt = Cipher.getInstance(algorithm, "AmazonCorrettoCryptoProvider");
-                amzCipherDecrypt = Cipher.getInstance(algorithm, "AmazonCorrettoCryptoProvider");
+                amzCipherEncrypt = Cipher.getInstance(algorithm, NATIVE_PROVIDER);
+                amzCipherDecrypt = Cipher.getInstance(algorithm, NATIVE_PROVIDER);
             } // fall through to init
             case 1: {
                 // Re-init existing ciphers

--- a/tst/com/amazon/corretto/crypto/provider/test/AccessibleByteArrayOutputStreamTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/AccessibleByteArrayOutputStreamTest.java
@@ -7,14 +7,20 @@ import static com.amazon.corretto.crypto.provider.test.TestUtil.assertThrows;
 import static com.amazon.corretto.crypto.provider.test.TestUtil.sneakyConstruct;
 import static com.amazon.corretto.crypto.provider.test.TestUtil.sneakyInvoke;
 import static com.amazon.corretto.crypto.provider.test.TestUtil.sneakyInvoke_int;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
+@ExtendWith(TestResultLogger.class)
+@Execution(ExecutionMode.CONCURRENT)
 public class AccessibleByteArrayOutputStreamTest {
 
     @Test

--- a/tst/com/amazon/corretto/crypto/provider/test/AesTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/AesTest.java
@@ -54,8 +54,8 @@ import org.junit.jupiter.api.parallel.ResourceLock;
 
 @ExtendWith(TestResultLogger.class)
 @Execution(ExecutionMode.SAME_THREAD)
-@ResourceLock(value = TestUtil.RESOURCE_REFLECTION, mode = ResourceAccessMode.READ)
-@ResourceLock(value = TestUtil.RESOURCE_GLOBAL, mode = ResourceAccessMode.READ)
+@ResourceLock(value = TestUtil.RESOURCE_REFLECTION)
+@ResourceLock(value = TestUtil.RESOURCE_GLOBAL, mode = ResourceAccessMode.READ_WRITE)
 public class AesTest {
     private static final Class<?> SPI_CLASS;
     private static final byte[] PLAINTEXT = "Hello world. Good night moon.".getBytes(StandardCharsets.UTF_8);

--- a/tst/com/amazon/corretto/crypto/provider/test/AesTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/AesTest.java
@@ -4,18 +4,16 @@
 package com.amazon.corretto.crypto.provider.test;
 
 import static com.amazon.corretto.crypto.provider.test.TestUtil.assumeMinimumVersion;
+import static com.amazon.corretto.crypto.provider.test.TestUtil.assertThrows;
 import static com.amazon.corretto.crypto.provider.test.TestUtil.sneakyConstruct;
 import static com.amazon.corretto.crypto.provider.test.TestUtil.sneakyGetField;
-import static com.amazon.corretto.crypto.provider.test.TestUtil.assertThrows;
 import static com.amazon.corretto.crypto.provider.test.TestUtil.sneakyInvoke;
-import static com.amazon.corretto.crypto.provider.test.TestUtil.sneakyInvokeExplicit;
 import static com.amazon.corretto.crypto.provider.test.TestUtil.sneakyInvoke_int;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.io.ByteArrayOutputStream;
 import java.math.BigInteger;
@@ -32,7 +30,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
-import java.util.function.LongSupplier;
 
 import javax.crypto.AEADBadTagException;
 import javax.crypto.Cipher;
@@ -45,10 +42,20 @@ import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 
 import com.amazon.corretto.crypto.provider.AmazonCorrettoCryptoProvider;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 
+@ExtendWith(TestResultLogger.class)
+@Execution(ExecutionMode.SAME_THREAD)
+@ResourceLock(value = TestUtil.RESOURCE_REFLECTION, mode = ResourceAccessMode.READ)
+@ResourceLock(value = TestUtil.RESOURCE_GLOBAL, mode = ResourceAccessMode.READ)
 public class AesTest {
     private static final Class<?> SPI_CLASS;
     private static final byte[] PLAINTEXT = "Hello world. Good night moon.".getBytes(StandardCharsets.UTF_8);
@@ -68,10 +75,13 @@ public class AesTest {
       }
     }
 
-    @Before
-    public void setup() throws Throwable {
+    @BeforeAll
+    public static void setupProvider() {
         Security.addProvider(AmazonCorrettoCryptoProvider.INSTANCE);
-
+    }
+    
+    @BeforeEach
+    public void setup() throws Throwable {
         byte[] foo = TestUtil.getRandomBytes(16);
         key = new SecretKeySpec(foo, "AES");
         nonce = TestUtil.getRandomBytes(12);
@@ -79,7 +89,7 @@ public class AesTest {
         amznC = Cipher.getInstance(ALGO_NAME, AmazonCorrettoCryptoProvider.INSTANCE);
     }
 
-    @After
+    @AfterEach
     public void teardown() {
         // It is unclear if JUnit always properly releases references to classes and thus we may have memory leaks
         // if we do not properly null our references
@@ -270,9 +280,10 @@ public class AesTest {
 
     }
 
-    @Test(expected = NoSuchAlgorithmException.class)
+    @Test
     public void edge_badSetMode() throws Throwable {
-        sneakyInvoke(getSpiInstance(), "engineSetMode", "ECB");
+        assertThrows(NoSuchAlgorithmException.class, () ->
+            sneakyInvoke(getSpiInstance(), "engineSetMode", "ECB"));
     }
 
     @Test
@@ -281,9 +292,10 @@ public class AesTest {
         sneakyInvoke(getSpiInstance(), "engineSetMode", "gcm");
     }
 
-    @Test(expected = NoSuchPaddingException.class)
+    @Test
     public void edge_badSetPadding() throws Throwable {
-        sneakyInvoke(getSpiInstance(), "engineSetPadding", "PKCS5Padding");
+        assertThrows(NoSuchPaddingException.class, () ->
+            sneakyInvoke(getSpiInstance(), "engineSetPadding", "PKCS5Padding"));
     }
 
     @Test
@@ -589,7 +601,7 @@ public class AesTest {
                         new GCMParameterSpec(128, new byte[16]), rnd));
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void whenAADTagSetAfterInit_throws() throws Throwable {
         // COMPATIBILITY: SunJCE accepts updateAAD after update(), despite updateAAD being
         // documented as throwing
@@ -602,7 +614,7 @@ public class AesTest {
 
         c.update(new byte[1]);
 
-        c.updateAAD(new byte[1]);
+        assertThrows(IllegalStateException.class, () ->  c.updateAAD(new byte[1]));
     }
 
     @Test
@@ -651,9 +663,10 @@ public class AesTest {
         d.doFinal(data);
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void whenDoFinalWithoutInit_throwsCorrectException() throws Throwable {
-        sneakyInvoke(getSpiInstance(), "engineDoFinal", new byte[0], 0, 0, new byte[16], 0);
+        assertThrows(IllegalStateException.class, () ->
+            sneakyInvoke(getSpiInstance(), "engineDoFinal", new byte[0], 0, 0, new byte[16], 0));
     }
 
     @Test
@@ -789,7 +802,7 @@ public class AesTest {
         Cipher c = Cipher.getInstance(ALGO_NAME, PROVIDER_AMAZON);
         final Object spi = sneakyGetField(c, "spi");
         final int keyReuseThreshold = (int) sneakyGetField(spi.getClass(), "KEY_REUSE_THRESHOLD");
-        assertEquals("Test must be re-written for KEY_REUSE_THRESHOLD != 1", 1, keyReuseThreshold);
+        assertEquals(1, keyReuseThreshold, "Test must be re-written for KEY_REUSE_THRESHOLD != 1");
 
         GCMParameterSpec spec1 = new GCMParameterSpec(128, randomIV());
         GCMParameterSpec spec2 = new GCMParameterSpec(128, randomIV());

--- a/tst/com/amazon/corretto/crypto/provider/test/EcGenTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/EcGenTest.java
@@ -16,7 +16,6 @@ import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
-import java.security.Security;
 import java.security.Signature;
 import java.security.interfaces.ECPublicKey;
 import java.security.spec.ECFieldFp;
@@ -30,16 +29,22 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import com.amazon.corretto.crypto.provider.AmazonCorrettoCryptoProvider;
 import org.bouncycastle.asn1.ASN1Encodable;
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 import org.bouncycastle.asn1.ASN1Sequence;
 import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 
+@ExtendWith(TestResultLogger.class)
+@Execution(ExecutionMode.CONCURRENT)
+@ResourceLock(value = TestUtil.RESOURCE_GLOBAL, mode = ResourceAccessMode.READ)
 public class EcGenTest {
     public static final int[] KNOWN_SIZES = {192, 224, 256, 384, 521};
     public static final String[][] KNOWN_CURVES = new String[][] {
@@ -114,14 +119,9 @@ public class EcGenTest {
     private KeyPairGenerator nativeGen;
     private KeyPairGenerator jceGen;
 
-    @BeforeClass
-    public static void setUpBeforeClass() throws Exception {
-        Security.addProvider(AmazonCorrettoCryptoProvider.INSTANCE);
-    }
-
     @Before
     public void setup() throws GeneralSecurityException {
-        nativeGen = KeyPairGenerator.getInstance("EC", "AmazonCorrettoCryptoProvider");
+        nativeGen = KeyPairGenerator.getInstance("EC", TestUtil.NATIVE_PROVIDER);
         jceGen = KeyPairGenerator.getInstance("EC", "SunEC");
     }
 

--- a/tst/com/amazon/corretto/crypto/provider/test/EcGenTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/EcGenTest.java
@@ -3,6 +3,7 @@
 
 package com.amazon.corretto.crypto.provider.test;
 
+import static com.amazon.corretto.crypto.provider.test.TestUtil.NATIVE_PROVIDER;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -124,7 +125,7 @@ public class EcGenTest {
 
     @BeforeEach
     public void setup() throws GeneralSecurityException {
-        nativeGen = KeyPairGenerator.getInstance("EC", TestUtil.NATIVE_PROVIDER);
+        nativeGen = KeyPairGenerator.getInstance("EC", NATIVE_PROVIDER);
         jceGen = KeyPairGenerator.getInstance("EC", "SunEC");
 
     }
@@ -137,7 +138,7 @@ public class EcGenTest {
         jceGen = null;
     }
 
-    private String[][] knownCurveParams() {
+    private static String[][] knownCurveParams() {
         return KNOWN_CURVES;
     }
 
@@ -285,7 +286,7 @@ public class EcGenTest {
 
         final KeyPairGenerator[] generators = new KeyPairGenerator[generatorCount];
         for (int x = 0; x < generatorCount; x++) {
-            generators[x] = KeyPairGenerator.getInstance("EC", "AmazonCorrettoCryptoProvider");
+            generators[x] = KeyPairGenerator.getInstance("EC", NATIVE_PROVIDER);
             final int curveIdx = rng.nextInt(KNOWN_CURVES.length);
             generators[x].initialize(new ECGenParameterSpec(KNOWN_CURVES[curveIdx][0]));
         }

--- a/tst/com/amazon/corretto/crypto/provider/test/EvpKeyAgreementTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/EvpKeyAgreementTest.java
@@ -3,6 +3,7 @@
 
 package com.amazon.corretto.crypto.provider.test;
 
+import static com.amazon.corretto.crypto.provider.test.TestUtil.NATIVE_PROVIDER;
 import static com.amazon.corretto.crypto.provider.test.TestUtil.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -44,7 +45,6 @@ import javax.crypto.spec.DHPublicKeySpec;
 import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 
-import com.amazon.corretto.crypto.provider.AmazonCorrettoCryptoProvider;
 import org.bouncycastle.asn1.ASN1Encodable;
 import org.bouncycastle.asn1.ASN1Sequence;
 import org.bouncycastle.asn1.DERBitString;
@@ -53,9 +53,17 @@ import org.bouncycastle.jce.provider.BouncyCastleProvider;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
+@ExtendWith(TestResultLogger.class)
+@Execution(ExecutionMode.SAME_THREAD) // Parameters are shared
+@ResourceLock(value = TestUtil.RESOURCE_GLOBAL, mode = ResourceAccessMode.READ)
 public class EvpKeyAgreementTest {
     private static final BouncyCastleProvider BC_PROV = new BouncyCastleProvider();
     private static final int PAIR_COUNT = 25;
@@ -157,7 +165,7 @@ public class EvpKeyAgreementTest {
                 "DH",
                 "DH(" + keySize + ")",
                 generator,
-                AmazonCorrettoCryptoProvider.INSTANCE,
+                NATIVE_PROVIDER,
                 BC_PROV,
                 badKeys
         );
@@ -166,7 +174,7 @@ public class EvpKeyAgreementTest {
 
     private static TestParams buildEcdhParameters(final AlgorithmParameterSpec genSpec, final String name)
             throws GeneralSecurityException, IOException {
-        final KeyPairGenerator generator = KeyPairGenerator.getInstance("EC", AmazonCorrettoCryptoProvider.INSTANCE);
+        final KeyPairGenerator generator = KeyPairGenerator.getInstance("EC", NATIVE_PROVIDER);
         generator.initialize(genSpec);
         final KeyPair pair = generator.generateKeyPair();
         final ECPublicKey pubKey = (ECPublicKey) pair.getPublic();
@@ -174,7 +182,7 @@ public class EvpKeyAgreementTest {
                 "ECDH",
                 "ECDH(" + name + ")",
                 generator,
-                AmazonCorrettoCryptoProvider.INSTANCE,
+                NATIVE_PROVIDER,
                 BC_PROV,
                 Arrays.asList(
                         buildKeyAtInfinity(pubKey),

--- a/tst/com/amazon/corretto/crypto/provider/test/EvpSignatureTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/EvpSignatureTest.java
@@ -33,9 +33,14 @@ import java.util.stream.Stream;
 import com.amazon.corretto.crypto.provider.AmazonCorrettoCryptoProvider;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
+@ExtendWith(TestResultLogger.class)
+@ResourceLock(value = TestUtil.RESOURCE_GLOBAL, mode = ResourceAccessMode.READ)
 public class EvpSignatureTest {
     private static final Provider NATIVE_PROVIDER = AmazonCorrettoCryptoProvider.INSTANCE;
     private static final int[] LENGTHS = new int[] { 1, 3, 4, 7, 8, 16, 32, 48, 64, 128, 256, 1024, 1536, 2049 };
@@ -87,8 +92,8 @@ public class EvpSignatureTest {
 
         @Override
         public String toString() {
-            return String.format("%s params.message length %s. Read-only: %s, Sliced: %s",
-                    base,
+            return String.format("%s length %s. Read-only: %s, Sliced: %s",
+                    algorithm,
                     length,
                     readOnly,
                     slice

--- a/tst/com/amazon/corretto/crypto/provider/test/HashFunctionTester.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/HashFunctionTester.java
@@ -5,9 +5,9 @@ package com.amazon.corretto.crypto.provider.test;
 
 import static com.amazon.corretto.crypto.provider.test.TestUtil.assertThrows;
 import static com.amazon.corretto.crypto.provider.test.TestUtil.sneakyInvoke;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
@@ -152,7 +152,7 @@ public class HashFunctionTester {
 
     private MessageDigest getAmazonInstance() {
         try {
-            return MessageDigest.getInstance(algorithm, "AmazonCorrettoCryptoProvider");
+            return MessageDigest.getInstance(algorithm, TestUtil.NATIVE_PROVIDER);
         } catch (Throwable t) {
             throw new AssertionError(t);
         }

--- a/tst/com/amazon/corretto/crypto/provider/test/MD5Test.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/MD5Test.java
@@ -3,31 +3,32 @@
 
 package com.amazon.corretto.crypto.provider.test;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.security.MessageDigest;
-import java.security.Security;
 import java.util.zip.GZIPInputStream;
 
-import com.amazon.corretto.crypto.provider.AmazonCorrettoCryptoProvider;
 import org.apache.commons.codec.binary.Hex;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 
+@ExtendWith(TestResultLogger.class)
+@Execution(ExecutionMode.SAME_THREAD)
+@ResourceLock(value = TestUtil.RESOURCE_REFLECTION)
+@ResourceLock(value = TestUtil.RESOURCE_GLOBAL, mode = ResourceAccessMode.READ)
 public class MD5Test {
 
     private static final String ALGORITHM = "MD5";
 
-    @Before
-    public void setUp() throws Exception {
-        Security.addProvider(AmazonCorrettoCryptoProvider.INSTANCE);
-    }
-
     private MessageDigest getDigest() throws Exception {
-        return MessageDigest.getInstance(ALGORITHM, "AmazonCorrettoCryptoProvider");
+        return MessageDigest.getInstance(ALGORITHM, TestUtil.NATIVE_PROVIDER);
     }
 
     @Test

--- a/tst/com/amazon/corretto/crypto/provider/test/MiscSingleThreadedTests.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/MiscSingleThreadedTests.java
@@ -3,13 +3,18 @@
 
 package com.amazon.corretto.crypto.provider.test;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static com.amazon.corretto.crypto.provider.test.TestUtil.assumeMinimumVersion;
 import static com.amazon.corretto.crypto.provider.test.TestUtil.saveProviders;
 import static com.amazon.corretto.crypto.provider.test.TestUtil.restoreProviders;
 
 import com.amazon.corretto.crypto.provider.AmazonCorrettoCryptoProvider;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 
 import java.nio.charset.StandardCharsets;
 import java.security.KeyPair;
@@ -20,6 +25,9 @@ import java.security.Signature;
 /**
  * Contains miscellaneous tests which must be run in a single-threaded environment.
  */
+@ExtendWith(TestResultLogger.class)
+@Execution(ExecutionMode.SAME_THREAD)
+@ResourceLock(value = TestUtil.RESOURCE_GLOBAL, mode = ResourceAccessMode.READ)
 public class MiscSingleThreadedTests {
 
 

--- a/tst/com/amazon/corretto/crypto/provider/test/NativeTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/NativeTest.java
@@ -12,8 +12,14 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 
-@ExtendWith(NativeTestHooks.RequireHooks.class)
+@ExtendWith({TestResultLogger.class, NativeTestHooks.RequireHooks.class})
+@Execution(ExecutionMode.CONCURRENT)
+@ResourceLock(value = TestUtil.RESOURCE_GLOBAL, mode = ResourceAccessMode.READ)
 public class NativeTest {
 
     @Test

--- a/tst/com/amazon/corretto/crypto/provider/test/RecursiveInitializationTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/RecursiveInitializationTest.java
@@ -3,7 +3,7 @@
 
 package com.amazon.corretto.crypto.provider.test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import javax.crypto.Cipher;
 import java.security.NoSuchAlgorithmException;

--- a/tst/com/amazon/corretto/crypto/provider/test/RsaGenTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/RsaGenTest.java
@@ -6,9 +6,9 @@ package com.amazon.corretto.crypto.provider.test;
 import static com.amazon.corretto.crypto.provider.test.TestUtil.assertThrows;
 import static com.amazon.corretto.crypto.provider.test.TestUtil.assumeMinimumVersion;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.math.BigInteger;
 import java.security.GeneralSecurityException;
@@ -26,16 +26,24 @@ import java.util.List;
 import javax.crypto.Cipher;
 
 import org.bouncycastle.util.encoders.Hex;
-import org.junit.Before;
-import org.junit.Test;
 
 import com.amazon.corretto.crypto.provider.AmazonCorrettoCryptoProvider;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 
+@ExtendWith(TestResultLogger.class)
+@Execution(ExecutionMode.CONCURRENT)
+@ResourceLock(value = TestUtil.RESOURCE_GLOBAL, mode = ResourceAccessMode.READ)
 public class RsaGenTest {
     private static final byte[] PLAINTEXT = new byte[32];
 
-    @Before
-    public void setUp() throws Exception {
+    @BeforeAll
+    public static void setUp() throws Exception {
         Security.addProvider(AmazonCorrettoCryptoProvider.INSTANCE);
     }
 

--- a/tst/com/amazon/corretto/crypto/provider/test/SHA1Test.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/SHA1Test.java
@@ -3,31 +3,32 @@
 
 package com.amazon.corretto.crypto.provider.test;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.security.MessageDigest;
-import java.security.Security;
 import java.util.zip.GZIPInputStream;
 
-import com.amazon.corretto.crypto.provider.AmazonCorrettoCryptoProvider;
 import org.apache.commons.codec.binary.Hex;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 
+@ExtendWith(TestResultLogger.class)
+@Execution(ExecutionMode.SAME_THREAD)
+@ResourceLock(value = TestUtil.RESOURCE_REFLECTION)
+@ResourceLock(value = TestUtil.RESOURCE_GLOBAL, mode = ResourceAccessMode.READ)
 public class SHA1Test {
 
     private static final String ALGORITHM = "SHA-1";
 
-    @Before
-    public void setUp() throws Exception {
-        Security.addProvider(AmazonCorrettoCryptoProvider.INSTANCE);
-    }
-
     private MessageDigest getDigest() throws Exception {
-        return MessageDigest.getInstance(ALGORITHM, "AmazonCorrettoCryptoProvider");
+        return MessageDigest.getInstance(ALGORITHM, TestUtil.NATIVE_PROVIDER);
     }
 
     @Test

--- a/tst/com/amazon/corretto/crypto/provider/test/SHA1Test.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/SHA1Test.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.parallel.ResourceLock;
 @ExtendWith(TestResultLogger.class)
 @Execution(ExecutionMode.SAME_THREAD)
 @ResourceLock(value = TestUtil.RESOURCE_REFLECTION)
-@ResourceLock(value = TestUtil.RESOURCE_GLOBAL, mode = ResourceAccessMode.READ)
+@ResourceLock(value = TestUtil.RESOURCE_GLOBAL, mode = ResourceAccessMode.READ_WRITE)
 public class SHA1Test {
 
     private static final String ALGORITHM = "SHA-1";

--- a/tst/com/amazon/corretto/crypto/provider/test/SHA256Test.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/SHA256Test.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.parallel.ResourceLock;
 @ExtendWith(TestResultLogger.class)
 @Execution(ExecutionMode.SAME_THREAD)
 @ResourceLock(value = TestUtil.RESOURCE_REFLECTION)
-@ResourceLock(value = TestUtil.RESOURCE_GLOBAL, mode = ResourceAccessMode.READ)
+@ResourceLock(value = TestUtil.RESOURCE_GLOBAL, mode = ResourceAccessMode.READ_WRITE)
 public class SHA256Test {
 
     private static final String SHA_256 = "SHA-256";

--- a/tst/com/amazon/corretto/crypto/provider/test/SHA256Test.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/SHA256Test.java
@@ -3,32 +3,32 @@
 
 package com.amazon.corretto.crypto.provider.test;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.security.MessageDigest;
-import java.security.Security;
 import java.util.zip.GZIPInputStream;
 
 import org.apache.commons.codec.binary.Hex;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 
-import com.amazon.corretto.crypto.provider.AmazonCorrettoCryptoProvider;
-
+@ExtendWith(TestResultLogger.class)
+@Execution(ExecutionMode.SAME_THREAD)
+@ResourceLock(value = TestUtil.RESOURCE_REFLECTION)
+@ResourceLock(value = TestUtil.RESOURCE_GLOBAL, mode = ResourceAccessMode.READ)
 public class SHA256Test {
 
     private static final String SHA_256 = "SHA-256";
 
-    @Before
-    public void setUp() throws Exception {
-        Security.addProvider(AmazonCorrettoCryptoProvider.INSTANCE);
-    }
-
     private MessageDigest getDigest() throws Exception {
-        return MessageDigest.getInstance(SHA_256, "AmazonCorrettoCryptoProvider");
+        return MessageDigest.getInstance(SHA_256, TestUtil.NATIVE_PROVIDER);
     }
 
     @Test

--- a/tst/com/amazon/corretto/crypto/provider/test/SHA384Test.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/SHA384Test.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.parallel.ResourceLock;
 @ExtendWith(TestResultLogger.class)
 @Execution(ExecutionMode.SAME_THREAD)
 @ResourceLock(value = TestUtil.RESOURCE_REFLECTION)
-@ResourceLock(value = TestUtil.RESOURCE_GLOBAL, mode = ResourceAccessMode.READ)
+@ResourceLock(value = TestUtil.RESOURCE_GLOBAL, mode = ResourceAccessMode.READ_WRITE)
 public class SHA384Test {
 
     private static final String SHA_384 = "SHA-384";

--- a/tst/com/amazon/corretto/crypto/provider/test/SHA384Test.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/SHA384Test.java
@@ -3,31 +3,32 @@
 
 package com.amazon.corretto.crypto.provider.test;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.security.MessageDigest;
-import java.security.Security;
 import java.util.zip.GZIPInputStream;
 
-import com.amazon.corretto.crypto.provider.AmazonCorrettoCryptoProvider;
 import org.apache.commons.codec.binary.Hex;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 
+@ExtendWith(TestResultLogger.class)
+@Execution(ExecutionMode.SAME_THREAD)
+@ResourceLock(value = TestUtil.RESOURCE_REFLECTION)
+@ResourceLock(value = TestUtil.RESOURCE_GLOBAL, mode = ResourceAccessMode.READ)
 public class SHA384Test {
 
     private static final String SHA_384 = "SHA-384";
 
-    @Before
-    public void setUp() throws Exception {
-        Security.addProvider(AmazonCorrettoCryptoProvider.INSTANCE);
-    }
-
     private MessageDigest getDigest() throws Exception {
-        return MessageDigest.getInstance(SHA_384, "AmazonCorrettoCryptoProvider");
+        return MessageDigest.getInstance(SHA_384, TestUtil.NATIVE_PROVIDER);
     }
 
     @Test

--- a/tst/com/amazon/corretto/crypto/provider/test/SHA512Test.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/SHA512Test.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.parallel.ResourceLock;
 @ExtendWith(TestResultLogger.class)
 @Execution(ExecutionMode.SAME_THREAD)
 @ResourceLock(value = TestUtil.RESOURCE_REFLECTION)
-@ResourceLock(value = TestUtil.RESOURCE_GLOBAL, mode = ResourceAccessMode.READ)
+@ResourceLock(value = TestUtil.RESOURCE_GLOBAL, mode = ResourceAccessMode.READ_WRITE)
 public class SHA512Test {
 
     private static final String SHA_512 = "SHA-512";

--- a/tst/com/amazon/corretto/crypto/provider/test/SHA512Test.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/SHA512Test.java
@@ -3,32 +3,32 @@
 
 package com.amazon.corretto.crypto.provider.test;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.security.MessageDigest;
-import java.security.Security;
 import java.util.zip.GZIPInputStream;
 
 import org.apache.commons.codec.binary.Hex;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 
-import com.amazon.corretto.crypto.provider.AmazonCorrettoCryptoProvider;
-
+@ExtendWith(TestResultLogger.class)
+@Execution(ExecutionMode.SAME_THREAD)
+@ResourceLock(value = TestUtil.RESOURCE_REFLECTION)
+@ResourceLock(value = TestUtil.RESOURCE_GLOBAL, mode = ResourceAccessMode.READ)
 public class SHA512Test {
 
     private static final String SHA_512 = "SHA-512";
 
-    @Before
-    public void setUp() throws Exception {
-        Security.addProvider(AmazonCorrettoCryptoProvider.INSTANCE);
-    }
-
     private MessageDigest getDigest() throws Exception {
-        return MessageDigest.getInstance(SHA_512, "AmazonCorrettoCryptoProvider");
+        return MessageDigest.getInstance(SHA_512, TestUtil.NATIVE_PROVIDER);
     }
 
     @Test

--- a/tst/com/amazon/corretto/crypto/provider/test/SecurityPropertyRecursiveTester.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/SecurityPropertyRecursiveTester.java
@@ -8,7 +8,7 @@ import com.amazon.corretto.crypto.provider.AmazonCorrettoCryptoProvider;
 import java.security.Provider;
 import java.security.Security;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * This is a special stand-alone test case which asserts that NativeJCEBindings is installed as the highers priority provider

--- a/tst/com/amazon/corretto/crypto/provider/test/SecurityPropertyTester.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/SecurityPropertyTester.java
@@ -3,7 +3,7 @@
 
 package com.amazon.corretto.crypto.provider.test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.security.KeyPairGenerator;
 import java.security.Provider;

--- a/tst/com/amazon/corretto/crypto/provider/test/ServiceSelfTestMetaTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/ServiceSelfTestMetaTest.java
@@ -6,9 +6,9 @@ package com.amazon.corretto.crypto.provider.test;
 import static com.amazon.corretto.crypto.provider.test.TestUtil.sneakyConstruct;
 import static com.amazon.corretto.crypto.provider.test.TestUtil.sneakyGetInternalClass;
 import static com.amazon.corretto.crypto.provider.test.TestUtil.sneakyInvoke;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.security.NoSuchAlgorithmException;
 import java.security.Provider;
@@ -17,31 +17,39 @@ import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
-import org.junit.After;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.amazon.corretto.crypto.provider.AesCtrDrbg;
 import com.amazon.corretto.crypto.provider.HmacMD5Spi;
 import com.amazon.corretto.crypto.provider.AmazonCorrettoCryptoProvider;
 import com.amazon.corretto.crypto.provider.SelfTestResult;
 import com.amazon.corretto.crypto.provider.SelfTestStatus;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 
+@ExtendWith(TestResultLogger.class)
+@Execution(ExecutionMode.SAME_THREAD)
+@ResourceLock(value = TestUtil.RESOURCE_GLOBAL, mode = ResourceAccessMode.READ_WRITE)
 public class ServiceSelfTestMetaTest {
     AmazonCorrettoCryptoProvider accp;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Throwable {
         // We need RDRAND support for a lot of these tests to work properly
-        Assume.assumeTrue("RDRAND is supported", AmazonCorrettoCryptoProvider.isRdRandSupported());
+        Assumptions.assumeTrue(AmazonCorrettoCryptoProvider.isRdRandSupported(), "RDRAND is supported");
 
         // AACP instances cache the self-test status within each Service, so create a new instance to clear that cache.
         // This also makes sure the native library is loaded.
         accp = new AmazonCorrettoCryptoProvider();
     }
 
-    @After
+    @AfterEach
     public void reset() throws Throwable {
         sneakyInvoke(AmazonCorrettoCryptoProvider.INSTANCE, "resetAllSelfTests");
         // It is unclear if JUnit always properly releases references to classes and thus we may have memory leaks

--- a/tst/com/amazon/corretto/crypto/provider/test/TestProviderInstallation.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/TestProviderInstallation.java
@@ -3,23 +3,31 @@
 
 package com.amazon.corretto.crypto.provider.test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.security.MessageDigest;
 import java.security.Security;
 
 import com.amazon.corretto.crypto.provider.AmazonCorrettoCryptoProvider;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.amazon.corretto.crypto.provider.SelfTestStatus;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 
+@ExtendWith(TestResultLogger.class)
+@Execution(ExecutionMode.SAME_THREAD)
+@ResourceLock(value = TestUtil.RESOURCE_PROVIDER, mode = ResourceAccessMode.READ_WRITE)
+@ResourceLock(value = TestUtil.RESOURCE_GLOBAL, mode = ResourceAccessMode.READ_WRITE)
 public class TestProviderInstallation {
     @Test
     public void testProviderInstallation() throws Exception {

--- a/tst/com/amazon/corretto/crypto/provider/test/TestResultLogger.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/TestResultLogger.java
@@ -1,0 +1,110 @@
+package com.amazon.corretto.crypto.provider.test;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.TestWatcher;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Arrays;
+import java.util.Optional;
+
+public class TestResultLogger implements TestWatcher {
+    /**
+     * Reads the ACCP_TEST_COLOR environment variable and if it is case-insensitive equal to "false",
+     * returns the empty string. Else, returns the proper control codes to set the color/font specified by {@code code}.
+     */
+    private static final String maybeColor(String code) {
+        final String envVarValue = System.getenv("ACCP_TEST_COLOR");
+        if ("false".equalsIgnoreCase(envVarValue)) {
+            return "";
+        }
+
+        return (char)27 + "[" + code + "m";
+    }
+    private static final String BRIGHT_TEXT = maybeColor("1");
+    private static final String BRIGHT_RED_TEXT = maybeColor("31;1");
+    private static final String BRIGHT_GREEN_TEXT = maybeColor("32;1");
+    private static final String BRIGHT_CYAN_TEXT = maybeColor("36;1");
+    private static final String NORMAL_TEXT = maybeColor("0");
+    private static final String NOT_YET_FAILED_NOTICE = " ";
+    private static final String ALREADY_FAILED_NOTICE = BRIGHT_RED_TEXT + "!" + NORMAL_TEXT;
+    private static final String STARTED_NOTICE = BRIGHT_TEXT +                "[STARTED]         " + NORMAL_TEXT;
+    private static final String PASSED_NOTICE = BRIGHT_GREEN_TEXT +           "[PASSED]          " + NORMAL_TEXT;
+    private static final String ASSUMPTION_FAILED_NOTICE = BRIGHT_CYAN_TEXT + "[FALSE_ASSUMPTION]" + NORMAL_TEXT;
+    private static final String FAILED_NOTICE = BRIGHT_RED_TEXT +             "[FAILED]          " + NORMAL_TEXT;
+    private static final String IGNORED_NOTICE = BRIGHT_CYAN_TEXT +           "[IGNORED]         " + NORMAL_TEXT;
+
+    private static volatile boolean alreadyFailed = false;
+
+    @Override
+    public void testDisabled(ExtensionContext context, Optional<String> reason) {
+        printNotice(IGNORED_NOTICE, context, reason.orElse("Unspecified reason"));
+    }
+
+    @Override
+    public void testSuccessful(ExtensionContext context) {
+        printNotice(PASSED_NOTICE, context);
+    }
+
+    @Override
+    public void testAborted(ExtensionContext context, Throwable cause) {
+        printNotice(ASSUMPTION_FAILED_NOTICE, context, cause.toString());
+    }
+
+    @Override
+    public void testFailed(ExtensionContext context, Throwable cause) {
+        alreadyFailed = true;
+        printNotice(FAILED_NOTICE, context, cause.getMessage(), cause);
+
+    }
+
+    private void printNotice(final String notice, ExtensionContext context) {
+        printNotice(notice, context, "", null);
+    }
+
+    private void printNotice(final String notice, ExtensionContext context, String description) {
+        printNotice(notice, context, description, null);
+    }
+
+    private void printNotice(final String notice, ExtensionContext context, String description, Throwable cause) {
+        String methodName = context.getRequiredTestClass().getName();
+        if (context.getTestMethod().isPresent()) {
+            methodName += "." + context.getTestMethod().get().getName();
+        }
+        StringWriter causeText = new StringWriter();
+        if (cause != null) {
+            try (PrintWriter printWriter = new PrintWriter(causeText)) {
+                printWriter.append(" @ ").append(getFailureLocation(cause).toString());
+                // Don't print out traces for Assert.* failures which throw subclasses of AssertionError.
+                // Just for thrown exceptions
+                if (AssertionError.class.equals(cause.getClass()) ||
+                        !(cause instanceof AssertionError)) {
+                    causeText.append('\n');
+                    cause.printStackTrace(printWriter);
+                }
+            }
+        }
+
+        System.out.format("%s%s %s: %s%s%n",
+                alreadyFailed ? ALREADY_FAILED_NOTICE : NOT_YET_FAILED_NOTICE,
+                notice,
+                methodName,
+                context.getDisplayName(),
+                description,
+                causeText);
+    }
+
+    public static StackTraceElement getFailureLocation(Throwable t) {
+        final StackTraceElement[] stackTrace = t.getStackTrace();
+        for (StackTraceElement e : stackTrace) {
+            if (e.getClassName().startsWith("com.amazon.corretto.crypto.provider.")) {
+                return e;
+            }
+        }
+        if (stackTrace.length > 0) {
+            return stackTrace[0];
+        } else {
+            return null;
+        }
+    }
+}

--- a/tst/com/amazon/corretto/crypto/provider/test/TestUtil.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/TestUtil.java
@@ -5,9 +5,9 @@ package com.amazon.corretto.crypto.provider.test;
 
 import com.amazon.corretto.crypto.provider.AmazonCorrettoCryptoProvider;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
-import org.junit.Assume;
+import org.junit.jupiter.api.Assumptions;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -25,7 +25,12 @@ import java.util.Arrays;
 
 @SuppressWarnings("unchecked")
 public class TestUtil {
+    public static final String RESOURCE_REFLECTION = "REFLECTIVE_TOOLS";
+    public static final String RESOURCE_PROVIDER = "JCE_PROVIDER";
+    public static final String RESOURCE_GLOBAL = "GLOBAL_TEST_LOCK";
     public static final BouncyCastleProvider BC_PROVIDER = new BouncyCastleProvider();
+    public static final Provider NATIVE_PROVIDER = AmazonCorrettoCryptoProvider.INSTANCE;
+
     /**
      * Thread local instances of SecureRandom with no further guarantees about implementation or security.
      *
@@ -301,8 +306,8 @@ public class TestUtil {
 
     public static void assumeMinimumVersion(String minVersion, Provider provider) {
         String providerVersion = getProviderVersion(provider);
-        Assume.assumeTrue(String.format("Required version %s, Actual version %s", minVersion, providerVersion),
-                versionCompare(minVersion, providerVersion) <= 0);
+        Assumptions.assumeTrue(versionCompare(minVersion, providerVersion) <= 0,
+                String.format("Required version %s, Actual version %s", minVersion, providerVersion));
     }
 
     public synchronized static Provider[] saveProviders() {

--- a/tst/com/amazon/corretto/crypto/provider/test/TestUtil.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/TestUtil.java
@@ -27,6 +27,11 @@ import java.util.Arrays;
 public class TestUtil {
     public static final String RESOURCE_REFLECTION = "REFLECTIVE_TOOLS";
     public static final String RESOURCE_PROVIDER = "JCE_PROVIDER";
+    /**
+     * Pseudo-resource used by ACCP tests to enforce that certain tests run by themselves.
+     * All tests should takea "READ" lock on this resource.
+     * Tests which require exclusive control should take a "READ_WRITE" lock.
+     */
     public static final String RESOURCE_GLOBAL = "GLOBAL_TEST_LOCK";
     public static final BouncyCastleProvider BC_PROVIDER = new BouncyCastleProvider();
     public static final Provider NATIVE_PROVIDER = AmazonCorrettoCryptoProvider.INSTANCE;

--- a/tst/com/amazon/corretto/crypto/provider/test/UtilsTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/UtilsTest.java
@@ -4,19 +4,26 @@
 package com.amazon.corretto.crypto.provider.test;
 
 import static com.amazon.corretto.crypto.provider.test.TestUtil.sneakyInvoke;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.ByteBuffer;
 
 import org.junit.AssumptionViolatedException;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import com.amazon.corretto.crypto.provider.AmazonCorrettoCryptoProvider;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 
-
+@ExtendWith(TestResultLogger.class)
+@Execution(ExecutionMode.CONCURRENT)
+@ResourceLock(value = TestUtil.RESOURCE_GLOBAL, mode = ResourceAccessMode.READ)
 public class UtilsTest {
     private static final Class<?> UTILS_CLASS;
 
@@ -60,8 +67,8 @@ public class UtilsTest {
         return (Boolean) sneakyInvoke(UTILS_CLASS, "arraysOverlap", a1, o1, a2, o2, length);
     }
 
-    @Before
-    public void setUp() throws Exception {
+    @BeforeAll
+    public static void setUp() throws Exception {
         // Touch AmazonCorrettoCryptoProvider to get the JNI library loaded
         assertNotNull(AmazonCorrettoCryptoProvider.INSTANCE);
     }


### PR DESCRIPTION
Complete initial JUnit5 migration.
This includes fixing the regressions in #111 

* Parallelization of some tests (where it is possible)
* Restoring original output style. (though details are different).
  This includes both the easy to use prefixes and the already failed `!`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
