### PR TITLE
Move to OpenSSL 1.1.1j

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ method.
 * Stricter guarantees about which curves are used for EC key generation. [PR #127](https://github.com/corretto/amazon-corretto-crypto-provider/pull/127)
 * Reduce timing signal from trimming zeros of TLSPremasterSecrets from DH KeyAgreement. [PR #129](https://github.com/corretto/amazon-corretto-crypto-provider/pull/129)
 * Reuse state in `MessageDigest` to decrease object allocation rate. [PR #131](https://github.com/corretto/amazon-corretto-crypto-provider/pull/131)
-* Now uses [OpenSSL 1.1.1j](https://www.openssl.org/source/openssl-1.1.1j.tar.gz). [PR TODO](https://github.com/corretto/amazon-corretto-crypto-provider/pull/136)
+* Now uses [OpenSSL 1.1.1j](https://www.openssl.org/source/openssl-1.1.1j.tar.gz). [PR #145](https://github.com/corretto/amazon-corretto-crypto-provider/pull/145)
   (ACCP is not impacted by [CVE-2020-1971](https://www.openssl.org/news/secadv/20201208.txt), [CVE-2021-23841](https://www.openssl.org/news/secadv/20210216.txt), or [CVE-2021-23839](https://www.openssl.org/news/secadv/20210216.txt) as ACCP does not use or expose any of the relevant functionality.
   ACCP is not impacted by [CVE-2021-23840](https://www.openssl.org/news/secadv/20210216.txt) as ACCP does not use the relevant functionality under the affected conditions.)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,9 @@ method.
 * Stricter guarantees about which curves are used for EC key generation. [PR #127](https://github.com/corretto/amazon-corretto-crypto-provider/pull/127)
 * Reduce timing signal from trimming zeros of TLSPremasterSecrets from DH KeyAgreement. [PR #129](https://github.com/corretto/amazon-corretto-crypto-provider/pull/129)
 * Reuse state in `MessageDigest` to decrease object allocation rate. [PR #131](https://github.com/corretto/amazon-corretto-crypto-provider/pull/131)
-* Now uses [OpenSSL 1.1.1i](https://www.openssl.org/source/openssl-1.1.1i.tar.gz). [PR #136](https://github.com/corretto/amazon-corretto-crypto-provider/pull/136)
-  (ACCP is not impacted by [CVE-2020-1971](https://www.openssl.org/news/secadv/20201208.txt) as ACCP does not use or expose any of the relevant functionality.)
+* Now uses [OpenSSL 1.1.1j](https://www.openssl.org/source/openssl-1.1.1j.tar.gz). [PR TODO](https://github.com/corretto/amazon-corretto-crypto-provider/pull/136)
+  (ACCP is not impacted by [CVE-2020-1971](https://www.openssl.org/news/secadv/20201208.txt), [CVE-2021-23841](https://www.openssl.org/news/secadv/20210216.txt), or [CVE-2021-23839](https://www.openssl.org/news/secadv/20210216.txt) as ACCP does not use or expose any of the relevant functionality.
+  ACCP is not impacted by [CVE-2021-23840](https://www.openssl.org/news/secadv/20210216.txt) as ACCP does not use the relevant functionality under the affected conditions.)
 
 ### Patches
 * Add version gating to some tests introduced in 1.5.0 [PR #128](https://github.com/corretto/amazon-corretto-crypto-provider/pull/128)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 The Amazon Corretto Crypto Provider (ACCP) is a collection of high-performance cryptographic implementations exposed via the standard [JCA/JCE](https://docs.oracle.com/en/java/javase/11/security/java-cryptography-architecture-jca-reference-guide.html) interfaces.
 This means that it can be used as a drop in replacement for many different Java applications.
 (Differences from the default OpenJDK implementations are [documented here](./DIFFERENCES.md).)
-Currently algorithms are primarily backed by OpenSSL's implementations (1.1.1i as of ACCP 1.6.0) but this may change in the future.
+Currently algorithms are primarily backed by OpenSSL's implementations (1.1.1j as of ACCP 1.6.0) but this may change in the future.
 
 [Security issue notifications](./CONTRIBUTING.md#security-issue-notifications)
 

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
 group = 'software.amazon.cryptools'
 version = '1.6.0'
 
-def openssl_version = '1.1.1i'
+def openssl_version = '1.1.1j'
 def opensslSrcPath = "${buildDir}/openssl/openssl-${openssl_version}"
 
 configurations {

--- a/openssl.sha256
+++ b/openssl.sha256
@@ -1,1 +1,1 @@
-e8be6a35fe41d10603c3cc635e93289ed00bf34b79671a3a4de64fcee00d5242  openssl-1.1.1i.tar.gz
+aaf2fcb575cdf6491b98ab4829abf78a3dec8402b8b81efc8f23c00d443981bf  openssl-1.1.1j.tar.gz


### PR DESCRIPTION
Upgrades ACCP to OpenSSL version 1.1.1j.

Note that ACCP is not impacted by the CVEs listed in the [corresponding advisory](https://www.openssl.org/news/secadv/20210216.txt).

* ACCP does not use `X509_issuer_and_serial_hash` and so is not affected by CVE-2021-23841.
* ACCP does not use `RSA_padding_check_SSLv23` and so is not affected by CVE-2021-23839.
* Where ACCP uses `EVP_CipherUpdate` the input length never exceeds 256KB (far from supported platforms' maximum integer size); where it uses `EVP_EncryptUpdate` the input length is always `16` (far from maximum); and it does not use `EVP_DecryptUpdate` - so ACCP is not affected by CVE-2021-23840.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
