### PR TITLE
Better output size estimates. Fixes #135

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ method.
 
 ### Patches
 * Add version gating to some tests introduced in 1.5.0 [PR #128](https://github.com/corretto/amazon-corretto-crypto-provider/pull/128)
+* More accurate output size estimates from `Cipher.getOutputSize()` [PR #138](https://github.com/corretto/amazon-corretto-crypto-provider/pull/138)
 
 ## 1.5.0
 ### Breaking Change Warning

--- a/src/com/amazon/corretto/crypto/provider/AesGcmSpi.java
+++ b/src/com/amazon/corretto/crypto/provider/AesGcmSpi.java
@@ -237,9 +237,7 @@ final class AesGcmSpi extends CipherSpi {
     protected int engineGetOutputSize(int inputLen) {
         switch (opMode) {
             case NATIVE_MODE_ENCRYPT:
-                // Ensure we have room (on doFinal) for either an extra ciphertext block that was buffered in OpenSSL,
-                // or the final tag (whichever is bigger)
-                return inputLen + Math.max(tagLength, engineGetBlockSize() - 1);
+                return getUpdateOutputSize(inputLen) + tagLength;
             case NATIVE_MODE_DECRYPT:
                 return Math.max(0, decryptInputBuf.size() + inputLen - tagLength);
             default:
@@ -253,7 +251,7 @@ final class AesGcmSpi extends CipherSpi {
     private synchronized int getUpdateOutputSize(int inputLen) {
         switch (opMode) {
             case NATIVE_MODE_ENCRYPT:
-                return inputLen + engineGetBlockSize() - 1;
+                return inputLen;
             case NATIVE_MODE_DECRYPT:
                 // We do not return data from engineUpdate when decrypting - all data is returned from engineDoFinal()
                 return 0;
@@ -854,6 +852,9 @@ final class AesGcmSpi extends CipherSpi {
     }
 
     private void checkOutputBuffer(int inputLength, byte[] output, int outputOffset) throws ShortBufferException {
+        if (inputLength < 0 || outputOffset < 0 || outputOffset > output.length) {
+            throw new ArrayIndexOutOfBoundsException();
+        }
         if (output.length - outputOffset < getUpdateOutputSize(inputLength)) {
             throw new ShortBufferException("Expected a buffer of at least " + engineGetOutputSize(inputLength) + " bytes; got " + (output.length - outputOffset));
         }


### PR DESCRIPTION
Fixes #135

This improves the estimates provided by `Cipher.getOutputSize()` such that for AES-GCM they are completely accurate (when used with `doFinal` and not overestimates. (For use with `update` they must remain overestimates because they must take into account the size of the tag output from `doFinal`).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
