### PR TITLE
Update openssl to 1.1.1m

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
-## 1.6.2 (Unreleased)
+## 1.7.0 (Unreleased)
 ### Improvements
+* Now uses [OpenSSL 1.1.1m](https://www.openssl.org/source/openssl-1.1.1m.tar.gz). [PR #173](https://github.com/corretto/amazon-corretto-crypto-provider/pull/173)
 * Add "help" value to two of our properties which outputs (to STDERR) valid values.
    * `com.amazon.corretto.crypto.provider.extrachecks`
    * `com.amazon.corretto.crypto.provider.debug`

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 The Amazon Corretto Crypto Provider (ACCP) is a collection of high-performance cryptographic implementations exposed via the standard [JCA/JCE](https://docs.oracle.com/en/java/javase/11/security/java-cryptography-architecture-jca-reference-guide.html) interfaces.
 This means that it can be used as a drop in replacement for many different Java applications.
 (Differences from the default OpenJDK implementations are [documented here](./DIFFERENCES.md).)
-Currently algorithms are primarily backed by OpenSSL's implementations (1.1.1j as of ACCP 1.6.0) but this may change in the future.
+Currently algorithms are primarily backed by OpenSSL's implementations (1.1.1m as of ACCP 1.7.0) but this may change in the future.
 
 [Security issue notifications](./CONTRIBUTING.md#security-issue-notifications)
 

--- a/build.gradle
+++ b/build.gradle
@@ -9,9 +9,9 @@ plugins {
 }
 
 group = 'software.amazon.cryptools'
-version = '1.6.2'
+version = '1.7.0'
 
-def openssl_version = '1.1.1j'
+def openssl_version = '1.1.1m'
 def opensslSrcPath = "${buildDir}/openssl/openssl-${openssl_version}"
 
 configurations {

--- a/openssl.sha256
+++ b/openssl.sha256
@@ -1,1 +1,1 @@
-aaf2fcb575cdf6491b98ab4829abf78a3dec8402b8b81efc8f23c00d443981bf  openssl-1.1.1j.tar.gz
+f89199be8b23ca45fc7cb9f1d8d3ee67312318286ad030f5316aca6462db6c96  openssl-1.1.1m.tar.gz


### PR DESCRIPTION
# Testing

Tests were run on (relatively) fresh Ubuntu 20.04 LTS VM w/ kernel version 5.4:

```
$ ./gradlew clean && ./gradlew release
...
[100%] Built target check

BUILD SUCCESSFUL in 45m 57s
13 actionable tasks: 12 executed, 1 up-to-date

$ lsb_release -a
No LSB modules are available.
Distributor ID: Ubuntu
Description:    Ubuntu 20.04.3 LTS
Release:        20.04
Codename:       focal

$ uname -a
Linux desktop 5.4.0-92-generic #103-Ubuntu SMP Fri Nov 26 16:13:00 UTC 2021 x86_64 x86_64 x86_64 GNU/Linux
```
