### PR TITLE
Throw IllegalBlockSizeException for overlarge RSA input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,9 @@ For other sizes, there are no documented guarantees of the SunEC behavior.
 
   You may need to do a clean build when changing tests.
 
+### Patches
+* Throw `IllegalBlockSizeException` when attempting RSA encryption/decryption on data larger than the keysize. [PR #122](https://github.com/corretto/amazon-corretto-crypto-provider/pull/122)
+
 ### Maintenance
 * Upgrade tests to JUnit5. [PR #111](https://github.com/corretto/amazon-corretto-crypto-provider/pull/111)
 * Upgrade BouncyCastle test dependency 1.65. [PR #110](https://github.com/corretto/amazon-corretto-crypto-provider/pull/110)

--- a/src/com/amazon/corretto/crypto/provider/RsaCipher.java
+++ b/src/com/amazon/corretto/crypto/provider/RsaCipher.java
@@ -183,7 +183,7 @@ class RsaCipher extends CipherSpi {
             }
             if (mode_ == Cipher.ENCRYPT_MODE || mode_ == Cipher.WRAP_MODE) {
                 if (inputLen > keySizeBytes_ - padding_.paddingLength) {
-                    throw new BadPaddingException("Data must not be longer than "
+                    throw new IllegalBlockSizeException("Data must not be longer than "
                             + (keySizeBytes_ - padding_.paddingLength) + " bytes");
                 }
                 // We're allowed to pad NO_PADDING with zero bytes on the left.
@@ -199,7 +199,7 @@ class RsaCipher extends CipherSpi {
                 }
             } else {
                 if (inputLen > keySizeBytes_) {
-                    throw new BadPaddingException("Input length is too long.");
+                    throw new IllegalBlockSizeException("Data must not be longer than " + keySizeBytes_ + " bytes");
                 }
             }
             

--- a/tst/com/amazon/corretto/crypto/provider/test/RsaCipherTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/RsaCipherTest.java
@@ -144,8 +144,8 @@ public class RsaCipherTest {
         byte[] plaintext = getPlaintext(1024 / 8 + 1);
         try {
             nativeEncrypt.doFinal(plaintext);
-            fail("Expected bad padding exception");
-        } catch (final BadPaddingException ex) {
+            fail("Expected IllegalBlockSizeException");
+        } catch (final IllegalBlockSizeException ex) {
             // expected
         }
 
@@ -163,8 +163,8 @@ public class RsaCipherTest {
         plaintext = getPlaintext(2048 / 8 + 1);
         try {
             nativeEncrypt.doFinal(plaintext);
-            fail("Expected bad padding exception");
-        } catch (final BadPaddingException ex) {
+            fail("Expected IllegalBlockSizeException");
+        } catch (final IllegalBlockSizeException ex) {
             // expected
         }
 
@@ -182,8 +182,8 @@ public class RsaCipherTest {
         plaintext = getPlaintext(4096 / 8 + 1);
         try {
             nativeEncrypt.doFinal(plaintext);
-            fail("Expected bad padding exception");
-        } catch (final BadPaddingException ex) {
+            fail("Expected IllegalBlockSizeException");
+        } catch (final IllegalBlockSizeException ex) {
             // expected
         }
 
@@ -353,8 +353,8 @@ public class RsaCipherTest {
         byte[] plaintext = getPlaintext(1024 / 8 - 10);
         try {
             nativeC.doFinal(plaintext);
-            fail("Expected bad padding exception");
-        } catch (final BadPaddingException ex) {
+            fail("Expected IllegalBlockSizeException");
+        } catch (final IllegalBlockSizeException ex) {
             // expected
         }
 
@@ -363,8 +363,8 @@ public class RsaCipherTest {
         plaintext = getPlaintext(2048 / 8 - 10);
         try {
             nativeC.doFinal(plaintext);
-            fail("Expected bad padding exception");
-        } catch (final BadPaddingException ex) {
+            fail("Expected IllegalBlockSizeException");
+        } catch (final IllegalBlockSizeException ex) {
             // expected
         }
 
@@ -373,8 +373,8 @@ public class RsaCipherTest {
         plaintext = getPlaintext(4096 / 8 - 10);
         try {
             nativeC.doFinal(plaintext);
-            fail("Expected bad padding exception");
-        } catch (final BadPaddingException ex) {
+            fail("Expected IllegalBlockSizeException");
+        } catch (final IllegalBlockSizeException ex) {
             // expected
         }
     }
@@ -417,8 +417,8 @@ public class RsaCipherTest {
         byte[] plaintext = getPlaintext(1024 / 8 - 41);
         try {
             nativeC.doFinal(plaintext);
-            fail("Expected bad padding exception");
-        } catch (final BadPaddingException ex) {
+            fail("Expected IllegalBlockSizeException");
+        } catch (final IllegalBlockSizeException ex) {
             // expected
         }
 
@@ -427,8 +427,8 @@ public class RsaCipherTest {
         plaintext = getPlaintext(2048 / 8 - 41);
         try {
             nativeC.doFinal(plaintext);
-            fail("Expected bad padding exception");
-        } catch (final BadPaddingException ex) {
+            fail("Expected IllegalBlockSizeException");
+        } catch (final IllegalBlockSizeException ex) {
             // expected
         }
 
@@ -437,8 +437,8 @@ public class RsaCipherTest {
         plaintext = getPlaintext(4096 / 8 - 41);
         try {
             nativeC.doFinal(plaintext);
-            fail("Expected bad padding exception");
-        } catch (final BadPaddingException ex) {
+            fail("Expected IllegalBlockSizeException");
+        } catch (final IllegalBlockSizeException ex) {
             // expected
         }
     }
@@ -738,35 +738,12 @@ public class RsaCipherTest {
         assertThrows(BadPaddingException.class, () -> dec.doFinal(ciphertext));
     }
 
+    // Unlike padded modes which have an upper-plaintext size defined in bytes,
+    // NoPadding has an upper-plaintext size defined numerically as the value of
+    // the modulus. So, we have a special test case for that.
     @Test
     public void slightlyOverlargePlaintextNoPadding() throws Exception {
         final Cipher enc = Cipher.getInstance(NO_PADDING, NATIVE_PROVIDER);
-        enc.init(Cipher.ENCRYPT_MODE, PAIR_2048.getPublic());
-        byte[] plaintext = ((RSAPublicKey) PAIR_2048.getPublic()).getModulus().toByteArray();
-        // Strip leading zero sign bit/byte if present
-        if (plaintext[0] == 0) {
-            plaintext = Arrays.copyOfRange(plaintext, 1, plaintext.length);
-        }
-        final byte[] tmp = plaintext;
-        assertThrows(BadPaddingException.class, () -> enc.doFinal(tmp));
-    }
-
-    @Test
-    public void slightlyOverlargePlaintextPkcs1() throws Exception {
-        final Cipher enc = Cipher.getInstance(PKCS1_PADDING, NATIVE_PROVIDER);
-        enc.init(Cipher.ENCRYPT_MODE, PAIR_2048.getPublic());
-        byte[] plaintext = ((RSAPublicKey) PAIR_2048.getPublic()).getModulus().toByteArray();
-        // Strip leading zero sign bit/byte if present
-        if (plaintext[0] == 0) {
-            plaintext = Arrays.copyOfRange(plaintext, 1, plaintext.length);
-        }
-        final byte[] tmp = plaintext;
-        assertThrows(BadPaddingException.class, () -> enc.doFinal(tmp));
-    }
-
-    @Test
-    public void slightlyOverlargePlaintextOaepSha1() throws Exception {
-        final Cipher enc = Cipher.getInstance(OAEP_PADDING, NATIVE_PROVIDER);
         enc.init(Cipher.ENCRYPT_MODE, PAIR_2048.getPublic());
         byte[] plaintext = ((RSAPublicKey) PAIR_2048.getPublic()).getModulus().toByteArray();
         // Strip leading zero sign bit/byte if present


### PR DESCRIPTION
*Description of changes:*
Throw `IllegalBlockSizeException` for overlarge RSA input. This is for better compatibility with the default Java implementation of RSA.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
