### PR TITLE
Fix static linkage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -290,7 +290,7 @@ set(OLD_CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS}")
 ## command line while building a _shared_ library. This works only on certain
 ## platforms, but if successful it gives us a private copy of libcrypto that we
 ## can be sure will not interfere with any other openssl users.
-set(OPENSSL_STATIC_LINK_FLAGS "${OPENSSL_ROOT_DIR}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}crypto${CMAKE_STATIC_LIBRARY_SUFFIX}")
+set(OPENSSL_STATIC_LINK_FLAGS "${OPENSSL_ROOT_DIR}/lib64/${CMAKE_STATIC_LIBRARY_PREFIX}crypto${CMAKE_STATIC_LIBRARY_SUFFIX}")
 
 # This macro helps us perform tests that are not supported through the
 # generic CHECK_CXX_COMPILER_FLAG mechanism. Specifically, these result

--- a/build.gradle
+++ b/build.gradle
@@ -59,7 +59,7 @@ task buildAwsLc {
             workingDir awslcSrcPath
             executable 'cmake'
             args "-B${cMakeBuildDir}"
-            args '-DBUILD_SHARED_LIBS=ON'
+            args '-DBUILD_SHARED_LIBS=OFF'
             args '-DCMAKE_BUILD_TYPE=RelWithDebInfo'
             args "-DCMAKE_INSTALL_PREFIX=${sharedObjectOutDir}"
         }


### PR DESCRIPTION
*Description of changes:*
The current aws-lc branch doesn't properly do static linking but doesn't break dynamic linking enough for tests to find it. (We should fix that but I'm not sure how yet.) This fixes static link so that it all works again.

When we switch to dynamic linking for FIPS, we'll need to approach it more intentionally.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
