### PR TITLE
Bump to OpenSSL 1.1.1k

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 The Amazon Corretto Crypto Provider (ACCP) is a collection of high-performance cryptographic implementations exposed via the standard [JCA/JCE](https://docs.oracle.com/en/java/javase/11/security/java-cryptography-architecture-jca-reference-guide.html) interfaces.
 This means that it can be used as a drop in replacement for many different Java applications.
 (Differences from the default OpenJDK implementations are [documented here](./DIFFERENCES.md).)
-Currently algorithms are primarily backed by OpenSSL's implementations (1.1.1j as of ACCP 1.6.0) but this may change in the future.
+Currently algorithms are primarily backed by OpenSSL's implementations (1.1.1k as of ACCP 1.6.2) but this may change in the future.
 
 [Security issue notifications](./CONTRIBUTING.md#security-issue-notifications)
 

--- a/build.gradle
+++ b/build.gradle
@@ -9,9 +9,9 @@ plugins {
 }
 
 group = 'software.amazon.cryptools'
-version = '1.6.1'
+version = '1.6.2'
 
-def openssl_version = '1.1.1j'
+def openssl_version = '1.1.1k'
 def opensslSrcPath = "${buildDir}/openssl/openssl-${openssl_version}"
 
 configurations {

--- a/openssl.sha256
+++ b/openssl.sha256
@@ -1,1 +1,1 @@
-aaf2fcb575cdf6491b98ab4829abf78a3dec8402b8b81efc8f23c00d443981bf  openssl-1.1.1j.tar.gz
+892a0875b9872acd04a9fde79b1f943075d5ea162415de3047c327df33fbaee5  openssl-1.1.1k.tar.gz


### PR DESCRIPTION
*Description of changes:* Bumped OpenSSL from 1.1.1j to 1.1.1k

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
