### PR TITLE
Handle RsaCipher#engineDoFinal with no input bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ method.
 ### Patches
 * Add version gating to some tests introduced in 1.5.0 [PR #128](https://github.com/corretto/amazon-corretto-crypto-provider/pull/128)
 * More accurate output size estimates from `Cipher.getOutputSize()` [PR #138](https://github.com/corretto/amazon-corretto-crypto-provider/pull/138)
+* Gracefully handle calling `Cipher.doFinal()` without any input bytes in `RsaCipher` [PR #147](https://github.com/corretto/amazon-corretto-crypto-provider/pull/147)
 
 ## 1.5.0
 ### Breaking Change Warning

--- a/src/com/amazon/corretto/crypto/provider/RsaCipher.java
+++ b/src/com/amazon/corretto/crypto/provider/RsaCipher.java
@@ -181,7 +181,7 @@ class RsaCipher extends CipherSpi {
             // that don't take an input buffer, and in those cases, inputOffset and inputLen are 0.
             // We set them here anyways to be safe, because the API makes no such guarantee.
             else if (input == null) {
-                input = new byte[0];
+                input = Utils.EMPTY_ARRAY;
                 inputOffset = 0;
                 inputLen = 0;
             }

--- a/src/com/amazon/corretto/crypto/provider/RsaCipher.java
+++ b/src/com/amazon/corretto/crypto/provider/RsaCipher.java
@@ -177,6 +177,14 @@ class RsaCipher extends CipherSpi {
                 inputOffset = 0;
                 inputLen = buffer_.size();
             }
+            // One-shot, no input. Cipher only calls engineDoFinal with null input in doFinal overloads
+            // that don't take an input buffer, and in those cases, inputOffset and inputLen are 0.
+            // We set them here anyways to be safe, because the API makes no such guarantee.
+            else if (input == null) {
+                input = new byte[0];
+                inputOffset = 0;
+                inputLen = 0;
+            }
 
             if (output.length - outputOffset < engineGetOutputSize(inputLen)) {
                 throw new ShortBufferException();

--- a/tst/com/amazon/corretto/crypto/provider/test/RsaCipherTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/RsaCipherTest.java
@@ -867,6 +867,17 @@ public class RsaCipherTest {
         }
     }
 
+    @Test
+    public void noInputDoFinal() throws Exception {
+        assumeMinimumVersion("1.6.0", AmazonCorrettoCryptoProvider.INSTANCE);
+        final Cipher enc = Cipher.getInstance(NO_PADDING, NATIVE_PROVIDER);
+        enc.init(Cipher.ENCRYPT_MODE, PAIR_1024.getPublic());
+        final byte[] result = enc.doFinal();
+        for (final byte b : result) {
+            assertEquals(b, 0);
+        }
+    }
+
     private void testNative2Jce(final String padding, final int keySize) throws GeneralSecurityException {
         final Cipher jceC = Cipher.getInstance(padding);
         final Cipher nativeC = Cipher.getInstance(padding, NATIVE_PROVIDER);


### PR DESCRIPTION
*Issue #, if available:* #143

*Description of changes:* Ensure that RsaCipher correctly returns all 0 bytes when calling `Cipher#doFinal` without any input bytes provided (via `update` or `doFinal`), like SunJCE does.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
