### PR TITLE
Add TLS1.3 to local integ tests.

### DIFF
--- a/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
+++ b/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
@@ -211,7 +211,7 @@ public final class AmazonCorrettoCryptoProvider extends java.security.Provider {
                  * end up falling back.
                  */
                 if (!getType().equals("SecureRandom")) {
-                    throw new NoSuchAlgorithmException("Can't use AACP before JAR validation completes");
+                    throw new NoSuchAlgorithmException("Can't use ACCP before JAR validation completes");
                 }
             }
 

--- a/tst/com/amazon/corretto/crypto/provider/test/RecursiveInitializationTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/RecursiveInitializationTest.java
@@ -21,7 +21,7 @@ import com.amazon.corretto.crypto.provider.AesCtrDrbg;
 /**
  * This test is a special case - it tests a recursive initialization path that looks like:
  *
- * AACP.[ctor] -> Self tests -> Mac.getInstance -> JceSecurity.[static init] -> SecureRandom.[ctor] ->
+ * ACCP.[ctor] -> Self tests -> Mac.getInstance -> JceSecurity.[static init] -> SecureRandom.[ctor] ->
  * BouncyCastle.createBaseRandom -> AesCtrDrbg.[ctor] -> NJCE.[ctor] -> Self tests -> Mac.getInstance ->
  * JceSecurity (uninitialized)
  *
@@ -58,7 +58,7 @@ public class RecursiveInitializationTest {
         }
 
         if (!installProviderAtHighestPriority(AmazonCorrettoCryptoProvider.INSTANCE)) {
-            throw new RuntimeException("Failed to install AACP");
+            throw new RuntimeException("Failed to install ACCP");
         }
     }
 

--- a/tst/com/amazon/corretto/crypto/provider/test/ServiceSelfTestMetaTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/ServiceSelfTestMetaTest.java
@@ -44,7 +44,7 @@ public class ServiceSelfTestMetaTest {
         // We need RDRAND support for a lot of these tests to work properly
         Assumptions.assumeTrue(AmazonCorrettoCryptoProvider.isRdRandSupported(), "RDRAND is supported");
 
-        // AACP instances cache the self-test status within each Service, so create a new instance to clear that cache.
+        // ACCP instances cache the self-test status within each Service, so create a new instance to clear that cache.
         // This also makes sure the native library is loaded.
         accp = new AmazonCorrettoCryptoProvider();
     }

--- a/tst/com/amazon/corretto/crypto/provider/test/integration/LocalHTTPSIntegrationTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/integration/LocalHTTPSIntegrationTest.java
@@ -98,12 +98,30 @@ public class LocalHTTPSIntegrationTest {
             } else if (cipherSuite.contains("RSA")) {
                 keyAlgorithm = "RSA";
             } else {
-                // unsupported
-                continue;
+                // We also want to support TLS 1.3.
+                // At the moment we simply hardcode the known suites and mark a keyAlgorithm of "TLS1.3" since
+                // these suites no longer tie the certificate key type to the suite.
+                switch (cipherSuite) {
+                    case "TLS_AES_128_GCM_SHA256":
+                    case "TLS_AES_256_GCM_SHA384":
+                    case "TLS_CHACHA20_POLY1305_SHA256":
+                    case "TLS_AES_128_CCM_SHA256":
+                    case "TLS_AES_128_CCM_8_SHA256":
+                        keyAlgorithm = "TLS1.3";
+                        break;
+                    default:
+                        // Unsupported suite
+                        continue;
+                }
             }
 
             for (String method : SIGNATURE_METHODS_TO_TEST) {
-                if (!method.endsWith("with" + keyAlgorithm)) {
+                if (keyAlgorithm.equals("TLS1.3")) {
+                    // TLS 1.3 only support RSA and ECDSA certificates
+                    if (!method.endsWith("withRSA") && !method.endsWith("withECDSA")) {
+                        continue;
+                    }
+                } else if (!method.endsWith("with" + keyAlgorithm)) {
                     // We generate our server certificates in such a way that the key type in the server certificate
                     // matches the key type used to sign the certificate. As such, this key type must _also_ match
                     // the key required by the cipher suite in use. We can't use a server cert showing a DH public key
@@ -114,7 +132,7 @@ public class LocalHTTPSIntegrationTest {
                 List<Integer> keySizes = HTTPSTestParameters.keySizesForSignatureMethod(method);
 
                 for (int size: keySizes) {
-                    // boolean flags: AACP on server, BC on client
+                    // boolean flags: ACCP on server, BC on client
                     params.add(new Object[] { true, true, cipherSuite, method, size });
                     params.add(new Object[] { false, true, cipherSuite, method, size });
                     params.add(new Object[] { true, false, cipherSuite, method, size });
@@ -127,11 +145,11 @@ public class LocalHTTPSIntegrationTest {
     }
 
     private static TrustManagerFactory trustManagerFactory;
-    private static TestHTTPSServer withAACP, withoutAACP;
+    private static TestHTTPSServer withACCP, withoutACCP;
 
     @BeforeAll
     public static void launchServer() throws Exception {
-        // Do this before setting up providers, as loading BC early in the provider chain (even without AACP) breaks
+        // Do this before setting up providers, as loading BC early in the provider chain (even without ACCP) breaks
         // KeyStore.
         KeyStore keyStore = KeyStore.getInstance("JKS");
         try (InputStream is = TestHTTPSServer.class.getResourceAsStream("test_CA.jks")) {
@@ -140,26 +158,26 @@ public class LocalHTTPSIntegrationTest {
         trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
         trustManagerFactory.init(keyStore);
 
-        withoutAACP = TestHTTPSServer.launch(false);
+        withoutACCP = TestHTTPSServer.launch(false);
         try {
-            withAACP = TestHTTPSServer.launch(true);
+            withACCP = TestHTTPSServer.launch(true);
         } catch (Throwable t) {
-            withoutAACP.kill();
+            withoutACCP.kill();
             throw t;
         }
     }
 
     @AfterAll
     public static void shutdown() {
-        withoutAACP.kill();
-        withAACP.kill();
+        withoutACCP.kill();
+        withACCP.kill();
     }
 
     @BeforeEach
     public void setup() throws Exception {
         resetProviders();
 
-        if (!withoutAACP.isAlive() || !withAACP.isAlive()) {
+        if (!withoutACCP.isAlive() || !withACCP.isAlive()) {
             fail("Server died");
         }
 
@@ -174,14 +192,14 @@ public class LocalHTTPSIntegrationTest {
         resetProviders();
     }
 
-    @ParameterizedTest(name = "ServerAACPEnabled({0}) BCEnabled({1}) Suite({2}) SignatureType({3}) KeyBits({4})")
+    @ParameterizedTest(name = "ServerACCPEnabled({0}) BCEnabled({1}) Suite({2}) SignatureType({3}) KeyBits({4})")
     @MethodSource("data")
-    public void test(boolean serverAACPEnabled, boolean bcEnabled, String suite, String signatureType, int keyBits) throws Exception {
+    public void test(boolean serverACCPEnabled, boolean bcEnabled, String suite, String signatureType, int keyBits) throws Exception {
         if (bcEnabled) {
             Security.insertProviderAt(new BouncyCastleProvider(), 2);
         }
 
-        int port = serverAACPEnabled ? withAACP.getPort() : withoutAACP.getPort();
+        int port = serverACCPEnabled ? withACCP.getPort() : withoutACCP.getPort();
 
         HttpsURLConnection conn = (HttpsURLConnection) new URL("https://127.0.0.1:" + port).openConnection();
         // this has the side effect of disabling the default SNI logic


### PR DESCRIPTION
Add TLS1.3 to local integ tests. (Also fixes "AACP" typo throughout.)

Resolves #166. 

Manual verification of test output shows that TLS 1.3 suites are being properly tested. Manual testing against JDK16 shows that the ChaCha20 suites are also tested when the rest of the system supports it. (Additional manual testing against JDK8 shows that these tests work there too. Default JDK for testing is 11.)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
