### PR TITLE
Validate that AesGcmSpi#engineInit gets non-null key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ method.
 ### Patches
 * Add version gating to some tests introduced in 1.5.0 [PR #128](https://github.com/corretto/amazon-corretto-crypto-provider/pull/128)
 * More accurate output size estimates from `Cipher.getOutputSize()` [PR #138](https://github.com/corretto/amazon-corretto-crypto-provider/pull/138)
+* Validate that `AesGcmSpi` receives a non-null key on init to prevent unncessarily late NPE [PR #146](https://github.com/corretto/amazon-corretto-crypto-provider/pull/146)
 
 ## 1.5.0
 ### Breaking Change Warning

--- a/src/com/amazon/corretto/crypto/provider/AesGcmSpi.java
+++ b/src/com/amazon/corretto/crypto/provider/AesGcmSpi.java
@@ -294,6 +294,10 @@ final class AesGcmSpi extends CipherSpi {
     protected synchronized void engineInit(
         int jceOpMode, Key key, AlgorithmParameterSpec algorithmParameterSpec, SecureRandom secureRandom
     ) throws InvalidKeyException, InvalidAlgorithmParameterException {
+	if (key == null) {
+	    throw new InvalidKeyException("Key can't be null");
+	}
+
         final GCMParameterSpec spec;
         if (algorithmParameterSpec instanceof GCMParameterSpec) {
             spec = (GCMParameterSpec) algorithmParameterSpec;

--- a/src/com/amazon/corretto/crypto/provider/AesGcmSpi.java
+++ b/src/com/amazon/corretto/crypto/provider/AesGcmSpi.java
@@ -294,9 +294,9 @@ final class AesGcmSpi extends CipherSpi {
     protected synchronized void engineInit(
         int jceOpMode, Key key, AlgorithmParameterSpec algorithmParameterSpec, SecureRandom secureRandom
     ) throws InvalidKeyException, InvalidAlgorithmParameterException {
-	if (key == null) {
-	    throw new InvalidKeyException("Key can't be null");
-	}
+        if (key == null) {
+            throw new InvalidKeyException("Key can't be null");
+        }
 
         final GCMParameterSpec spec;
         if (algorithmParameterSpec instanceof GCMParameterSpec) {

--- a/tst/com/amazon/corretto/crypto/provider/test/AesTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/AesTest.java
@@ -23,9 +23,11 @@ import java.security.AlgorithmParameters;
 import java.security.GeneralSecurityException;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
+import java.security.Key;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.security.Security;
+import java.security.spec.AlgorithmParameterSpec;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -577,6 +579,24 @@ public class AesTest {
         byte[] decrypted = amznC.doFinal(ciphertext);
 
         assertArrayEquals(PLAINTEXT, decrypted);
+    }
+
+    @SuppressWarnings("ConstantConditions")
+    @Test
+    public void test_initNullKey() throws Throwable {
+        jceC.init(Cipher.ENCRYPT_MODE, key);
+
+        Key key = null;
+        AlgorithmParameters params = jceC.getParameters();
+        AlgorithmParameterSpec spec = params.getParameterSpec(GCMParameterSpec.class);
+        SecureRandom random = TestUtil.MISC_SECURE_RANDOM.get();
+
+        assertThrows(InvalidKeyException.class, () -> amznC.init(Cipher.ENCRYPT_MODE, key));
+        assertThrows(InvalidKeyException.class, () -> amznC.init(Cipher.ENCRYPT_MODE, key, params));
+        assertThrows(InvalidKeyException.class, () -> amznC.init(Cipher.ENCRYPT_MODE, key, params, random));
+        assertThrows(InvalidKeyException.class, () -> amznC.init(Cipher.ENCRYPT_MODE, key, random));
+        assertThrows(InvalidKeyException.class, () -> amznC.init(Cipher.ENCRYPT_MODE, key, spec));
+        assertThrows(InvalidKeyException.class, () -> amznC.init(Cipher.ENCRYPT_MODE, key, spec, random));
     }
 
     @Test

--- a/tst/com/amazon/corretto/crypto/provider/test/AesTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/AesTest.java
@@ -584,6 +584,7 @@ public class AesTest {
     @SuppressWarnings("ConstantConditions")
     @Test
     public void test_initNullKey() throws Throwable {
+        assumeMinimumVersion("1.6.0", AmazonCorrettoCryptoProvider.INSTANCE);
         jceC.init(Cipher.ENCRYPT_MODE, key);
 
         Key key = null;

--- a/tst/com/amazon/corretto/crypto/provider/test/AesTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/AesTest.java
@@ -587,7 +587,7 @@ public class AesTest {
         assumeMinimumVersion("1.6.0", AmazonCorrettoCryptoProvider.INSTANCE);
         jceC.init(Cipher.ENCRYPT_MODE, key);
 
-        Key key = null;
+        final Key key = null;
         AlgorithmParameters params = jceC.getParameters();
         AlgorithmParameterSpec spec = params.getParameterSpec(GCMParameterSpec.class);
         SecureRandom random = TestUtil.MISC_SECURE_RANDOM.get();


### PR DESCRIPTION
*Issue #, if available:* #144

*Description of changes:* Ensure that all initialization paths in AesGcmSpi validate that the passed Key is non-null, like RsaCipher does.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
