### PR TITLE
Add version gating to some tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 *.ipr
 *.iws
 *.iml
+*.orig

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ method.
 ### Improvements
 * Stricter guarantees about which curves are used for EC key generation. [PR #127](https://github.com/corretto/amazon-corretto-crypto-provider/pull/127)
 
+### Patches
+* Add version gating to some tests introduced in 1.5.0 [PR #128](https://github.com/corretto/amazon-corretto-crypto-provider/pull/128)
+
 ## 1.5.0
 ### Breaking Change Warning
 In accordance with our [versioning policy](https://github.com/corretto/amazon-corretto-crypto-provider/blob/master/VERSIONING.rst),

--- a/tst/com/amazon/corretto/crypto/provider/test/AesTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/AesTest.java
@@ -640,6 +640,8 @@ public class AesTest {
 
     @Test
     public void testBadAEADTagException_noRelease() throws Throwable {
+        assumeMinimumVersion("1.5.0", AmazonCorrettoCryptoProvider.INSTANCE);
+
         final SecureRandom rnd = TestUtil.MISC_SECURE_RANDOM.get();
 
         Cipher c = Cipher.getInstance(ALGO_NAME, PROVIDER_SUN);
@@ -664,6 +666,8 @@ public class AesTest {
 
     @Test
     public void testBadAEADTagException_noReleaseByteBuffer() throws Throwable {
+        assumeMinimumVersion("1.5.0", AmazonCorrettoCryptoProvider.INSTANCE);
+
         final SecureRandom rnd = TestUtil.MISC_SECURE_RANDOM.get();
 
         Cipher c = Cipher.getInstance(ALGO_NAME, PROVIDER_SUN);

--- a/tst/com/amazon/corretto/crypto/provider/test/HmacTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/HmacTest.java
@@ -378,8 +378,10 @@ public class HmacTest {
             assertThrows(InvalidAlgorithmParameterException.class, () -> mac.init(validKey, new IvParameterSpec(new byte[0])));
             assertThrows(InvalidKeyException.class, () -> mac.init(pubKey));
             assertThrows(InvalidKeyException.class, () -> mac.init(badFormat));
-            assertThrows(InvalidKeyException.class, () -> mac.init(nullFormat));
             assertThrows(InvalidKeyException.class, () -> mac.init(nullEncoding));
+
+            TestUtil.assumeMinimumVersion("1.5.0", AmazonCorrettoCryptoProvider.INSTANCE);
+            assertThrows(InvalidKeyException.class, () -> mac.init(nullFormat));
         }
     }
 

--- a/tst/com/amazon/corretto/crypto/provider/test/RsaCipherTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/RsaCipherTest.java
@@ -137,6 +137,20 @@ public class RsaCipherTest {
         testJce2Native(NO_PADDING, 1024);
     }
 
+    private void assertProperWrongInputSizeException(GeneralSecurityException ex) throws GeneralSecurityException {
+        // Behavior changed as of version 1.5.0 and sometimes we need tests to run
+        // against older versions.
+        if (TestUtil.versionCompare("1.5.0", NATIVE_PROVIDER) <= 0) {
+            if (!(ex instanceof IllegalBlockSizeException)) {
+                throw ex;
+            }
+        } else {
+            if (!(ex instanceof BadPaddingException)) {
+                throw ex;
+            }
+        }
+    }
+
     @Test
     public void noPaddingSizes() throws GeneralSecurityException {
         final Cipher nativeEncrypt = Cipher.getInstance(NO_PADDING, NATIVE_PROVIDER);
@@ -146,8 +160,8 @@ public class RsaCipherTest {
         try {
             nativeEncrypt.doFinal(plaintext);
             fail("Expected IllegalBlockSizeException");
-        } catch (final IllegalBlockSizeException ex) {
-            // expected
+        } catch (final GeneralSecurityException ex) {
+            assertProperWrongInputSizeException(ex);
         }
 
         plaintext = new byte[1024 / 8];
@@ -165,8 +179,8 @@ public class RsaCipherTest {
         try {
             nativeEncrypt.doFinal(plaintext);
             fail("Expected IllegalBlockSizeException");
-        } catch (final IllegalBlockSizeException ex) {
-            // expected
+        } catch (final GeneralSecurityException ex) {
+            assertProperWrongInputSizeException(ex);
         }
 
         plaintext = new byte[2048 / 8];
@@ -184,8 +198,8 @@ public class RsaCipherTest {
         try {
             nativeEncrypt.doFinal(plaintext);
             fail("Expected IllegalBlockSizeException");
-        } catch (final IllegalBlockSizeException ex) {
-            // expected
+        } catch (final GeneralSecurityException ex) {
+            assertProperWrongInputSizeException(ex);
         }
 
         plaintext = new byte[4096 / 8];
@@ -355,18 +369,17 @@ public class RsaCipherTest {
         try {
             nativeC.doFinal(plaintext);
             fail("Expected IllegalBlockSizeException");
-        } catch (final IllegalBlockSizeException ex) {
-            // expected
+        } catch (final GeneralSecurityException ex) {
+            assertProperWrongInputSizeException(ex);
         }
-
         nativeC.init(Cipher.ENCRYPT_MODE, PAIR_2048.getPublic());
 
         plaintext = getPlaintext(2048 / 8 - 10);
         try {
             nativeC.doFinal(plaintext);
             fail("Expected IllegalBlockSizeException");
-        } catch (final IllegalBlockSizeException ex) {
-            // expected
+        } catch (final GeneralSecurityException ex) {
+            assertProperWrongInputSizeException(ex);
         }
 
         nativeC.init(Cipher.ENCRYPT_MODE, PAIR_4096.getPublic());
@@ -375,8 +388,8 @@ public class RsaCipherTest {
         try {
             nativeC.doFinal(plaintext);
             fail("Expected IllegalBlockSizeException");
-        } catch (final IllegalBlockSizeException ex) {
-            // expected
+        } catch (final GeneralSecurityException ex) {
+            assertProperWrongInputSizeException(ex);
         }
     }
 
@@ -419,8 +432,8 @@ public class RsaCipherTest {
         try {
             nativeC.doFinal(plaintext);
             fail("Expected IllegalBlockSizeException");
-        } catch (final IllegalBlockSizeException ex) {
-            // expected
+        } catch (final GeneralSecurityException ex) {
+            assertProperWrongInputSizeException(ex);
         }
 
         nativeC.init(Cipher.ENCRYPT_MODE, PAIR_2048.getPublic());
@@ -429,8 +442,8 @@ public class RsaCipherTest {
         try {
             nativeC.doFinal(plaintext);
             fail("Expected IllegalBlockSizeException");
-        } catch (final IllegalBlockSizeException ex) {
-            // expected
+        } catch (final GeneralSecurityException ex) {
+            assertProperWrongInputSizeException(ex);
         }
 
         nativeC.init(Cipher.ENCRYPT_MODE, PAIR_4096.getPublic());
@@ -439,8 +452,8 @@ public class RsaCipherTest {
         try {
             nativeC.doFinal(plaintext);
             fail("Expected IllegalBlockSizeException");
-        } catch (final IllegalBlockSizeException ex) {
-            // expected
+        } catch (final GeneralSecurityException ex) {
+            assertProperWrongInputSizeException(ex);
         }
     }
 


### PR DESCRIPTION
*Description of changes:*
Add version gating to some tests. This lets the tests run even on systems with older versions of ACCP.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
