### PR TITLE
Do not modify output when Cipher.doFinal fails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 /.project
 /.settings/
 /.vscode/
+/.idea/
 *~
+\#*#
 *.ipr
 *.iws
+*.iml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,9 @@ For other sizes, there are no documented guarantees of the SunEC behavior.
 
   You may need to do a clean build when changing tests.
 
+### Patches
+* Ensure unauthenticated plaintext is not released through either [Cipher.doFinal(byte[], int, int, byte[], int)](https://docs.oracle.com/javase/9/docs/api/javax/crypto/Cipher.html#doFinal-byte:A-int-int-byte:A-int-) or [Cipher.doFinal(ByteBuffer, ByteBuffer)](https://docs.oracle.com/javase/9/docs/api/javax/crypto/Cipher.html#doFinal-java.nio.ByteBuffer-java.nio.ByteBuffer-). [PR #123](https://github.com/corretto/amazon-corretto-crypto-provider/pull/123)
+
 ### Maintenance
 * Upgrade tests to JUnit5. [PR #111](https://github.com/corretto/amazon-corretto-crypto-provider/pull/111)
 * Upgrade BouncyCastle test dependency 1.65. [PR #110](https://github.com/corretto/amazon-corretto-crypto-provider/pull/110)

--- a/tst/com/amazon/corretto/crypto/provider/test/RsaCipherTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/RsaCipherTest.java
@@ -21,6 +21,7 @@ import javax.crypto.ShortBufferException;
 import javax.crypto.spec.SecretKeySpec;
 
 import java.math.BigInteger;
+import java.nio.ByteBuffer;
 import java.security.AlgorithmParameters;
 import java.security.GeneralSecurityException;
 import java.security.InvalidKeyException;
@@ -933,6 +934,21 @@ public class RsaCipherTest {
         final byte[] ciphertext = encrypt.doFinal(plaintext);
         final byte[] decrypted = decrypt.doFinal(ciphertext);
         assertArrayEquals(plaintext, decrypted);
+
+        // Verify no release of data even on bad padding
+        if (!NO_PADDING.equals(padding)) {
+            final byte[] result = new byte[ciphertext.length]; // Full size
+            ciphertext[3] ^= 0x13; // Just twiddle some bits
+            assertThrows(BadPaddingException.class, () -> decrypt.doFinal(ciphertext, 0, ciphertext.length, result, 0));
+            assertArrayEquals(new byte[ciphertext.length], result);
+
+            Arrays.fill(result, (byte) 0);
+            ByteBuffer ciphertextBuff = ByteBuffer.wrap(ciphertext);
+            ByteBuffer resultBuff = ByteBuffer.wrap(result);
+            assertThrows(BadPaddingException.class, () -> decrypt.doFinal(ciphertextBuff, resultBuff));
+            assertArrayEquals(new byte[ciphertext.length], result);
+        }
+
     }
 
     private void wrapUnwrap(final Cipher wrap, final Cipher unwrap) throws InvalidKeyException,


### PR DESCRIPTION
*Description of changes:*
This change modifies `Cipher.doFinal` such that when an exception is thrown the out-parameter remain unchanged.

The diff appears to be choking on some indentation changes and thinking this is a bigger change than it appears. I strongly recommend that viewers select the "ignore white-space" option when reviewing this PR as it makes the change much easier to see and read.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
