### PR TITLE
Support SHA2 family in RSA OAEP

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -7,7 +7,7 @@
 # to re-run a single test with:
 #
 # $ SINGLE_TEST=com.amazon.corretto.crypto.provider.test.EvpSignatureTest
-# $ rm ./build/awslc/bin/lib/libcrypto.{a,so} ./build/cmake/*.jar; ./gradlew single_test -DSINGLE_TEST=${SINGLE_TEST}
+# $ ./gradlew minimal_clean && ./gradlew single_test -DSINGLE_TEST=${SINGLE_TEST}
 
 
 FROM ubuntu:20.04

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -7,7 +7,7 @@
 # to re-run a single test with:
 #
 # $ SINGLE_TEST=com.amazon.corretto.crypto.provider.test.EvpSignatureTest
-# $ rm ./build/awslc/bin/lib/libcrypto.so ./build/cmake/*.jar; ./gradlew single_test -DSINGLE_TEST=${SINGLE_TEST}
+# $ rm ./build/awslc/bin/lib/libcrypto.{a,so} ./build/cmake/*.jar; ./gradlew single_test -DSINGLE_TEST=${SINGLE_TEST}
 
 
 FROM ubuntu:20.04

--- a/build.gradle
+++ b/build.gradle
@@ -437,6 +437,7 @@ task minimal_clean(type: Delete) {
     dependsOn cmake_clean
     delete "${buildDir}/awslc/bin/lib/libcrypto.*"
     delete "${buildDir}/awslc/build/crypto/libcrypto.*"
+    delete "${buildDir}/lib/*"
 }
 
 task generateEclipseClasspath {

--- a/build.gradle
+++ b/build.gradle
@@ -432,6 +432,13 @@ task cmake_clean(type: Delete) {
     delete "${buildDir}/cmake"
     delete "${buildDir}/cmake-coverage"
 }
+
+task minimal_clean(type: Delete) {
+    dependsOn cmake_clean
+    delete "${buildDir}/awslc/bin/lib/libcrypto.*"
+    delete "${buildDir}/awslc/build/crypto/libcrypto.*"
+}
+
 task generateEclipseClasspath {
     doLast {
         file(".classpath").withWriter { writer ->

--- a/csrc/auto_free.h
+++ b/csrc/auto_free.h
@@ -156,16 +156,6 @@ public:
         return &buf;
     }
 
-    operator uint8_t *()
-    {
-        return reinterpret_cast<uint8_t *>(buf);
-    }
-
-    operator uint8_t *() const
-    {
-        return reinterpret_cast<uint8_t *>(buf);
-    }
-
     operator jbyte *()
     {
         return reinterpret_cast<jbyte *>(buf);

--- a/csrc/rsa_cipher.cpp
+++ b/csrc/rsa_cipher.cpp
@@ -5,6 +5,7 @@
 #include <openssl/rsa.h>
 #include <openssl/bn.h>
 #include <openssl/err.h>
+#include <openssl/evp.h>
 #include "generated-headers.h"
 #include "util.h"
 #include "bn.h"
@@ -12,12 +13,35 @@
 
 using namespace AmazonCorrettoCryptoProvider;
 
+void setPaddingParams(EVP_PKEY_CTX *keyCtx, int padding, long oaepMdPtr, long mgfMdPtr)
+{
+    CHECK_OPENSSL(EVP_PKEY_CTX_set_rsa_padding(keyCtx, padding));
+    switch (padding) {
+    case RSA_PKCS1_OAEP_PADDING:
+        if (oaepMdPtr) {
+            CHECK_OPENSSL(EVP_PKEY_CTX_set_rsa_oaep_md(keyCtx, reinterpret_cast<const EVP_MD*>(oaepMdPtr)));
+        }
+        if (mgfMdPtr) {
+            CHECK_OPENSSL(EVP_PKEY_CTX_set_rsa_mgf1_md(keyCtx, reinterpret_cast<const EVP_MD*>(mgfMdPtr)));
+        }
+        break;
+    case RSA_PKCS1_PADDING:
+    case RSA_NO_PADDING:
+    case RSA_PKCS1_PSS_PADDING:
+    default:
+        break; // nothing to do
+    }
+    return;
+}
+
 JNIEXPORT jint JNICALL Java_com_amazon_corretto_crypto_provider_RsaCipher_cipher(
     JNIEnv *pEnv,
     jclass,
     jlong ctxHandle,
     jint mode,
     jint padding,
+    jlong oaepMdPtr,
+    jlong mgfMdPtr,
     jbyteArray input,
     jint inOff,
     jint inLength,
@@ -29,13 +53,6 @@ JNIEXPORT jint JNICALL Java_com_amazon_corretto_crypto_provider_RsaCipher_cipher
     try {
         raii_env env(pEnv);
 
-        EvpKeyContext *ctx = reinterpret_cast<EvpKeyContext *>(ctxHandle);
-
-        RSA* r = EVP_PKEY_get0_RSA(ctx->getKey()); // Doesn't need to be freed
-
-        if (!r) {
-            throw_java_ex(EX_NPE, "Null RSA key");
-        }
         if (!input) {
             throw_java_ex(EX_NPE, "Null input array");
         }
@@ -43,42 +60,66 @@ JNIEXPORT jint JNICALL Java_com_amazon_corretto_crypto_provider_RsaCipher_cipher
             throw_java_ex(EX_NPE, "Null output array");
         }
 
+        EvpKeyContext *ctx = reinterpret_cast<EvpKeyContext *>(ctxHandle);
+
+        EVP_PKEY_CTX *keyCtx = ctx->getKeyCtx();
+        if (keyCtx == nullptr) {
+            keyCtx = ctx->setKeyCtx(EVP_PKEY_CTX_new(ctx->getKey(), /*engine*/nullptr));
+        }
+
         java_buffer inBuf = java_buffer::from_array(env, input, inOff, inLength);
-        java_buffer outBuf = java_buffer::from_array(env, output, outOff, RSA_size(r));
-        int len = 0;
+        java_buffer outBuf = java_buffer::from_array(env, output, outOff, EVP_PKEY_size(ctx->getKey()));
+
+        size_t len = outBuf.len();
 
         {
             jni_borrow in(env, inBuf, "input buffer");
             jni_borrow out(env, outBuf, "output buffer");
 
+            int ret = 0;
             switch (mode) {
             case 2: // Decrypt
             case 4: // Unwrap
-                len = RSA_private_decrypt(inLength, in.data(), out.data(), r, padding);
+                CHECK_OPENSSL(EVP_PKEY_decrypt_init(keyCtx));
+                setPaddingParams(keyCtx, padding, oaepMdPtr, mgfMdPtr);
+                ret = EVP_PKEY_decrypt(keyCtx, out.data(), &len, in.data(), inLength);
                 break;
             case 1: // Encrypt
             case 3: // Wrap
-                len = RSA_public_encrypt(inLength, in.data(), out.data(), r, padding);
+                CHECK_OPENSSL(EVP_PKEY_encrypt_init(keyCtx));
+                setPaddingParams(keyCtx, padding, oaepMdPtr, mgfMdPtr);
+                ret = EVP_PKEY_encrypt(keyCtx, out.data(), &len, in.data(), inLength);
                 break;
             case -1: // Encrypt with a private key, a.k.a. signing
-                len = RSA_private_encrypt(inLength, in.data(), out.data(), r, padding);
+                CHECK_OPENSSL(EVP_PKEY_sign_init(keyCtx));
+                setPaddingParams(keyCtx, padding, oaepMdPtr, mgfMdPtr);
+                ret = EVP_PKEY_sign(keyCtx, out.data(), &len, in.data(), inLength);
                 break;
             case -2: // Decrypt with a public key, a.k.a verification
-                len = RSA_public_decrypt(inLength, in.data(), out.data(), r, padding);
+                CHECK_OPENSSL(EVP_PKEY_verify_recover_init(keyCtx));
+                setPaddingParams(keyCtx, padding, oaepMdPtr, mgfMdPtr);
+                ret = EVP_PKEY_verify_recover(keyCtx, out.data(), &len, in.data(), inLength);
                 break;
             default:
                 throw_java_ex(EX_RUNTIME_CRYPTO, "Unknown cipher mode");
             }
 
-            if (len < 0) {
-                throw_openssl(EX_BADPADDING, "Unknown error");
+            if (ret <= 0) {
+                long err = drainOpensslErrors();
+                if ((err & RSA_R_DATA_TOO_LARGE_FOR_MODULUS)
+                        || (err & RSA_R_PADDING_CHECK_FAILED)
+                        || (err & RSA_R_OAEP_DECODING_ERROR)) {
+                    throw_java_ex(EX_BADPADDING, formatOpensslError(err, "Bad Padding"));
+                } else {
+                    throw_openssl(formatOpensslError(err, "Unexpected exception").c_str());
+                }
             }
         }
 
-        return len;
+        // mask off high order bytes + sign bits to return non-negative (signed) int
+        return (jint) (len & 0x00007fff);
     } catch (java_ex &ex) {
         ex.throw_to_java(pEnv);
         return -1;
     }
 }
-

--- a/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
+++ b/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
@@ -68,6 +68,7 @@ public final class AmazonCorrettoCryptoProvider extends java.security.Provider {
 
         addService("Cipher", "RSA/ECB/NoPadding", "RsaCipher$NoPadding");
         addService("Cipher", "RSA/ECB/Pkcs1Padding", "RsaCipher$Pkcs1");
+        addService("Cipher", "RSA/ECB/OAEPPadding", "RsaCipher$OAEP");
         addService("Cipher", "RSA/ECB/OAEPWithSHA-1AndMGF1Padding", "RsaCipher$OAEPSha1");
 
         for (String hash : new String[] { "MD5", "SHA1", "SHA256", "SHA384", "SHA512" }) {

--- a/src/com/amazon/corretto/crypto/provider/RsaCipher.java
+++ b/src/com/amazon/corretto/crypto/provider/RsaCipher.java
@@ -304,7 +304,7 @@ class RsaCipher extends CipherSpi {
     }
 
     private static long getMdPtr(String digestName) {
-        String name = jceNameToAwsLcName(digestName);
+        final String name = jceNameToAwsLcName(digestName);
         return digestPtrByName.computeIfAbsent(name, n -> Utils.getEvpMdFromName(n));
     }
 
@@ -344,12 +344,7 @@ class RsaCipher extends CipherSpi {
             params = oaepParams_;
         }
         try {
-            engineInit(
-                opmode,
-                key,
-                params,
-                random
-            );
+            engineInit(opmode, key, params, random);
         } catch (InvalidAlgorithmParameterException e) {
             throw new InvalidKeyException(e);
         }

--- a/src/com/amazon/corretto/crypto/provider/RsaCipher.java
+++ b/src/com/amazon/corretto/crypto/provider/RsaCipher.java
@@ -20,6 +20,8 @@ import java.security.spec.InvalidKeySpecException;
 import java.security.spec.InvalidParameterSpecException;
 import java.security.spec.MGF1ParameterSpec;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 
 import javax.crypto.BadPaddingException;
 import javax.crypto.Cipher;
@@ -36,21 +38,19 @@ class RsaCipher extends CipherSpi {
     private static final int HANDLE_USAGE_CREATE = 3;
 
     // From openssl/rsa.h
-    private static enum Padding {
+    private enum Padding {
         /** PKCS #1 v1.5 */
-        PKCS1(1, "PKCS1Padding", 11),
-        NO_PADDING(3, "NoPadding", 0),
-        /** PKCS #1 v2.0 with SHA-1, MGF1, and an empty encoding parameter */
-        OAEP_SHA1_MGF1(4, "OAEPWithSHA-1AndMGF1Padding", 42);
+        PKCS1(1, "PKCS1Padding"),
+        NO_PADDING(3, "NoPadding"),
+        /** PKCS #1 v2.0 */
+        OAEP(4, "OAEPWithSHA-1AndMGF1Padding");
 
         private final int nativeVal;
-        private final String jceName;
-        private final int paddingLength;
+        private final String paddingStr;
 
-        private Padding(final int val, final String name, final int length) {
+        private Padding(final int val, final String paddingIn) {
             nativeVal = val;
-            jceName = name;
-            paddingLength = length;
+            paddingStr = paddingIn;
         }
     }
 
@@ -62,12 +62,17 @@ class RsaCipher extends CipherSpi {
             long keyPtr,
             int mode,
             int padding,
+            long oaepMdPtr,
+            long mgfMdPtr,
             byte[] input, int inOff, int inLength,
             byte[] output, int outOff) throws BadPaddingException;
 
     private final AmazonCorrettoCryptoProvider provider_;
     private final Object lock_ = new Object();
     private final Padding padding_;
+
+    private static final Map<String,Long> digestPtrByName = new HashMap<>();
+    private static final Map<Long,Integer> digestLengthByPtr = new HashMap<>();
 
     // @GuardedBy("lock_") // Restore once replacement for JSR-305 available
     private int mode_;
@@ -76,14 +81,20 @@ class RsaCipher extends CipherSpi {
     // @GuardedBy("lock_") // Restore once replacement for JSR-305 available
     private int keySizeBytes_;
     // @GuardedBy("lock_") // Restore once replacement for JSR-305 available
+    private int paddingSize_;
+    // @GuardedBy("lock_") // Restore once replacement for JSR-305 available
+    private OAEPParameterSpec oaepParams_;
+    // @GuardedBy("lock_") // Restore once replacement for JSR-305 available
     private EvpKey nativeKey_;
     // @GuardedBy("lock_") // Restore once replacement for JSR-305 available
     private AccessibleByteArrayOutputStream buffer_;
 
-    RsaCipher(AmazonCorrettoCryptoProvider provider, final Padding padding) {
+    RsaCipher(AmazonCorrettoCryptoProvider provider, final Padding padding, final int paddingSize) {
         Loader.checkNativeLibraryAvailability();
         provider_ = provider;
         padding_ = padding;
+        paddingSize_ = paddingSize;
+        oaepParams_ = padding == Padding.OAEP ? OAEPParameterSpec.DEFAULT : null;
     }
 
     @Override
@@ -135,9 +146,9 @@ class RsaCipher extends CipherSpi {
                 throw new ShortBufferException();
             }
             if (mode_ == Cipher.ENCRYPT_MODE || mode_ == Cipher.WRAP_MODE) {
-                if (inputLen > keySizeBytes_ - padding_.paddingLength) {
+                if (inputLen > keySizeBytes_ - paddingSize_) {
                     throw new IllegalBlockSizeException("Data must not be longer than "
-                            + (keySizeBytes_ - padding_.paddingLength) + " bytes");
+                            + (keySizeBytes_ - paddingSize_) + " bytes");
                 }
                 // We're allowed to pad NO_PADDING with zero bytes on the left.
                 // This is because RSA fundamentally works on positive integers so
@@ -156,11 +167,23 @@ class RsaCipher extends CipherSpi {
                 }
             }
 
+            final long oaepMdPtr;
+            final long mgfMdPtr;
+            if (padding_ == Padding.OAEP) {
+                oaepMdPtr = getMdPtr(oaepParams_.getDigestAlgorithm());
+                mgfMdPtr = getMdPtr(
+                    ((MGF1ParameterSpec) oaepParams_.getMGFParameters()).getDigestAlgorithm()
+                );
+            } else {
+                oaepMdPtr = 0;
+                mgfMdPtr = 0;
+            }
+
             final byte[] finalInput = input;
             final int finalInputOffset = inputOffset;
             final int finalInputLen = inputLen;
             final int result = nativeKey_.use(ptr -> cipher(ptr, mode_, padding_.nativeVal,
-                    finalInput, finalInputOffset, finalInputLen, output, outputOffset));
+                    oaepMdPtr, mgfMdPtr, finalInput, finalInputOffset, finalInputLen, output, outputOffset));
 
             buffer_ = new AccessibleByteArrayOutputStream();
 
@@ -197,10 +220,10 @@ class RsaCipher extends CipherSpi {
 
     @Override
     protected AlgorithmParameters engineGetParameters() {
-        if (padding_.equals(Padding.OAEP_SHA1_MGF1)) {
+        if (padding_ == Padding.OAEP) {
             try {
                 final AlgorithmParameters params = AlgorithmParameters.getInstance("OAEP");
-                params.init(new OAEPParameterSpec("SHA-1", "MGF1", MGF1ParameterSpec.SHA1, PSource.PSpecified.DEFAULT));
+                params.init(oaepParams_);
                 return params;
             } catch (final GeneralSecurityException ex) {
                 throw new AssertionError(ex);
@@ -211,8 +234,34 @@ class RsaCipher extends CipherSpi {
     }
 
     @Override
-    protected void engineInit(final int opmode, final Key key, final SecureRandom random)
-            throws InvalidKeyException {
+    protected void engineInit(final int opmode, final Key key, final AlgorithmParameterSpec params,
+            final SecureRandom random)
+                    throws InvalidKeyException, InvalidAlgorithmParameterException {
+        if (params != null) {
+            if (params instanceof OAEPParameterSpec) {
+                final OAEPParameterSpec oaep = (OAEPParameterSpec) params;
+                if (!"MGF1".equalsIgnoreCase(oaep.getMGFAlgorithm()) ||
+                        oaep.getMGFParameters() == null ||
+                        !(oaep.getMGFParameters() instanceof MGF1ParameterSpec)) {
+                    throw new InvalidAlgorithmParameterException();
+                }
+                final PSource pDefault = PSource.PSpecified.DEFAULT;
+                final PSource psrc = oaep.getPSource();
+                if (psrc == null || !pDefault.getAlgorithm().equalsIgnoreCase(psrc.getAlgorithm())) {
+                    throw new InvalidAlgorithmParameterException();
+                }
+                // Only support empty label
+                if (!(psrc instanceof PSource.PSpecified)) {
+                    throw new InvalidAlgorithmParameterException();
+                }
+                if (((PSource.PSpecified) psrc).getValue().length != 0) {
+                    throw new InvalidAlgorithmParameterException();
+                }
+            } else {
+                throw new InvalidAlgorithmParameterException();
+            }
+        }
+
         synchronized (lock_) {
             if (!(key instanceof RSAKey)) {
                 throw new InvalidKeyException();
@@ -220,16 +269,89 @@ class RsaCipher extends CipherSpi {
             mode_ = checkMode(opmode, key);
 
             if (key_ != key) {
-              if (nativeKey_ != null) {
-                nativeKey_.releaseEphemeral();
-                nativeKey_ = null;
-              }
+                if (nativeKey_ != null) {
+                    nativeKey_.releaseEphemeral();
+                    nativeKey_ = null;
+                }
 
-              key_ = (RSAKey) key;
-              keySizeBytes_ = (key_.getModulus().bitLength() + 7) / 8;
-              buffer_ = new AccessibleByteArrayOutputStream();
-              nativeKey_ = provider_.translateKey(key, EvpKeyType.RSA);
-          }
+                key_ = (RSAKey) key;
+                keySizeBytes_ = (key_.getModulus().bitLength() + 7) / 8;
+                buffer_ = new AccessibleByteArrayOutputStream();
+                nativeKey_ = provider_.translateKey(key, EvpKeyType.RSA);
+            }
+
+            if (params instanceof OAEPParameterSpec) {
+                final OAEPParameterSpec oaepParams = (OAEPParameterSpec) params;
+                try {
+                    // Cache MD struct ptrs, validate digest names, update params + padding len
+                    getMdPtr(oaepParams.getDigestAlgorithm());
+                    getMdPtr(((MGF1ParameterSpec) oaepParams.getMGFParameters()).getDigestAlgorithm());
+                    paddingSize_ = calculateOaepPaddingLen(oaepParams.getDigestAlgorithm());
+                    oaepParams_ = oaepParams;
+                } catch (Exception e) {
+                    throw new InvalidAlgorithmParameterException();
+                }
+            }
+        }
+    }
+
+    private static String jceNameToAwsLcName(String jceName) {
+        if (jceName == null) {
+            return null;
+        }
+        // e.g. "SHA-512/256" => "SHA512-256"
+        return jceName.replace("-", "").replace("/", "-").toUpperCase();
+    }
+
+    private static long getMdPtr(String digestName) {
+        String name = jceNameToAwsLcName(digestName);
+        return digestPtrByName.computeIfAbsent(name, n -> Utils.getEvpMdFromName(n));
+    }
+
+    private static int getMdLen(long mdPtr) {
+        return digestLengthByPtr.computeIfAbsent(mdPtr, p -> Utils.getDigestLength(p));
+    }
+
+    // NOTE: while RFC-2437 stipulates[1] that OAEP padding has max length of 2*digestSize+1,
+    //       both standard JCE[2] and AWS-LC[3][4] reserve an extra byte of padding space to
+    //       ensure that the size of the padded message does not excede that of the modulus,
+    //       hence the +2 in the calculation below.
+    //
+    // [1]: https://datatracker.ietf.org/doc/html/rfc2437#section-9.1.1.1
+    // [2]: https://github.com/corretto/corretto-8/blob/develop/src/jdk/src/share/classes/sun/security/rsa/RSAPadding.java#L191
+    // [3]: https://github.com/awslabs/aws-lc/blob/main/crypto/fipsmodule/rsa/padding.c#L349
+    // [4]: https://github.com/awslabs/aws-lc/blob/main/crypto/fipsmodule/rsa/padding.c#L420-L427
+    private static int calculateOaepPaddingLen(String mdName) {
+        return 2 * getMdLen(getMdPtr(mdName)) + 2;
+    }
+
+    @Override
+    protected void engineInit(final int opmode, final Key key, final AlgorithmParameters params,
+            final SecureRandom random)
+                    throws InvalidKeyException, InvalidAlgorithmParameterException {
+        try {
+            engineInit(opmode, key, params.getParameterSpec(OAEPParameterSpec.class), random);
+        } catch (final InvalidParameterSpecException ex) {
+            throw new InvalidAlgorithmParameterException(ex);
+        }
+    }
+
+    @Override
+    protected void engineInit(final int opmode, final Key key, final SecureRandom random)
+            throws InvalidKeyException {
+        AlgorithmParameterSpec params = null;
+        if (padding_ == Padding.OAEP) {
+            params = oaepParams_;
+        }
+        try {
+            engineInit(
+                opmode,
+                key,
+                params,
+                random
+            );
+        } catch (InvalidAlgorithmParameterException e) {
+            throw new InvalidKeyException(e);
         }
     }
 
@@ -267,53 +389,6 @@ class RsaCipher extends CipherSpi {
     }
 
     @Override
-    protected void engineInit(final int opmode, final Key key, final AlgorithmParameterSpec params,
-            final SecureRandom random)
-                    throws InvalidKeyException, InvalidAlgorithmParameterException {
-        if (params != null) {
-            if (params instanceof OAEPParameterSpec && padding_.equals(Padding.OAEP_SHA1_MGF1)) {
-                final OAEPParameterSpec oaep = (OAEPParameterSpec) params;
-                if (!"SHA-1".equalsIgnoreCase(oaep.getDigestAlgorithm()) ||
-                        !"MGF1".equalsIgnoreCase(oaep.getMGFAlgorithm()) ||
-                        oaep.getMGFParameters() == null ||
-                        !(oaep.getMGFParameters() instanceof MGF1ParameterSpec)) {
-                    throw new InvalidAlgorithmParameterException();
-                }
-                final MGF1ParameterSpec mgf = (MGF1ParameterSpec) oaep.getMGFParameters();
-                if (!MGF1ParameterSpec.SHA1.getDigestAlgorithm().equals(mgf.getDigestAlgorithm())) {
-                    throw new InvalidAlgorithmParameterException();
-                }
-                final PSource pDefault = PSource.PSpecified.DEFAULT;
-                final PSource psrc = oaep.getPSource();
-                if (psrc == null || !pDefault.getAlgorithm().equalsIgnoreCase(psrc.getAlgorithm())) {
-                    throw new InvalidAlgorithmParameterException();
-                }
-                // Only support empty label
-                if (!(psrc instanceof PSource.PSpecified)) {
-                    throw new InvalidAlgorithmParameterException();
-                }
-                if (((PSource.PSpecified) psrc).getValue().length != 0) {
-                    throw new InvalidAlgorithmParameterException();
-                }
-            } else {
-                throw new InvalidAlgorithmParameterException();
-            }
-        }
-        engineInit(opmode, key, random);
-    }
-
-    @Override
-    protected void engineInit(final int opmode, final Key key, final AlgorithmParameters params,
-            final SecureRandom random)
-                    throws InvalidKeyException, InvalidAlgorithmParameterException {
-        try {
-            engineInit(opmode, key, params.getParameterSpec(OAEPParameterSpec.class), random);
-        } catch (final InvalidParameterSpecException ex) {
-            throw new InvalidAlgorithmParameterException(ex);
-        }
-    }
-
-    @Override
     protected void engineSetMode(final String mode) throws NoSuchAlgorithmException {
         if (!"ECB".equalsIgnoreCase(mode)) {
             throw new NoSuchAlgorithmException();
@@ -321,8 +396,13 @@ class RsaCipher extends CipherSpi {
     }
 
     @Override
-    protected void engineSetPadding(final String padding) throws NoSuchPaddingException {
-        if (!padding_.jceName.equalsIgnoreCase(padding)) {
+    protected void engineSetPadding(final String newPadding) throws NoSuchPaddingException {
+        if (newPadding == Padding.OAEP.paddingStr) {
+            synchronized(lock_) {
+                oaepParams_ = OAEPParameterSpec.DEFAULT;
+                paddingSize_ = calculateOaepPaddingLen(OAEPParameterSpec.DEFAULT.getDigestAlgorithm());
+            }
+        } else if (!padding_.paddingStr.equalsIgnoreCase(newPadding)) {
             throw new NoSuchPaddingException();
         }
     }
@@ -385,19 +465,23 @@ class RsaCipher extends CipherSpi {
 
     static class NoPadding extends RsaCipher {
         NoPadding(AmazonCorrettoCryptoProvider provider) {
-            super(provider, Padding.NO_PADDING);
+            super(provider, Padding.NO_PADDING, 0);
         }
     }
 
     static class Pkcs1 extends RsaCipher {
         Pkcs1(AmazonCorrettoCryptoProvider provider) {
-            super(provider, Padding.PKCS1);
+            super(provider, Padding.PKCS1, 11);
         }
     }
 
     static class OAEPSha1 extends RsaCipher {
         OAEPSha1(AmazonCorrettoCryptoProvider provider) {
-            super(provider, Padding.OAEP_SHA1_MGF1);
+            super(
+                provider,
+                Padding.OAEP,
+                calculateOaepPaddingLen(OAEPParameterSpec.DEFAULT.getDigestAlgorithm())
+            );
         }
     }
 }

--- a/tst/com/amazon/corretto/crypto/provider/test/RsaCipherTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/RsaCipherTest.java
@@ -114,8 +114,8 @@ public class RsaCipherTest {
                     Object o = f.get(null); // static field, so null "instance"
                     Method m = MGF1ParameterSpec.class.getDeclaredMethod("getDigestAlgorithm");
                     String digest = (String) m.invoke(o);
-                    // NOTE: AWS-LC doesn't support SHA-512/224
-                    if ("SHA-512/224".equals(digest)) {
+                    // NOTE: AWS-LC doesn't support SHA-512/224 or SHA3
+                    if ("SHA-512/224".equals(digest) || !digest.startsWith("SHA-")) {
                         continue;
                     }
                     digests.add(digest);

--- a/tst/com/amazon/corretto/crypto/provider/test/RsaCipherTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/RsaCipherTest.java
@@ -187,10 +187,10 @@ public class RsaCipherTest {
 
         final KeyPair keyPair = getKeyPair(keySize);
         Cipher cipher = getNativeCipher(padding);
-        cipher.init(Cipher.ENCRYPT_MODE, keyPair.getPublic());
+        cipher.init(Cipher.ENCRYPT_MODE, keyPair.getPublic(), oaep);
         byte[] ciphertext = cipher.doFinal(plaintext, 1, plaintext.length - 1);
 
-        cipher.init(Cipher.DECRYPT_MODE, keyPair.getPrivate());
+        cipher.init(Cipher.DECRYPT_MODE, keyPair.getPrivate(), oaep);
 
         byte[] result = new byte[cipher.getOutputSize(ciphertext.length) + 2];
         int resultLen = cipher.doFinal(ciphertext, 0, ciphertext.length, result, 2);
@@ -210,14 +210,14 @@ public class RsaCipherTest {
 
         final KeyPair keyPair = getKeyPair(keySize);
         Cipher cipher = getNativeCipher(padding);
-        cipher.init(Cipher.ENCRYPT_MODE, keyPair.getPublic());
+        cipher.init(Cipher.ENCRYPT_MODE, keyPair.getPublic(), oaep);
         byte[] ciphertext = new byte[cipher.getOutputSize(plaintext.length) + 2];
         int ciphertextLen = cipher.doFinal(plaintext, 0, plaintext.length, ciphertext, 1);
 
         // Shift the ciphertext over before reading
         System.arraycopy(ciphertext, 1, ciphertext, 2, ciphertext.length - 2);
 
-        cipher.init(Cipher.DECRYPT_MODE, keyPair.getPrivate());
+        cipher.init(Cipher.DECRYPT_MODE, keyPair.getPrivate(), oaep);
 
         byte[] result = cipher.doFinal(ciphertext, 2, ciphertextLen);
 
@@ -273,7 +273,7 @@ public class RsaCipherTest {
     public void overlargeCiphertext(final String padding, final Integer keySize, final OAEPParameterSpec oaep)
             throws GeneralSecurityException {
         final Cipher nativeEncrypt = getNativeCipher(padding);
-        nativeEncrypt.init(Cipher.DECRYPT_MODE, getKeyPair(keySize).getPrivate());
+        nativeEncrypt.init(Cipher.DECRYPT_MODE, getKeyPair(keySize).getPrivate(), oaep);
 
         byte[] ciphertext = new byte[(keySize / 8) + 1];
         Arrays.fill(ciphertext, (byte) 1); // All zeroes isn't a valid ciphertext
@@ -485,8 +485,8 @@ public class RsaCipherTest {
 
         final byte[] plaintext = getPlaintext((keySize / 8) - getPaddingSize(padding, oaep));
         final KeyPair keyPair = getKeyPair(keySize);
-        nativeC.init(Cipher.ENCRYPT_MODE, keyPair.getPublic());
-        jceC.init(Cipher.DECRYPT_MODE, keyPair.getPrivate());
+        nativeC.init(Cipher.ENCRYPT_MODE, keyPair.getPublic(), oaep);
+        jceC.init(Cipher.DECRYPT_MODE, keyPair.getPrivate(), oaep);
 
         nativeC.update(plaintext, 0, plaintext.length / 2);
         nativeC.update(plaintext, plaintext.length / 2, plaintext.length - (plaintext.length / 2));
@@ -504,8 +504,8 @@ public class RsaCipherTest {
 
         final byte[] plaintext = getPlaintext((keySize / 8) - getPaddingSize(padding, oaep));
         final KeyPair keyPair = getKeyPair(keySize);
-        nativeC.init(Cipher.ENCRYPT_MODE, keyPair.getPublic());
-        jceC.init(Cipher.DECRYPT_MODE, keyPair.getPrivate());
+        nativeC.init(Cipher.ENCRYPT_MODE, keyPair.getPublic(), oaep);
+        jceC.init(Cipher.DECRYPT_MODE, keyPair.getPrivate(), oaep);
 
         nativeC.update(plaintext, 0, plaintext.length / 2);
         nativeC.update(plaintext, plaintext.length / 2, plaintext.length - (plaintext.length / 2) - 1);
@@ -528,8 +528,8 @@ public class RsaCipherTest {
         final Cipher dec = getNativeCipher(padding);
 
         final byte[] plaintext = getPlaintext(keySize / 8 - getPaddingSize(padding, oaep));
-        enc.init(Cipher.ENCRYPT_MODE, keyPair.getPublic());
-        dec.init(Cipher.DECRYPT_MODE, strippedKey);
+        enc.init(Cipher.ENCRYPT_MODE, keyPair.getPublic(), oaep);
+        dec.init(Cipher.DECRYPT_MODE, strippedKey, oaep);
 
         final byte[] ciphertext = enc.doFinal(plaintext);
         final byte[] decrypted = dec.doFinal(ciphertext);
@@ -553,7 +553,7 @@ public class RsaCipherTest {
 
         final Cipher cipher = getNativeCipher(padding);
 
-        TestUtil.assertThrows(InvalidKeyException.class, () -> cipher.init(Cipher.DECRYPT_MODE, privateKey));
+        TestUtil.assertThrows(InvalidKeyException.class, () -> cipher.init(Cipher.DECRYPT_MODE, privateKey, oaep));
     }
 
     @ParameterizedTest
@@ -565,8 +565,8 @@ public class RsaCipherTest {
 
         final byte[] plaintext = getPlaintext((keySize / 8) - getPaddingSize(padding, oaep));
         final KeyPair keyPair = getKeyPair(keySize);
-        enc.init(Cipher.ENCRYPT_MODE, keyPair.getPublic());
-        dec.init(Cipher.DECRYPT_MODE, keyPair.getPrivate());
+        enc.init(Cipher.ENCRYPT_MODE, keyPair.getPublic(), oaep);
+        dec.init(Cipher.DECRYPT_MODE, keyPair.getPrivate(), oaep);
 
         final byte[] output = new byte[(keySize / 8) - 1];
         try {
@@ -703,7 +703,7 @@ public class RsaCipherTest {
         plaintext[plaintext.length - 1] = 2;
         final byte[] ciphertext = enc.doFinal(plaintext);
         final Cipher dec = getNativeCipher(padding);
-        dec.init(Cipher.DECRYPT_MODE, keyPair.getPrivate());
+        dec.init(Cipher.DECRYPT_MODE, keyPair.getPrivate(), oaep);
         assertThrows(BadPaddingException.class, () -> dec.doFinal(ciphertext));
     }
 
@@ -719,7 +719,7 @@ public class RsaCipherTest {
         Arrays.fill(plaintext, (byte) 1);
         byte[] ciphertext = enc.doFinal(plaintext);
         final Cipher dec = getNativeCipher(padding);
-        dec.init(Cipher.DECRYPT_MODE, keyPair.getPrivate());
+        dec.init(Cipher.DECRYPT_MODE, keyPair.getPrivate(), oaep);
         assertThrows(BadPaddingException.class, () -> dec.doFinal(ciphertext));
     }
 
@@ -745,7 +745,7 @@ public class RsaCipherTest {
             throws Exception {
         final Cipher dec = getNativeCipher(padding);
         final KeyPair keyPair = getKeyPair(keySize);
-        dec.init(Cipher.DECRYPT_MODE, keyPair.getPrivate());
+        dec.init(Cipher.DECRYPT_MODE, keyPair.getPrivate(), oaep);
         byte[] plaintext = ((RSAPublicKey) keyPair.getPublic()).getModulus().toByteArray();
         // Strip leading zero sign bit/byte if present
         if (plaintext[0] == 0) {


### PR DESCRIPTION
*Issue #, if available:*

CryptoAlg-1035

*Description of changes:*

This commit implements support for specifying SHA2 digests in RSA OAEP
padding, for both the primary digest algorithm as well as MGF1's digest
algorithm. Due to documented ambiguities in String-specified parameters
(see [here][1]), we only support non-default OAEP parameter
specification by passing an appropriate `OAEPParameterSpec` into
`Cipher.init`.

Upon encountering an as-yet unseen digest algorithm, `RsaCipher` will
call AWS-LC over the JNI to validate that algorithm, obtain a pointer to
its struct representation, ascertain the algorithm's digest size, and
(statically) cache all of that for future reference. The digest struct
pointer is then passed down to AWS-LC when invoking the cipher. These
struct pointers remain constant through the process's lifetime, so we
don't need to worry about cache staleness or invalidation.

Finally, we migrate `rsa_cipher.cpp` to use the EVP API exclusively for
all RSA encryption and decryption.

[1]: https://quip-amazon.com/h34QAjnEF1bH/Humboldt-ACCP-Integration#temp:C:JTP49fd24edba3a7dcd8aab0425d

# ToDo
- [x] parameterize more extant tests with new PSS params
- [x] add test case to ensure we disallow MD5 and other "valid" but undesirable hash algorithms
- [ ]  determine if/which KATs we want to add

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
