### PR TITLE
Implement Java agent as an alternative installation method

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,6 +107,7 @@ set(ACCP_SRC
         src/com/amazon/corretto/crypto/provider/AccessibleByteArrayOutputStream.java
         src/com/amazon/corretto/crypto/provider/AesCtrDrbg.java
         src/com/amazon/corretto/crypto/provider/AesGcmSpi.java
+        src/com/amazon/corretto/crypto/provider/Agent.java
         src/com/amazon/corretto/crypto/provider/EcGen.java
         src/com/amazon/corretto/crypto/provider/EvpKeyAgreement.java
         src/com/amazon/corretto/crypto/provider/EvpKeyType.java
@@ -190,6 +191,7 @@ else()
         COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_PROPERTY:code-only-jar,JAR_FILE> ${ACCP_JAR_TMP}
         COMMAND ${CMAKE_COMMAND} -E remove_directory ${ACCP_JAR_TMP}/com/amazon/corretto/crypto/provider/test
         COMMAND ${Java_JAR_EXECUTABLE} uf ${ACCP_JAR_TMP} -C ${CMAKE_CURRENT_SOURCE_DIR}/extra-jar-files .
+        COMMAND ${Java_JAR_EXECUTABLE} ufm ${ACCP_JAR_TMP} ${CMAKE_CURRENT_SOURCE_DIR}/src/MANIFEST.MF
         COMMAND ${Java_JAR_EXECUTABLE} uf ${ACCP_JAR_TMP} -C $<TARGET_PROPERTY:module-jar,CLASSDIR> module-info.class
         COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/tmplib/com/amazon/corretto/crypto/provider/
         COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:amazonCorrettoCryptoProvider> ${CMAKE_CURRENT_BINARY_DIR}/tmplib/com/amazon/corretto/crypto/provider/

--- a/README.md
+++ b/README.md
@@ -174,6 +174,11 @@ Add the following Java property to your programs command line: `-Djava.security.
 ### Modify the JVM settings
 Modify the `java.security` file provided by your JVM so that the highest priority provider is the Amazon Corretto Crypto Provider. Look at [amazon-corretto-crypto-provider.security](https://github.com/corretto/amazon-corretto-crypto-provider/blob/master/etc/amazon-corretto-crypto-provider.security) for an example of what this change will look like.
 
+### Agent
+Add the `-javaagent:AmazonCorrettoCryptoProvider.jar` argument to your Java command line, modifying the path if necessary.
+The agent runs before your application's `main` method, configuring ACCP as the crypto provider and then runs the verification steps below.
+Optionally, add the `assert` option to agent options e.g. `-javaagent:AmazonCorrettoCryptoProvider.jar=assert` to also run the assertion step.
+
 ### Verification (Optional)
 If you want to check to verify that ACCP is properly working on your system, you can do any of the following:
 1. Verify that the highest priority provider actually is ACCP:

--- a/src/MANIFEST.MF
+++ b/src/MANIFEST.MF
@@ -1,0 +1,1 @@
+Premain-Class: com.amazon.corretto.crypto.provider.Agent

--- a/src/com/amazon/corretto/crypto/provider/Agent.java
+++ b/src/com/amazon/corretto/crypto/provider/Agent.java
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package com.amazon.corretto.crypto.provider;
+
+import static com.amazon.corretto.crypto.provider.AmazonCorrettoCryptoProvider.install;
+import static com.amazon.corretto.crypto.provider.AmazonCorrettoCryptoProvider.INSTANCE;
+import static com.amazon.corretto.crypto.provider.AmazonCorrettoCryptoProvider.PROVIDER_NAME;
+import static com.amazon.corretto.crypto.provider.Loader.PROVIDER_VERSION_STR;
+
+import javax.crypto.Cipher;
+import javax.crypto.NoSuchPaddingException;
+import java.security.NoSuchAlgorithmException;
+import java.security.Provider;
+
+public final class Agent {
+    private final static String OPTION_ASSERT = "assert";
+
+    public static void premain(final String options) {
+        install();
+        verify();
+        if (OPTION_ASSERT.equals(options)) INSTANCE.assertHealthy();
+    }
+
+    private static void verify() {
+        Provider provider = null;
+        try {
+            provider = Cipher.getInstance("AES/GCM/NoPadding").getProvider();
+        }
+        catch (NoSuchAlgorithmException e) { }
+        catch (NoSuchPaddingException e) { }
+
+        if (provider != null && provider.getName().equals(PROVIDER_NAME)) {
+            System.err.println(PROVIDER_NAME + " version " + PROVIDER_VERSION_STR);
+        }
+
+        if (INSTANCE.getLoadingError() == null) {
+            final SelfTestStatus selfTestStatus = INSTANCE.runSelfTests();
+            System.err.println(PROVIDER_NAME + " self-check " + selfTestStatus);
+        }
+    }
+
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adds support for installing ACCP using the Java agent interface, with verification and optional assertion check.
This allows the safe installation of ACCP using the `java -javaagent:AmazonCorrettoCryptoProvider.jar`  argument.
Introducing ACCP thus can involve only ops and can use existing jars, without the need for code changes or rebuilds.

 - Introduces the `Agent` class with the `premain` method invoked by the JVM. 
 - Adds the `Premain-Class` attribute to JAR manifest to configure `Agent` as the agent class.
 - Document runtime option in README.md

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
