### PR TITLE
Initial commit of clang tidy

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,33 @@
+BasedOnStyle:  WebKit
+---
+Language:        Cpp
+AlignConsecutiveMacros: true
+AlignOperands:   Align
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+BinPackParameters: false
+ColumnLimit:     120
+IncludeCategories:
+  - Regex:           '^<openssl/'
+    Priority:        2
+    SortPriority:    0
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        3
+    SortPriority:    0
+  - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
+    Priority:        4
+    SortPriority:    0
+  - Regex:           '.*'
+    Priority:        1
+    SortPriority:    0
+MaxEmptyLinesToKeep: 3
+WhitespaceSensitiveMacros:
+  - STRINGIZE
+  - PP_STRINGIZE
+  - BOOST_PP_STRINGIZE
+  - TO_STRING
+  - TO_STRING_0
+  - CONCAT2
+  - CONCAT2_INTERNAL
+...
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Current values are:
 * External integration tests now skip certificate validation for expired certificates.
    This is to work around external sites which may have allowed their certificates to expire.
    [PR #190](https://github.com/corretto/amazon-corretto-crypto-provider/pull/189)
+* Allows developers to run `clang-tidy` against the source by passing `-DUSE_CLANG_TIDY=true` to gradlew.
+   Example: `./gradlew -DUSE_CLANG_TIDY=true build`
+   This may require deleting `build/cmake` prior to running.
+   [PR #191](https://github.com/corretto/amazon-corretto-crypto-provider/pull/191)
 
 ### Patches
 * Improve zeroization of DRBG output. [PR #162](https://github.com/corretto/amazon-corretto-crypto-provider/pull/162)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,29 @@ set(FORCE_DISABLE_RDRAND NO CACHE BOOL "Force CPUID detection of rdrand support 
 set(TEST_DATA_DIR ${PROJECT_SOURCE_DIR}/test-data/ CACHE STRING "Path to directory containing test data")
 set(ORIG_SRCROOT ${PROJECT_SOURCE_DIR} CACHE STRING "Path to root of original package")
 set(PROVIDER_VERSION_STRING "" CACHE STRING "X.Y.Z formatted version of the provider")
+if (USE_CLANG_TIDY)
+    # https://releases.llvm.org/9.0.0/tools/clang/tools/extra/docs/clang-tidy/checks/list.html
+    # https://clang.llvm.org/extra/clang-tidy/#suppressing-undesired-diagnostics
+    # TODO: Make this enforcing with "-warnings-as-errors=*;" once we're happy with the state
+    set(CMAKE_CXX_CLANG_TIDY "clang-tidy;-checks=-*")
+    # Categories we want
+    set(CMAKE_CXX_CLANG_TIDY ${CMAKE_CXX_CLANG_TIDY},bugprone-*)
+    set(CMAKE_CXX_CLANG_TIDY ${CMAKE_CXX_CLANG_TIDY},cert-*)
+    set(CMAKE_CXX_CLANG_TIDY ${CMAKE_CXX_CLANG_TIDY},cppcoreguidelines-*)
+    set(CMAKE_CXX_CLANG_TIDY ${CMAKE_CXX_CLANG_TIDY},clang-analyzer-*)
+    set(CMAKE_CXX_CLANG_TIDY ${CMAKE_CXX_CLANG_TIDY},performance-*)
+    set(CMAKE_CXX_CLANG_TIDY ${CMAKE_CXX_CLANG_TIDY},portability-*)
+    set(CMAKE_CXX_CLANG_TIDY ${CMAKE_CXX_CLANG_TIDY},readability-*)
+
+    # Things we don't want
+    # We must use reinterpret cast to move things across the JNI boundary
+    set(CMAKE_CXX_CLANG_TIDY ${CMAKE_CXX_CLANG_TIDY},-cppcoreguidelines-pro-type-reinterpret-cast)
+    # We intentionally omit the parameters for jclass
+    set(CMAKE_CXX_CLANG_TIDY ${CMAKE_CXX_CLANG_TIDY},-readability-named-parameter)
+    # We target older styles of C++. We can revisit these after checking all build chains
+    set(CMAKE_CXX_CLANG_TIDY ${CMAKE_CXX_CLANG_TIDY},-cppcoreguidelines-macro-usage)
+    # Anything referencing gsl:: (Guidelines support library) is too new for us
+endif()
 
 if (NOT DEFINED JACOCO_AGENT_JAR)
    set(JACOCO_AGENT_JAR ${JACOCO_ROOT}/jacocoagent.jar)

--- a/build.gradle
+++ b/build.gradle
@@ -162,9 +162,12 @@ task executeCmake(type: Exec) {
     if (System.properties['TEST_JAVA_MAJOR_VERSION'] != null) {
         args '-DTEST_JAVA_MAJOR_VERSION=' + System.properties['TEST_JAVA_MAJOR_VERSION']
     }
-
     if (System.properties['SINGLE_TEST'] != null) {
         args '-DSINGLE_TEST=' + System.properties['SINGLE_TEST']
+
+    }
+    if (System.properties['USE_CLANG_TIDY'] != null) {
+        args '-DUSE_CLANG_TIDY=' + System.properties['USE_CLANG_TIDY']
 
     }
     args projectDir


### PR DESCRIPTION
*Issue #, if available:* #133

*Description of changes:*
Initial commit of clang tidy. I'm adding this way since I'm not sure if `clang-tidy` is an available dependency on all of our build systems right now.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
