### PR TITLE
Reuse state in MessageDigest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ method.
 ### Improvements
 * Stricter guarantees about which curves are used for EC key generation. [PR #127](https://github.com/corretto/amazon-corretto-crypto-provider/pull/127)
 * Reduce timing signal from trimming zeros of TLSPremasterSecrets from DH KeyAgreement. [PR #129](https://github.com/corretto/amazon-corretto-crypto-provider/pull/129)
+* Reuse state in `MessageDigest` to decrease object allocation rate. [PR #131](https://github.com/corretto/amazon-corretto-crypto-provider/pull/131)
 
 ### Patches
 * Add version gating to some tests introduced in 1.5.0 [PR #128](https://github.com/corretto/amazon-corretto-crypto-provider/pull/128)

--- a/src/com/amazon/corretto/crypto/provider/InputBuffer.java
+++ b/src/com/amazon/corretto/crypto/provider/InputBuffer.java
@@ -165,7 +165,7 @@ public class InputBuffer<T, S> implements Cloneable {
     //@ spec_public
     private /*@ { Consumer.Local<S> } @*/ Consumer<S> stateResetter = (ignored) -> { }; // NOP
     //@ spec_public
-    private StateSupplier<S> stateSupplier = () -> null;
+    private StateSupplier<S> stateSupplier = () -> state;
     //@ spec_public
     private Optional<Function<S, S>> stateCloner = Optional.empty();
     // If absent, delegates to arrayUpdater
@@ -229,10 +229,7 @@ public class InputBuffer<T, S> implements Cloneable {
     public void reset() {
         buff.reset();
         firstData = true;
-        if (state != null) {
-            stateResetter.accept(state);
-        }
-        state = stateSupplier.get();
+        state = null;
         /*@ set bytesReceived = 0;
           @ set bytesProcessed = 0;
           @ set bufferState = ((bufferState == BufferState.Uninitialized)

--- a/template-src/com/amazon/corretto/crypto/provider/TemplateHashSpi.java
+++ b/template-src/com/amazon/corretto/crypto/provider/TemplateHashSpi.java
@@ -28,6 +28,7 @@ public final class TemplateHashSpi extends MessageDigestSpi implements Cloneable
     private static final int HASH_SIZE;
     private static final byte[] INITIAL_CONTEXT;
 
+    private byte[] myContext;
     private byte[] oneByteArray = null;
     private InputBuffer<byte[], byte[]> buffer;
 
@@ -108,11 +109,17 @@ public final class TemplateHashSpi extends MessageDigestSpi implements Cloneable
         }
     }
 
+    private byte[] resetContext() {
+        System.arraycopy(INITIAL_CONTEXT, 0, myContext, 0, INITIAL_CONTEXT.length);
+        return myContext;
+    }
+
     public TemplateHashSpi() {
         Loader.checkNativeLibraryAvailability();
+        myContext = INITIAL_CONTEXT.clone();
 
         this.buffer = new InputBuffer<byte[], byte[]>(1024)
-            .withInitialStateSupplier(INITIAL_CONTEXT::clone)
+            .withInitialStateSupplier(this::resetContext)
             .withUpdater(TemplateHashSpi::synchronizedUpdateContextByteArray)
             .withUpdater(TemplateHashSpi::synchronizedUpdateNativeByteBuffer)
             .withDoFinal((context) -> {
@@ -158,6 +165,7 @@ public final class TemplateHashSpi extends MessageDigestSpi implements Cloneable
         try {
             TemplateHashSpi clonedObject = (TemplateHashSpi)super.clone();
 
+            clonedObject.myContext = myContext.clone();
             clonedObject.buffer = (InputBuffer<byte[], byte[]>) buffer.clone();
 
             return clonedObject;


### PR DESCRIPTION
*Description of changes:*
By reusing the underlying state in our implementations of `MessageDigest` we can reduce our allocation rate from ~304 bytes per hash (minimum) to ~48 bytes per hash.

This also removes some related unused code and simplifies some related logic to avoid initializing state multiple times.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
