### PR TITLE
Fix issue with hashing

### DIFF
--- a/template-src/com/amazon/corretto/crypto/provider/TemplateHashSpi.java
+++ b/template-src/com/amazon/corretto/crypto/provider/TemplateHashSpi.java
@@ -28,7 +28,6 @@ public final class TemplateHashSpi extends MessageDigestSpi implements Cloneable
     private static final int HASH_SIZE;
     private static final byte[] INITIAL_CONTEXT;
 
-    private byte[] myContext;
     private InputBuffer<byte[], byte[]> buffer;
 
     static {
@@ -108,33 +107,40 @@ public final class TemplateHashSpi extends MessageDigestSpi implements Cloneable
         }
     }
 
-    private byte[] resetContext() {
-        System.arraycopy(INITIAL_CONTEXT, 0, myContext, 0, INITIAL_CONTEXT.length);
-        return myContext;
+    private static byte[] resetContext(byte[] context) {
+	if (context == null) {
+	    context = INITIAL_CONTEXT.clone();
+	} else {
+            System.arraycopy(INITIAL_CONTEXT, 0, context, 0, INITIAL_CONTEXT.length);
+	}
+        return context;
+    }
+
+    private static byte[] doFinal(byte[] context) {
+        final byte[] result = new byte[HASH_SIZE];
+        synchronizedFinish(context, result, 0);
+        return result;
+    }
+
+    private static byte[] singlePass(byte[] src, int offset, int length) {
+        if (offset != 0 || length != src.length) {
+            src = Arrays.copyOf(src, length);
+            offset = 0;
+        }
+        final byte[] result = new byte[HASH_SIZE];
+        fastDigest(result, src, src.length);
+        return result;
     }
 
     public TemplateHashSpi() {
         Loader.checkNativeLibraryAvailability();
-        myContext = INITIAL_CONTEXT.clone();
 
         this.buffer = new InputBuffer<byte[], byte[]>(1024)
-            .withInitialStateSupplier(this::resetContext)
+            .withInitialStateSupplier(TemplateHashSpi::resetContext)
             .withUpdater(TemplateHashSpi::synchronizedUpdateContextByteArray)
             .withUpdater(TemplateHashSpi::synchronizedUpdateNativeByteBuffer)
-            .withDoFinal((context) -> {
-                final byte[] result = new byte[HASH_SIZE];
-                synchronizedFinish(context, result, 0);
-                return result;
-            })
-            .withSinglePass((src, offset, length) -> {
-                if (offset != 0 || length != src.length) {
-                    src = Arrays.copyOf(src, length);
-                    offset = 0;
-                }
-                final byte[] result = new byte[HASH_SIZE];
-                fastDigest(result, src, src.length);
-                return result;
-            })
+            .withDoFinal(TemplateHashSpi::doFinal)
+            .withSinglePass(TemplateHashSpi::singlePass)
             .withStateCloner((context) -> context.clone());
     }
 
@@ -164,7 +170,6 @@ public final class TemplateHashSpi extends MessageDigestSpi implements Cloneable
         try {
             TemplateHashSpi clonedObject = (TemplateHashSpi)super.clone();
 
-            clonedObject.myContext = myContext.clone();
             clonedObject.buffer = (InputBuffer<byte[], byte[]>) buffer.clone();
 
             return clonedObject;

--- a/tst/com/amazon/corretto/crypto/provider/test/InputBufferTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/InputBufferTest.java
@@ -54,7 +54,7 @@ public class InputBufferTest {
         final ByteBuffer result = ByteBuffer.allocate(17);
 
         final InputBuffer<byte[], ByteBuffer> buffer = getBuffer(4);
-        buffer.withInitialStateSupplier(() -> { return result; })
+        buffer.withInitialStateSupplier((s) -> { return result; })
               .withUpdater((ctx, src, offset, length) -> ctx.put(src, offset, length))
               .withDoFinal(ByteBuffer::array);
 
@@ -93,7 +93,7 @@ public class InputBufferTest {
         // In all cases, the byte being processed should be exactly one byte and one byte behind.
 
         final InputBuffer<byte[], ByteBuffer> buffer = getBuffer(1);
-        buffer.withInitialStateSupplier(() -> { return result; })
+        buffer.withInitialStateSupplier((s) -> { return result; })
               .withUpdater((ctx, src, offset, length) -> ctx.put(src, offset, length))
               .withDoFinal(ByteBuffer::array);
 
@@ -150,7 +150,7 @@ public class InputBufferTest {
         
         // By leaving other handlers null, I'll force an exception if they are used
         final InputBuffer<byte[], ByteBuffer> buffer = getBuffer(1);
-        buffer.withInitialStateSupplier(() -> { return result;} )
+        buffer.withInitialStateSupplier((s) -> { return result;} )
               .withUpdater((ctx, src) -> ctx.put(src))
               .withDoFinal(ByteBuffer::array);
         
@@ -174,7 +174,7 @@ public class InputBufferTest {
     public void cloneDuplicatesBufferAndState() throws Throwable {
         byte[] expected = new byte[]{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
         final InputBuffer<byte[], ByteArrayOutputStream> buffer1 = getBuffer(16);
-        buffer1.withInitialStateSupplier(ByteArrayOutputStream::new)
+        buffer1.withInitialStateSupplier((s) -> new ByteArrayOutputStream())
               .withUpdater((state, src, offset, length) -> { state.write(src, offset, length); })
               .withDoFinal(ByteArrayOutputStream::toByteArray)
               .withStateCloner((state) -> {
@@ -216,7 +216,7 @@ public class InputBufferTest {
     @Test
     public void cantCloneUncloneable() throws Throwable {
         final InputBuffer<byte[], byte[]> buffer = getBuffer(8);
-        buffer.withInitialStateSupplier(() -> { return new byte[128]; } )
+        buffer.withInitialStateSupplier((s) -> { return new byte[128]; } )
               .withUpdater((state, src, offset, length) -> { System.arraycopy(src, offset, state, 0, length); })
               .withDoFinal((state) -> state.clone());
 
@@ -228,7 +228,7 @@ public class InputBufferTest {
     @Test
     public void nullStateProperlyHandled() throws Throwable {
       InputBuffer<byte[], byte[]> buffer = getBuffer(4);
-      buffer.withInitialStateSupplier(() -> {
+      buffer.withInitialStateSupplier((s) -> {
         return new byte[4];
       }).withUpdater((state, src, offset, length) -> {
         System.arraycopy(src, offset, state, 0, length);

--- a/tst/com/amazon/corretto/crypto/provider/test/TestUtil.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/TestUtil.java
@@ -4,9 +4,12 @@
 package com.amazon.corretto.crypto.provider.test;
 
 import com.amazon.corretto.crypto.provider.AmazonCorrettoCryptoProvider;
+
+import org.apache.commons.codec.binary.Hex;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.junit.jupiter.api.Assumptions;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
@@ -58,7 +61,13 @@ public class TestUtil {
         MISC_SECURE_RANDOM.get().nextBytes(result);
         return result;
     }
-    
+
+    public static void assertArraysHexEquals(byte[] expected, byte[] actual) {
+        final String expectedHex = Hex.encodeHexString(expected);
+        final String actualHex = Hex.encodeHexString(actual);
+        assertEquals(expectedHex, actualHex);
+    }
+
     public static void assertThrows(Class<? extends Throwable> expected, ThrowingRunnable callable) {
         try {
             callable.run();


### PR DESCRIPTION
*Description of changes:*
A race condition can cause ACCP’s MessageDigest hashing algorithms
to return the same value for different inputs. This patch fixes the
issue, and adds new unit tests for both the hash and hmac code to
prevent regression.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
