### PR TITLE
Add logic to generate a classpath file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 /build
 /.gradle
-/.project
 /.settings/
 /.vscode/
 /.idea/
@@ -10,3 +9,4 @@
 *.iws
 *.iml
 *.orig
+/.classpath

--- a/.project
+++ b/.project
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+    <name>AmazonCorrettoCryptoProvider</name>
+    <comment>Project amazon-corretto-crypto-provider file has been manually crafted.</comment>
+    <projects>
+    </projects>
+    <buildSpec>
+        <buildCommand>
+            <name>org.eclipse.jdt.core.javabuilder</name>
+            <arguments>
+            </arguments>
+        </buildCommand>
+    </buildSpec>
+    <natures>
+        <nature>org.eclipse.jdt.core.javanature</nature>
+    </natures>
+    <filteredResources>
+        <filter>
+            <id>0</id>
+            <name></name>
+            <type>30</type>
+            <matcher>
+                <id>org.eclipse.core.resources.regexFilterMatcher</id>
+                <arguments>node_modules|.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+            </matcher>
+        </filter>
+    </filteredResources>
+</projectDescription>

--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ Whether you're using Maven, Gradle, or some other build system that also pulls
 packages from Maven Central, it's important to specify `linux-x86_64` as the
 classifier. You'll get an empty package otherwise.
 
+Regardless of how you acquire ACCP (Maven, manual build, etc.) you will still need to follow the guidance in the [Configuration section][#configuration] to enable ACCP in your application.
+
 ### Maven
 Add the following to your `pom.xml` or wherever you configure your Maven dependencies.
 This will instruct it to use the most recent 1.x version of ACCP.
@@ -167,6 +169,7 @@ Building this provider requires a 64 bit Linux build system with the following p
 * coverage: Run target `test` and collect both Java and C++ coverage metrics (saved in `build/reports`)
 * release: **Default target** depends on build, test, and coverage
 * overkill: Run **all** tests (no coverage)
+* generateEclipseClasspath: Generates a `.classpath` file which is understandable by Eclipse and VS Code to make development easier. (This should ideally be run prior to opening ACCP in your IDE.)
 
 ## Configuration
 There are several ways to configure the ACCP as the highest priority provider in Java.
@@ -185,13 +188,13 @@ If you want to check to verify that ACCP is properly working on your system, you
 1. Verify that the highest priority provider actually is ACCP:
 ```java
 if (Cipher.getInstance("AES/GCM/NoPadding").getProvider().getName().equals(AmazonCorrettoCryptoProvider.PROVIDER_NAME)) {
-	// Successfully installed
+    // Successfully installed
 }
 ```
 2. Ask ACCP about its health
 ```java
 if (AmazonCorrettoCryptoProvider.INSTANCE.getLoadingError() == null && AmazonCorrettoCryptoProvider.INSTANCE.runSelfTests().equals(SelfTestStatus.PASSED)) {
-	// Successfully installed
+    // Successfully installed
 }
 ```
 3. Assert that ACCP is healthy and throw a `RuntimeCryptoException` if it isn't.

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,8 @@
 // Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import groovy.xml.*
+
 plugins {
     id 'maven-publish'
     id 'signing'
@@ -454,3 +456,45 @@ task clean(overwrite: true, type: Delete) {
 task deep_clean(type: Delete) {
    delete buildDir
 }
+
+task generateEclipseClasspath {
+    doLast {
+        file(".classpath").withWriter { writer ->
+            // Create MarkupBuilder with 4 space indent
+            def xml = new MarkupBuilder(new IndentPrinter(writer, "    ", true))
+
+            xml.doubleQuotes = true
+            xml.mkp.xmlDeclaration(version: '1.0', encoding: 'utf-8')
+            xml.classpath {
+                classpathentry('kind': 'con', 'path': 'org.eclipse.jdt.launching.JRE_CONTAINER') {
+                    attributes {
+                        attribute('name': 'module', 'value': 'true')
+                    }
+                }
+                classpathentry('kind': 'src', 'output': 'build/eclipse/src', 'path': 'src')
+                classpathentry('kind': 'src', 'output': 'build/eclipse/template-src', 'path': 'template-src')
+                classpathentry('kind': 'src', 'output': 'build/eclipse/tst', 'path': 'tst') {
+                    attributes {
+                        attribute('name': 'test', 'value': 'true')
+                    }
+                }
+                classpathentry('kind': 'src', 'output': 'build/eclipse/src', 'path': 'build/cmake/generated-java') {
+                    attributes {
+                        attribute('name': 'optional', 'value': 'true')
+                    }
+                }
+                classpathentry('kind': 'src', 'output': 'build/eclipse/src', 'path': 'build/coverage-cmake/generated-java') {
+                    attributes {
+                        attribute('name': 'optional', 'value': 'true')
+                    }
+                }
+
+                configurations.testDep.files.each{f ->
+                    classpathentry('kind': 'lib', 'path': f) {
+                        attribute('name': 'test', 'value': 'true')
+                    }
+                }
+            } // xml.classpath
+        } // file.withWriter
+    } // doLast
+} // generateEclipseClasspath


### PR DESCRIPTION
*Description of changes:*
The primary change is the addition of a `.project` file and the new `generateEclipseClasspath` gradle task. This task will generate a `.classpath` file in the root of the project which (along with the new `.project` file) makes editing the Java files much easier in VS Code (and likely also Eclipse). It does this by generating configuration files in the standard used by Eclipse (which is the engine used by VS Code for Java projects). This has been tested locally using VS Code.

There is a second (minor) language change in the `README` to clarify that configuration is always necessary, regardless of how you get ACCP. (Also a replacement of tabs with spaces.)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
