### PR TITLE
Clarify best practices are local to ACCP

### DIFF
--- a/DEVELOPMENT-GUIDE.md
+++ b/DEVELOPMENT-GUIDE.md
@@ -38,7 +38,7 @@ In decreasing order of importance:
     2. Test to prove correctness. (While we must always do this, it is even more critical here.)
     3. Comment to explain exactly what is intended and, when appropriate, why a particular technique was chosen.
     Examples: ([ConstantTime](https://github.com/corretto/amazon-corretto-crypto-provider/blob/develop/src/com/amazon/corretto/crypto/provider/ConstantTime.java) and its [tests](https://github.com/corretto/amazon-corretto-crypto-provider/blob/develop/tst/com/amazon/corretto/crypto/provider/test/ConstantTimeTests.java), [Janitor](https://github.com/corretto/amazon-corretto-crypto-provider/blob/develop/src/com/amazon/corretto/crypto/provider/Janitor.java) and its [tests](https://github.com/corretto/amazon-corretto-crypto-provider/blob/develop/tst/com/amazon/corretto/crypto/provider/test/JanitorTest.java))
-7. New best practices *must* be applied uniformly to the codebase.
+7. New best practices for this project *must* be applied uniformly to the codebase.
     As we extend and improve ACCP, we will create new tools and frameworks to make our code better (cleaner, safer, easier to read, etc.).
     When we do this, we must  go back through the rest of the ACCP codebase to make the same improvements everywhere.
     Historical examples of this include `java_buffer`, `InputBuffer`, `NativeResource`, `raii_env` and others.


### PR DESCRIPTION
*Description of changes:*
Clarify best practices are local to ACCP

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
