### PR TITLE
Ignore expired certs in tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ Current values are:
    * `ALL` - Enables all of the above
 (May still require changes to your logging configuration to see the new logs.)
 * Enables skipping the bundled lib by setting the system property `com.amazon.corretto.crypto.provider.useExternalLib` [PR #168](https://github.com/corretto/amazon-corretto-crypto-provider/pull/168)
+* External integration tests now skip certificate validation for expired certificates.
+   This is to work around external sites which may have allowed their certificates to expire.
+   [PR #190](https://github.com/corretto/amazon-corretto-crypto-provider/pull/189)
 
 ### Patches
 * Improve zeroization of DRBG output. [PR #162](https://github.com/corretto/amazon-corretto-crypto-provider/pull/162)

--- a/tst/com/amazon/corretto/crypto/provider/test/integration/CustomTrustManager.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/integration/CustomTrustManager.java
@@ -3,18 +3,23 @@
 
 package com.amazon.corretto.crypto.provider.test.integration;
 
+import static java.util.logging.Logger.getLogger;
 import static com.amazon.corretto.crypto.provider.test.integration.HTTPSTestParameters.SUPER_SECURE_PASSWORD;
 
 import javax.net.ssl.TrustManagerFactory;
 import javax.net.ssl.X509TrustManager;
+import javax.security.auth.x500.X500Principal;
+
 import java.io.InputStream;
 import java.security.KeyStore;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
+import java.util.Date;
 
 /**
- * This just adds Amazon Trust roots to the default set of trusted CA root certificates, allowing us to connect to the
- * amazontrust.com test sites.
+ * This adds Amazon Trust roots to the default set of trusted CA root certificates, allowing us to connect to the
+ * amazontrust.com test sites. It also skips validation of expired certificates because external sites sometimes let
+ * them expire incorrectly.
  */
 class CustomTrustManager implements X509TrustManager {
     private final X509TrustManager defaultTrustManager;
@@ -45,6 +50,20 @@ class CustomTrustManager implements X509TrustManager {
     }
 
     @Override public void checkServerTrusted(X509Certificate[] chain, String authType) throws CertificateException {
+        // Certificates from badssl.com are bad sometimes, and this includes expired.
+        // If they are expired, skip further validation for them as most of cryptography we care about is in using
+        // the certificates rather than validating them
+        final Date now = new Date();
+        for (X509Certificate cert: chain) {
+            final Date notAfter = cert.getNotAfter();
+            final String subjectName = cert.getSubjectX500Principal().getName(X500Principal.RFC2253);
+            if (subjectName.contains(".badssl.com,") && notAfter.before(now)) {
+                getLogger("CustomTrustManager").warning(String.format("%s has expired as of %s. Skipping validation.",
+                        subjectName, notAfter));
+                return;
+            }
+        }
+
         try {
             defaultTrustManager.checkServerTrusted(chain, authType);
         } catch (Exception e) {


### PR DESCRIPTION
*Description of changes:*
External integration tests now skip certificate validation for expired certificates. This is to work around external sites which may have allowed their certificates to expire.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
