### PR TITLE
Restrict EC generation configured by size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ This change only impacts libraries that generate EC keys using the
 method.
 
 ### Improvements
-* Stricter guarantees around which curves are used for EC key generation. [PR #127](https://github.com/corretto/amazon-corretto-crypto-provider/pull/127)
+* Stricter guarantees about which curves are used for EC key generation. [PR #127](https://github.com/corretto/amazon-corretto-crypto-provider/pull/127)
 
 ## 1.5.0
 ### Breaking Change Warning

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 1.6.0 (Unreleased)
+### Breaking Change
+In accordance with our [versioning policy](https://github.com/corretto/amazon-corretto-crypto-provider/blob/master/VERSIONING.rst),
+this release contains a low-risk breaking change. For details please see the [1.5.0](#150) section of this document.
+This change only impacts libraries that generate EC keys using the
+[KeyPairGenerator.initialize(int keysize)](https://docs.oracle.com/javase/8/docs/api/java/security/KeyPairGenerator.html#initialize-int-)
+method.
+
+### Improvements
+* Stricter guarantees around which curves are used for EC key generation. [PR #127](https://github.com/corretto/amazon-corretto-crypto-provider/pull/127)
+
 ## 1.5.0
 ### Breaking Change Warning
 In accordance with our [versioning policy](https://github.com/corretto/amazon-corretto-crypto-provider/blob/master/VERSIONING.rst),

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = 'software.amazon.cryptools'
-version = '1.5.0'
+version = '1.6.0'
 
 def openssl_version = '1.1.1g'
 def opensslSrcPath = "${buildDir}/openssl/openssl-${openssl_version}"

--- a/src/com/amazon/corretto/crypto/provider/EcGen.java
+++ b/src/com/amazon/corretto/crypto/provider/EcGen.java
@@ -166,30 +166,28 @@ class EcGen extends KeyPairGeneratorSpi {
     public void initialize(final int keysize, final SecureRandom random)
             throws InvalidParameterException {
         try {
-            final String curveName = "secp" + keysize + "r1";
             // Explicitly list default curves
             // Mapping from OpenJDK
-            // TODO: Uncomment following code at version 1.6.0
-//            final String curveName;
-//            switch (keysize) {
-//                case 192:
-//                    curveName = "secp192r1"; // NIST P-192
-//                    break;
-//                case 224:
-//                    curveName = "secp224r1"; // NIST P-224
-//                    break;
-//                case 256:
-//                    curveName = "secp256r1"; // NIST P-256
-//                    break;
-//                case 384:
-//                    curveName = "secp384r1"; // NIST P-384
-//                    break;
-//                case 521:
-//                    curveName = "secp521r1"; // NIST P-521
-//                    break;
-//                default:
-//                    throw new InvalidParameterException("No default NIST prime curve for keysize " + keysize);
-//            }
+           final String curveName;
+           switch (keysize) {
+               case 192:
+                   curveName = "secp192r1"; // NIST P-192
+                   break;
+               case 224:
+                   curveName = "secp224r1"; // NIST P-224
+                   break;
+               case 256:
+                   curveName = "secp256r1"; // NIST P-256
+                   break;
+               case 384:
+                   curveName = "secp384r1"; // NIST P-384
+                   break;
+               case 521:
+                   curveName = "secp521r1"; // NIST P-521
+                   break;
+               default:
+                   throw new InvalidParameterException("No default NIST prime curve for keysize " + keysize);
+           }
             initialize(new ECGenParameterSpec(curveName), random);
         } catch (final InvalidAlgorithmParameterException ex) {
             throw new InvalidParameterException(ex.getMessage());


### PR DESCRIPTION
*Description of changes:*
As discussed in #115, as of version `1.6.0` we restrict which sizes we'll accept when generation EC keys.

The test for this change was also introduced in the original PR and can be seen in [EcGenTest.java](https://github.com/corretto/amazon-corretto-crypto-provider/blob/68737e0eeedda3ed999cf356beb1015107252d49/tst/com/amazon/corretto/crypto/provider/test/EcGenTest.java#L196-L200). Prior to the version bump this test disabled itself. The test is now enabled and enforcing the new behavior.

Old result of running `./gradlew single_test -DSINGLE_TEST=com.amazon.corretto.crypto.provider.test.EcGenTest`
```
 [FALSE_ASSUMPTION] com.amazon.corretto.crypto.provider.test.EcGenTest.explicitSizesOnly: explicitSizesOnly()org.opentest4j.TestAbortedException: Assumption failed: Required version 1.6.0, Actual version 1.5.0
```

New result of running `./gradlew single_test -DSINGLE_TEST=com.amazon.corretto.crypto.provider.test.EcGenTest`

```
 [PASSED]           com.amazon.corretto.crypto.provider.test.EcGenTest.explicitSizesOnly: explicitSizesOnly()
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
