### PR TITLE
Improve OpenSSL source acquisition

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,7 +68,6 @@ defaultTasks 'release'
 task getOpensslSrc(type: Copy) {
     def tarPath = project.configurations.openssl.find {it.name.startsWith("openssl-") }
     def tarFile = file(tarPath)
-    println tarFile
 
     doFirst {
         exec {
@@ -88,9 +87,8 @@ task getOpensslSrc(type: Copy) {
         ant.patch(patchfile: "${projectDir}/arm.patch",
             dir: opensslSrcPath,
             strip: 1)
+    }
 }
-}
-
 
 task buildOpenSsl {
     outputs.dir("${buildDir}/openssl/bin/")

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,11 @@ plugins {
 group = 'software.amazon.cryptools'
 version = '1.5.0'
 
+def openssl_version = '1.1.1g'
+def opensslSrcPath = "${buildDir}/openssl/openssl-${openssl_version}"
+
 configurations {
+    openssl
     jacocoAgent
     testDep.extendsFrom(jacocoAgent)
     stagingJar
@@ -17,7 +21,27 @@ configurations {
 }
 
 repositories {
-    mavenCentral()
+    mavenCentral {
+        content { excludeGroup("openssl-src") }
+    }
+    // Fake Ivy Repository for current OpenSSL sources
+    ivy {
+        url 'https://www.openssl.org/source/'
+            patternLayout {
+            artifact '/[module]-[revision].[ext]'
+        }
+            metadataSources { artifact() }
+            content { includeGroup("openssl-src") }
+    }
+    // Fake Ivy Repository for old OpenSSL sources
+    ivy {
+        url 'https://www.openssl.org/source/old/1.1.1/'
+            patternLayout {
+            artifact '/[module]-[revision].[ext]'
+        }
+        metadataSources { artifact() }
+        content { includeGroup("openssl-src") }
+    }
 }
 
 dependencies {
@@ -35,53 +59,63 @@ dependencies {
     testDep 'org.hamcrest:hamcrest:2.1'
     testDep 'org.jacoco:org.jacoco.core:0.8.3'
     testDep 'org.jacoco:org.jacoco.report:0.8.3'
+
+    openssl "openssl-src:openssl:${openssl_version}@tar.gz"
 }
 
 defaultTasks 'release'
 
-task getOpensslSrc {
-    inputs.file("${projectDir}/openssl.sha256")
-    outputs.dir("${buildDir}/openssl/src")
-    doLast {
-        mkdir "${buildDir}/openssl/src"
-        mkdir "${buildDir}/openssl/bin"
+task getOpensslSrc(type: Copy) {
+    def tarPath = project.configurations.openssl.find {it.name.startsWith("openssl-") }
+    def tarFile = file(tarPath)
+    println tarFile
+
+    doFirst {
         exec {
-            workingDir "${buildDir}/openssl"
-            commandLine 'wget', 'https://www.openssl.org/source/openssl-1.1.1g.tar.gz'
-        }
-        exec {
-            workingDir "${buildDir}/openssl"
+            workingDir tarFile.parent
             commandLine 'sha256sum', '--check', "${projectDir}/openssl.sha256"
         }
-        exec {
-            workingDir "${buildDir}/openssl/src"
-            commandLine 'tar', '-xzv', '-C', "${buildDir}/openssl/src", '--strip-components=1', '-f', "${buildDir}/openssl/openssl-1.1.1g.tar.gz"
-        }
-    }
-}
 
-task buildOpenSsl {
-    outputs.file("${buildDir}/openssl/bin/lib/libcrypto.a")
-    dependsOn getOpensslSrc
+        mkdir "${buildDir}/openssl/bin"
+    }
+
+    def outputDir = file("${buildDir}/openssl/")
+    from tarTree(tarFile)
+    into outputDir
+
     doLast {
         // Remove this once the patch is incorporated into an official OpenSSL release
         ant.patch(patchfile: "${projectDir}/arm.patch",
-            dir: "${buildDir}/openssl/src",
+            dir: opensslSrcPath,
             strip: 1)
+}
+}
+
+
+task buildOpenSsl {
+    outputs.dir("${buildDir}/openssl/bin/")
+    dependsOn getOpensslSrc
+
+    doLast {
         exec {
-            workingDir "${buildDir}/openssl/src"
-            commandLine './config', '-fPIC', '-ffunction-sections', '-fdata-sections', "--prefix=${buildDir}/openssl/bin", 'no-autoload-config', 'no-capieng', 'no-cms', 'no-comp', 'no-ct', 'no-dgram', 'no-devcryptoeng', 'no-gost', 'no-hw-padlock', 'no-nextprotoneg', 'no-ocsp', 'no-psk', 'no-rfc3779', 'no-shared', 'no-sock', 'no-srp', 'no-srtp', 'threads', 'no-ts',  "no-bf", "no-cast", "no-md2", "no-rc2", "no-rc4", "no-rc5", "no-srp", 'no-comp', 'no-hw', 'no-mdc2'
+            workingDir opensslSrcPath
+            executable './config'
+            args '-fPIC', '-ffunction-sections', '-fdata-sections', "--prefix=${buildDir}/openssl/bin"
+            args 'no-autoload-config', 'no-capieng', 'no-cms', 'no-comp', 'no-ct', 'no-dgram', 'no-devcryptoeng'
+            args 'no-gost', 'no-hw-padlock', 'no-nextprotoneg', 'no-ocsp', 'no-psk', 'no-rfc3779', 'no-shared'
+            args 'no-sock', 'no-srp', 'no-srtp', 'threads', 'no-ts',  "no-bf", "no-cast", "no-md2", "no-rc2"
+            args "no-rc4", "no-rc5", "no-srp", 'no-comp', 'no-hw', 'no-mdc2'
         }
         exec {
-            workingDir "${buildDir}/openssl/src"
+            workingDir opensslSrcPath
             commandLine 'make', 'depend'
         }
         exec {
-            workingDir "${buildDir}/openssl/src"
+            workingDir opensslSrcPath
             commandLine 'make', '-j', Runtime.runtime.availableProcessors()
         }
         exec {
-            workingDir "${buildDir}/openssl/src"
+            workingDir opensslSrcPath
             commandLine 'make', 'install_sw'
         }
     }
@@ -89,6 +123,16 @@ task buildOpenSsl {
 
 task executeCmake(type: Exec) {
     outputs.dir("${buildDir}/cmake")
+    inputs.dir("${buildDir}/openssl/bin/")
+    inputs.dir("${projectDir}/src")
+    inputs.dir("${projectDir}/tst")
+    inputs.dir("${projectDir}/csrc")
+    inputs.dir("${projectDir}/CMake")
+    inputs.dir("${projectDir}/etc")
+    inputs.dir("${projectDir}/extra-jar-files")
+    inputs.dir("${projectDir}/test-data")
+    inputs.dir("${projectDir}/template-src")
+
     dependsOn buildOpenSsl
 
     workingDir "${buildDir}/cmake"
@@ -126,6 +170,8 @@ task executeCmake(type: Exec) {
 
 task build_objects(type: Exec) {
     dependsOn executeCmake
+    outputs.file("${buildDir}/cmake/AmazonCorrettoCryptoProvider.jar")
+
     workingDir "${buildDir}/cmake"
 
     commandLine 'make', '-j', Runtime.runtime.availableProcessors(), 'accp-jar'


### PR DESCRIPTION
This improves OpenSSL source acquisition by:
*  Modeling it as an actual dependency. (Which improves caching)
* Allowing fallback to the "old" sources (in case OpenSSL starts removing older tarballs from the primary location).

I have manually tested to ensure both the primary and fallback locations work.

I have also verified that gradle is now more intelligent about reusing build artifacts.

This fixes #107 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
