### PR TITLE
Add property to skip bundled lib and improve docs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Current values are:
    * `VerboseLogging` - Enables more detailed logging.
    * `ALL` - Enables all of the above
 (May still require changes to your logging configuration to see the new logs.)
+* Enables skipping the bundled lib by setting the system property `com.amazon.corretto.crypto.provider.useExternalLib` [PR #168](https://github.com/corretto/amazon-corretto-crypto-provider/pull/168)
 
 ### Patches
 * Improve zeroization of DRBG output. [PR #162](https://github.com/corretto/amazon-corretto-crypto-provider/pull/162)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -603,8 +603,12 @@ if (TEST_JAVA_MAJOR_VERSION VERSION_GREATER_EQUAL 17)
     )
 endif()
 
-set(TEST_RUNNER_ARGUMENTS
+set(COVERAGE_ARGUMENTS
     -javaagent:${JACOCO_AGENT_JAR}=destfile=coverage/jacoco.exec,classdumpdir=coverage/classes
+)
+
+set(TEST_RUNNER_ARGUMENTS
+    ${COVERAGE_ARGUMENTS}
     ${TEST_ADD_OPENS}
     -Djava.library.path=$<TARGET_FILE_DIR:amazonCorrettoCryptoProvider>
     -Dcom.amazon.corretto.crypto.provider.inTestSuite=hunter2
@@ -667,6 +671,7 @@ add_custom_target(check-junit-extra-checks
 
 add_custom_target(check-recursive-init
     COMMAND ${TEST_JAVA_EXECUTABLE}
+        ${COVERAGE_ARGUMENTS}
         -cp $<TARGET_PROPERTY:accp-jar,JAR_FILE>:$<TARGET_PROPERTY:tests-jar,JAR_FILE>:${TEST_CLASSPATH}
         -Djava.library.path=$<TARGET_FILE_DIR:amazonCorrettoCryptoProvider>
         -Dcom.amazon.corretto.crypto.provider.inTestSuite=hunter2
@@ -678,6 +683,7 @@ add_custom_target(check-recursive-init
 
 add_custom_target(check-install-via-properties
     COMMAND ${TEST_JAVA_EXECUTABLE}
+        ${COVERAGE_ARGUMENTS}
         -cp $<TARGET_PROPERTY:accp-jar,JAR_FILE>:$<TARGET_PROPERTY:tests-jar,JAR_FILE>:${TEST_CLASSPATH}
         -Djava.library.path=$<TARGET_FILE_DIR:amazonCorrettoCryptoProvider>
         -Dcom.amazon.corretto.crypto.provider.inTestSuite=hunter2
@@ -692,6 +698,7 @@ add_custom_target(check-external-lib
     # Unfortunately we do not have a way to know where the library is loaded from.
     # So this test just proves that requesting the external lib does not break things
     COMMAND ${TEST_JAVA_EXECUTABLE}
+        ${COVERAGE_ARGUMENTS}
         -cp $<TARGET_PROPERTY:accp-jar,JAR_FILE>:$<TARGET_PROPERTY:tests-jar,JAR_FILE>:${TEST_CLASSPATH}
         -Djava.library.path=$<TARGET_FILE_DIR:amazonCorrettoCryptoProvider>
         -Dcom.amazon.corretto.crypto.provider.useExternalLib=true
@@ -705,6 +712,7 @@ add_custom_target(check-external-lib
 
 add_custom_target(check-install-via-properties-recursive
     COMMAND ${TEST_JAVA_EXECUTABLE}
+        ${COVERAGE_ARGUMENTS}
         -cp $<TARGET_PROPERTY:accp-jar,JAR_FILE>:$<TARGET_PROPERTY:tests-jar,JAR_FILE>:${TEST_CLASSPATH}
         -Djava.library.path=$<TARGET_FILE_DIR:amazonCorrettoCryptoProvider>
         -Dcom.amazon.corretto.crypto.provider.inTestSuite=hunter2
@@ -717,6 +725,7 @@ add_custom_target(check-install-via-properties-recursive
 
 add_custom_target(check-install-via-properties-with-debug
     COMMAND ${TEST_JAVA_EXECUTABLE}
+        ${COVERAGE_ARGUMENTS}
         -cp $<TARGET_PROPERTY:accp-jar,JAR_FILE>:$<TARGET_PROPERTY:tests-jar,JAR_FILE>:${TEST_CLASSPATH}
         -Djava.library.path=$<TARGET_FILE_DIR:amazonCorrettoCryptoProvider>
         -Dcom.amazon.corretto.crypto.provider.inTestSuite=hunter2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -688,6 +688,21 @@ add_custom_target(check-install-via-properties
 
     DEPENDS accp-jar tests-jar)
 
+add_custom_target(check-external-lib
+    # Unfortunately we do not have a way to know where the library is loaded from.
+    # So this test just proves that requesting the external lib does not break things
+    COMMAND ${TEST_JAVA_EXECUTABLE}
+        -cp $<TARGET_PROPERTY:accp-jar,JAR_FILE>:$<TARGET_PROPERTY:tests-jar,JAR_FILE>:${TEST_CLASSPATH}
+        -Djava.library.path=$<TARGET_FILE_DIR:amazonCorrettoCryptoProvider>
+        -Dcom.amazon.corretto.crypto.provider.useExternalLib=true
+        -Dcom.amazon.corretto.crypto.provider.inTestSuite=hunter2
+        -Dtest.data.dir=${TEST_DATA_DIR}
+        -Djava.security.properties=${ORIG_SRCROOT}/etc/amazon-corretto-crypto-provider.security
+        ${TEST_JAVA_ARGS}
+        com.amazon.corretto.crypto.provider.test.SecurityPropertyTester
+
+    DEPENDS accp-jar tests-jar)
+
 add_custom_target(check-install-via-properties-recursive
     COMMAND ${TEST_JAVA_EXECUTABLE}
         -cp $<TARGET_PROPERTY:accp-jar,JAR_FILE>:$<TARGET_PROPERTY:tests-jar,JAR_FILE>:${TEST_CLASSPATH}
@@ -714,7 +729,7 @@ add_custom_target(check-install-via-properties-with-debug
     DEPENDS accp-jar tests-jar)
 
 add_custom_target(check
-    DEPENDS check-recursive-init check-install-via-properties check-install-via-properties-with-debug check-junit check-junit-SecurityManager)
+    DEPENDS check-recursive-init check-install-via-properties check-install-via-properties-with-debug check-junit check-junit-SecurityManager check-external-lib)
 
 if(ENABLE_NATIVE_TEST_HOOKS)
     if (CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")

--- a/README.md
+++ b/README.md
@@ -185,6 +185,26 @@ Add the following Java property to your programs command line: `-Djava.security.
 ### Modify the JVM settings
 Modify the `java.security` file provided by your JVM so that the highest priority provider is the Amazon Corretto Crypto Provider. Look at [amazon-corretto-crypto-provider.security](https://github.com/corretto/amazon-corretto-crypto-provider/blob/master/etc/amazon-corretto-crypto-provider.security) for an example of what this change will look like.
 
+### Verification (Optional)
+If you want to check to verify that ACCP is properly working on your system, you can do any of the following:
+1. Verify that the highest priority provider actually is ACCP:
+```java
+if (Cipher.getInstance("AES/GCM/NoPadding").getProvider().getName().equals(AmazonCorrettoCryptoProvider.PROVIDER_NAME)) {
+    // Successfully installed
+}
+```
+2. Ask ACCP about its health
+```java
+if (AmazonCorrettoCryptoProvider.INSTANCE.getLoadingError() == null && AmazonCorrettoCryptoProvider.INSTANCE.runSelfTests().equals(SelfTestStatus.PASSED)) {
+    // Successfully installed
+}
+```
+3. Assert that ACCP is healthy and throw a `RuntimeCryptoException` if it isn't.
+We generally do not recommend this solution as we believe that gracefully falling back to other providers is usually the better option.
+```java
+AmazonCorrettoCryptoProvider.INSTANCE.assertHealthy();
+```
+
 ### Other system properties
 ACCP can be configured via several system properties.
 None of these should be needed for standard deployments and we recommend not touching them.
@@ -211,26 +231,6 @@ Thus, these should all be set on the JVM command line using `-D`.
    (Current behavior is to default this value to 4 times the CPU core count and then round the value up to the nearest power of two.)
    See `Janitor.java` for for more information.
 
-
-### Verification (Optional)
-If you want to check to verify that ACCP is properly working on your system, you can do any of the following:
-1. Verify that the highest priority provider actually is ACCP:
-```java
-if (Cipher.getInstance("AES/GCM/NoPadding").getProvider().getName().equals(AmazonCorrettoCryptoProvider.PROVIDER_NAME)) {
-    // Successfully installed
-}
-```
-2. Ask ACCP about its health
-```java
-if (AmazonCorrettoCryptoProvider.INSTANCE.getLoadingError() == null && AmazonCorrettoCryptoProvider.INSTANCE.runSelfTests().equals(SelfTestStatus.PASSED)) {
-    // Successfully installed
-}
-```
-3. Assert that ACCP is healthy and throw a `RuntimeCryptoException` if it isn't.
-We generally do not recommend this solution as we believe that gracefully falling back to other providers is usually the better option.
-```java
-AmazonCorrettoCryptoProvider.INSTANCE.assertHealthy();
-```
 
 # License
 This library is licensed under the Apache 2.0 license although portions of this product include software licensed under the

--- a/README.md
+++ b/README.md
@@ -196,13 +196,13 @@ Thus, these should all be set on the JVM command line using `-D`.
    Adds exta cryptographic consistency checks which are not necessary on standard systems.
    These checks may be computationally expensive and are not normally relevant.
    See `ExtraCheck.java` for values and more information.
-   (Also accepts "ALL" as a value to enable all flags.)
+   (Also accepts "ALL" as a value to enable all flags and "help" to print out all flags to STDERR.)
 * `com.amazon.corretto.crypto.provider.debug`
    Enables extra debugging behavior.
    These behaviors may be computationally expensive, produce additional output, or otherwise change the behavior of ACCP.
    No values here will lower the security of ACCP or cause it to give incorrect results.
    See `DebugFlag.java` for values and more information.
-   (Also accepts "ALL" as a value to enable all flags.)
+   (Also accepts "ALL" as a value to enable all flags and "help" to print out all flags to STDERR.)
 * `com.amazon.corretto.crypto.provider.useExternalLib`
    Takes in `true` or `false` (defaults to `false`).
    If `true` then ACCP skips trying to load the native library bundled within its JAR and goes directly to the system library path.

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ For more information, please see [VERSIONING.rst](https://github.com/corretto/am
 ### Gradle
 Add the following to your `build.gradle` file. If you already have a
 `dependencies` block in your `build.gradle`, you can add the ACCP line to your
-existing block. 
+existing block.
 This will instruct it to use the most recent 1.x version of ACCP.
 For more information, please see [VERSIONING.rst](https://github.com/corretto/amazon-corretto-crypto-provider/blob/develop/VERSIONING.rst).
 
@@ -184,6 +184,33 @@ Add the following Java property to your programs command line: `-Djava.security.
 
 ### Modify the JVM settings
 Modify the `java.security` file provided by your JVM so that the highest priority provider is the Amazon Corretto Crypto Provider. Look at [amazon-corretto-crypto-provider.security](https://github.com/corretto/amazon-corretto-crypto-provider/blob/master/etc/amazon-corretto-crypto-provider.security) for an example of what this change will look like.
+
+### Other system properties
+ACCP can be configured via several system properties.
+None of these should be needed for standard deployments and we recommend not touching them.
+They are of most use to developers needing to test ACCP or experiment with benchmarking.
+These are all read early in the load process and may be cached so any changes to them made from within Java may not be respected.
+Thus, these should all be set on the JVM command line using `-D`.
+
+* `com.amazon.corretto.crypto.provider.extrachecks`
+   Adds exta cryptographic consistency checks which are not necessary on standard systems.
+   These checks may be computationally expensive and are not normally relevant.
+   See `ExtraCheck.java` for values and more information.
+   (Also accepts "ALL" as a value to enable all flags.)
+* `com.amazon.corretto.crypto.provider.debug`
+   Enables extra debugging behavior.
+   These behaviors may be computationally expensive, produce additional output, or otherwise change the behavior of ACCP.
+   No values here will lower the security of ACCP or cause it to give incorrect results.
+   See `DebugFlag.java` for values and more information.
+   (Also accepts "ALL" as a value to enable all flags.)
+* `com.amazon.corretto.crypto.provider.useExternalLib`
+   Takes in `true` or `false` (defaults to `false`).
+   If `true` then ACCP skips trying to load the native library bundled within its JAR and goes directly to the system library path.
+* `com.amazon.corretto.crypto.provider.janitor.stripes`
+   Takes *positive integer value* which is the requested minimum number of "stripes" used by the `Janitor` for dividing cleaning tasks (messes) among its workers.
+   (Current behavior is to default this value to 4 times the CPU core count and then round the value up to the nearest power of two.)
+   See `Janitor.java` for for more information.
+
 
 ### Verification (Optional)
 If you want to check to verify that ACCP is properly working on your system, you can do any of the following:


### PR DESCRIPTION
* Enables skipping the bundled lib by setting the system property `com.amazon.corretto.crypto.provider.useExternalLib`. (Resolves #140)
* Documents all currently defined system properties. (Resolves #83)

I have manually verified via coverage reports that the requested control-flow is hit.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
