### PR TITLE
 Support PSS padding for RSA signatures

### DIFF
--- a/DIFFERENCES.md
+++ b/DIFFERENCES.md
@@ -59,7 +59,7 @@ Any time an instance of `SecureRandom` is used, ACCP routes the requests to the 
 Because the output of calls to `SecureRandom` is computationally indistinguishable from actual random data, this implementation detail has no impact on callers other than improving performance.
 
 ## RSASSA-PSS Signature parameters may not be updated in-flight
-To prevent callers from corrupting their signatures, we forbid them from updating a Signature's PSSParameterSpec while they are still updating a Signature object. Once the Signature has been updated, it must be reset, `sign()`'d, or `verify`'d before the PSS parameters may be updated.
+To prevent callers from corrupting their signatures, we forbid them from updating a Signature's PSSParameterSpec while they are still updating a Signature object. Once the Signature has been updated, it must be reset, `sign()`'d, or `verify`'d before the PSS parameters may be updated. If a caller attempts to call `Signature.setParameter(...)` while a Signature instance has buffered data, we will throw an `IllegalStateException`.
 
 # Extensions
 Applications are unlikely to directly encounter any of these changes but may choose to take advantage of them.

--- a/DIFFERENCES.md
+++ b/DIFFERENCES.md
@@ -58,6 +58,9 @@ To avoid the costs of both RNG initialization and thread contention, ACCP mainta
 Any time an instance of `SecureRandom` is used, ACCP routes the requests to the appropriate backing instance for the calling thread.
 Because the output of calls to `SecureRandom` is computationally indistinguishable from actual random data, this implementation detail has no impact on callers other than improving performance.
 
+## RSASSA-PSS Signature parameters may not be updated in-flight
+To prevent callers from corrupting their signatures, we forbid them from updating a Signature's PSSParameterSpec while they are still updating a Signature object. Once the Signature has been updated, it must be reset, `sign()`'d, or `verify`'d before the PSS parameters may be updated.
+
 # Extensions
 Applications are unlikely to directly encounter any of these changes but may choose to take advantage of them.
 

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ Cipher algorithms:
 * AES_256/GCM/NoPadding
 * RSA/ECB/NoPadding
 * RSA/ECB/PKCS1Padding
+* RSA/ECB/OAEPPadding
 * RSA/ECB/OAEPWithSHA-1AndMGF1Padding
-
 
 Signature algorithms:
 * SHA1withRSA
@@ -63,6 +63,7 @@ Signature algorithms:
 * SHA384withECDSAinP1363Format
 * SHA512withECDSA
 * SHA512withECDSAinP1363Format
+* RSASSA-PSS
 
 KeyPairGenerator algorithms:
 * EC

--- a/build.gradle
+++ b/build.gradle
@@ -16,9 +16,20 @@ def awslcSrcPath = "aws-lc/"
 
 configurations {
     jacocoAgent
-    testDep.extendsFrom(jacocoAgent)
+    testDep {
+        extendsFrom(jacocoAgent)
+        attributes {
+            // Make sure gradle knows to resolve the dependency which actually has the code
+            attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling, 'external'))
+        }
+    }
     stagingJar
-    testRunner
+    testRunner {
+        attributes {
+            // Make sure gradle knows to resolve the dependency which actually has the code
+            attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling, 'external'))
+        }
+    }
     checkstyle
 }
 
@@ -31,13 +42,14 @@ dependencies {
     jacocoAgent group: 'org.jacoco', name: 'org.jacoco.agent', version: '0.8.7', classifier: 'runtime'
 
     // Separate so we can extract the jar for the runner specifically
-    testRunner group: 'org.junit.platform', name: 'junit-platform-console-standalone', version: '1.6.2'
+    testRunner group: 'org.junit.platform', name: 'junit-platform-console-standalone', version: '1.8.2'
 
     // Separate so we can extract the jar for the checker specifically
     checkstyle group: 'com.puppycrawl.tools', name: 'checkstyle', version: '9.3'
 
-    testDep 'org.junit.jupiter:junit-jupiter:5.6.2'
-    testDep 'org.junit.vintage:junit-vintage-engine:5.6.2'
+    testDep 'org.apiguardian:apiguardian-api:1.1.2'
+    testDep 'org.junit.jupiter:junit-jupiter:5.8.2'
+    testDep 'org.junit.vintage:junit-vintage-engine:5.8.2'
     testDep 'org.bouncycastle:bcprov-debug-jdk15on:1.69'
     testDep 'org.bouncycastle:bcpkix-jdk15on:1.69'
     testDep 'commons-codec:commons-codec:1.12'

--- a/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
+++ b/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
@@ -101,6 +101,7 @@ public final class AmazonCorrettoCryptoProvider extends java.security.Provider {
             }
         }
 
+        addService("Signature", "RSASSA-PSS", "EvpSignature$RSASSA_PSS");
         addService("Signature", "NONEwithECDSA", "EvpSignatureRaw$NONEwithECDSA");
     }
 

--- a/src/com/amazon/corretto/crypto/provider/EvpSignature.java
+++ b/src/com/amazon/corretto/crypto/provider/EvpSignature.java
@@ -333,11 +333,12 @@ class EvpSignature extends EvpSignatureBase {
     }
 
     private InputBuffer<byte[], EvpContext, RuntimeException> getSigningBuffer() {
-        final String pssMgfMd = pssParams_ != null
-            ? Utils.jceDigestNameToAwsLcName(
-                ((MGF1ParameterSpec) pssParams_.getMGFParameters()).getDigestAlgorithm()
-            )
-            : null;
+        final String pssMgfMd;
+        if (pssParams_ != null) {
+            pssMgfMd = Utils.jceDigestNameToAwsLcName(((MGF1ParameterSpec) pssParams_.getMGFParameters()).getDigestAlgorithm());
+        } else {
+            pssMgfMd = null;
+        }
         final int pssSaltLen = pssParams_ != null ? pssParams_.getSaltLength() : 0;
         return new InputBuffer<byte[], EvpContext, RuntimeException>(1024)
             .withInitialUpdater((src, offset, length) ->
@@ -369,11 +370,14 @@ class EvpSignature extends EvpSignatureBase {
     }
 
     private InputBuffer<Boolean, EvpContext, SignatureException> getVerifyingBuffer() {
-        final String pssMgfMd = pssParams_ != null
-            ? Utils.jceDigestNameToAwsLcName(
+        final String pssMgfMd;
+        if (pssParams_ != null) {
+            pssMgfMd = Utils.jceDigestNameToAwsLcName(
                 ((MGF1ParameterSpec) pssParams_.getMGFParameters()).getDigestAlgorithm()
-            )
-            : null;
+            );
+        } else {
+            pssMgfMd = null;
+        }
         final int pssSaltLen = pssParams_ != null ? pssParams_.getSaltLength() : 0;
         return new InputBuffer<Boolean, EvpContext, SignatureException>(1024)
             .withInitialUpdater((src, offset, length) ->

--- a/src/com/amazon/corretto/crypto/provider/EvpSignature.java
+++ b/src/com/amazon/corretto/crypto/provider/EvpSignature.java
@@ -4,8 +4,12 @@
 package com.amazon.corretto.crypto.provider;
 
 import java.nio.ByteBuffer;
+import java.security.InvalidAlgorithmParameterException;
 import java.security.SignatureException;
+import java.security.spec.AlgorithmParameterSpec;
 import java.security.spec.PKCS8EncodedKeySpec;
+import java.security.spec.MGF1ParameterSpec;
+import java.security.spec.PSSParameterSpec;
 import java.security.spec.X509EncodedKeySpec;
 
 class EvpSignature extends EvpSignatureBase {
@@ -301,10 +305,10 @@ class EvpSignature extends EvpSignatureBase {
      */
     private static native boolean verifyFinish(long ctx, byte[] signature, int sigOff, int sigLen) throws SignatureException;
 
-    private final String digestName_;
+    private String digestName_;
     private byte[] oneByteArray_ = null;
-    private final InputBuffer<byte[], EvpContext, RuntimeException> signingBuffer;
-    private final InputBuffer<Boolean, EvpContext, SignatureException> verifyingBuffer;
+    private InputBuffer<byte[], EvpContext, RuntimeException> signingBuffer;
+    private InputBuffer<Boolean, EvpContext, SignatureException> verifyingBuffer;
 
     /**
      * Creates a new instances of this class.
@@ -324,17 +328,28 @@ class EvpSignature extends EvpSignatureBase {
         Loader.checkNativeLibraryAvailability();
         digestName_ = digestName;
 
-        signingBuffer = new InputBuffer<byte[], EvpContext, RuntimeException>(1024)
+        signingBuffer = getSigningBuffer();
+        verifyingBuffer = getVerifyingBuffer();
+    }
+
+    private InputBuffer<byte[], EvpContext, RuntimeException> getSigningBuffer() {
+        final String pssMgfMd = pssParams_ != null
+            ? Utils.jceDigestNameToAwsLcName(
+                ((MGF1ParameterSpec) pssParams_.getMGFParameters()).getDigestAlgorithm()
+            )
+            : null;
+        final int pssSaltLen = pssParams_ != null ? pssParams_.getSaltLength() : 0;
+        return new InputBuffer<byte[], EvpContext, RuntimeException>(1024)
             .withInitialUpdater((src, offset, length) ->
                 new EvpContext(key_.use(ptr ->
                     signStart(ptr,
-                        digestName_, paddingType_, null, 0,
+                        digestName_, paddingType_, pssMgfMd, pssSaltLen,
                         src, offset, length)))
             )
             .withInitialUpdater((src) ->
                 new EvpContext(key_.use(ptr ->
                     signStartBuffer(ptr,
-                        digestName_, paddingType_, null, 0, src)))
+                        digestName_, paddingType_, pssMgfMd, pssSaltLen, src)))
             )
             .withUpdater((ctx, src, offset, length) ->
                 ctx.useVoid(ptr -> signUpdate(ptr, src, offset, length))
@@ -348,20 +363,29 @@ class EvpSignature extends EvpSignatureBase {
             .withSinglePass((src, offset, length) ->
                 key_.use(ptr ->
                     sign(ptr,
-                            digestName_, paddingType, null, 0,
+                            digestName_, paddingType_, pssMgfMd, pssSaltLen,
                             src, offset, length))
             );
-        verifyingBuffer = new InputBuffer<Boolean, EvpContext, SignatureException>(1024)
+    }
+
+    private InputBuffer<Boolean, EvpContext, SignatureException> getVerifyingBuffer() {
+        final String pssMgfMd = pssParams_ != null
+            ? Utils.jceDigestNameToAwsLcName(
+                ((MGF1ParameterSpec) pssParams_.getMGFParameters()).getDigestAlgorithm()
+            )
+            : null;
+        final int pssSaltLen = pssParams_ != null ? pssParams_.getSaltLength() : 0;
+        return new InputBuffer<Boolean, EvpContext, SignatureException>(1024)
             .withInitialUpdater((src, offset, length) ->
                 new EvpContext(key_.use(ptr ->
                     verifyStart(ptr, digestName_,
-                        paddingType_, null, 0,
+                        paddingType_, pssMgfMd, pssSaltLen,
                         src, offset, length)))
             )
             .withInitialUpdater((src) ->
                 new EvpContext(key_.use(ptr ->
                     verifyStartBuffer(ptr,
-                        digestName_, paddingType_, null, 0, src)))
+                        digestName_, paddingType_, pssMgfMd, pssSaltLen, src)))
             )
             .withUpdater((ctx, src, offset, length) ->
                 ctx.useVoid(ptr -> verifyUpdate(ptr, src, offset, length))
@@ -376,6 +400,23 @@ class EvpSignature extends EvpSignatureBase {
     protected synchronized void engineReset() {
         signingBuffer.reset();
         verifyingBuffer.reset();
+    }
+
+    @Override
+    protected synchronized void engineSetParameter(final AlgorithmParameterSpec params)
+            throws InvalidAlgorithmParameterException {
+        super.engineSetParameter(params);
+        if (params instanceof PSSParameterSpec) {
+            final String jceDigestName = ((PSSParameterSpec) params).getDigestAlgorithm();
+            digestName_ = Utils.jceDigestNameToAwsLcName(jceDigestName);
+            // referesh signing and verifying buffer closures now that we've updated PSS params
+            signingBuffer = getSigningBuffer();
+            verifyingBuffer = getVerifyingBuffer();
+        }
+    }
+
+    protected boolean isBufferEmpty() {
+        return signingBuffer.size() == 0 && verifyingBuffer.size() == 0;
     }
 
     @Override
@@ -441,6 +482,12 @@ class EvpSignature extends EvpSignatureBase {
             finalOff = off;
             finalLen = len;
         }
+        final String pssMgfMd = pssParams_ != null
+            ? Utils.jceDigestNameToAwsLcName(
+                ((MGF1ParameterSpec) pssParams_.getMGFParameters()).getDigestAlgorithm()
+            )
+            : null;
+        final int pssSaltLen = pssParams_ != null ? pssParams_.getSaltLength() : 0;
         try {
             return verifyingBuffer
                 .withDoFinal((ctx) ->
@@ -448,7 +495,7 @@ class EvpSignature extends EvpSignatureBase {
                 )
                 .withSinglePass((src, offset, length) ->
                     key_.use(ptr -> verify(ptr,
-                        digestName_, paddingType_, null, 0,
+                        digestName_, paddingType_, pssMgfMd, pssSaltLen,
                         src, offset, length, finalSigBytes, finalOff, finalLen))
                 ).doFinal();
         } finally {
@@ -485,6 +532,12 @@ class EvpSignature extends EvpSignatureBase {
     static final class SHA512withRSA extends EvpSignature {
         SHA512withRSA(AmazonCorrettoCryptoProvider provider) {
             super(provider, EvpKeyType.RSA, RSA_PKCS1_PADDING, "sha512");
+        }
+    }
+
+    static final class RSASSA_PSS extends EvpSignature {
+        RSASSA_PSS(AmazonCorrettoCryptoProvider provider) {
+            super(provider, EvpKeyType.RSA, RSA_PKCS1_PSS_PADDING, null);
         }
     }
 

--- a/src/com/amazon/corretto/crypto/provider/EvpSignatureBase.java
+++ b/src/com/amazon/corretto/crypto/provider/EvpSignatureBase.java
@@ -169,7 +169,8 @@ abstract class EvpSignatureBase extends SignatureSpi {
             final int saltLen = pssParams.getSaltLength();
             final int mdLen = Utils.getMdLen(Utils.getMdPtr(pssParams.getDigestAlgorithm()));
             // If key is not yet set, assume it has a 2048-bit modulus. Even if a smaller key ends up being
-            // used, AWS-LC will detect this and throw an error.
+            // used, AWS-LC will detect this and throw an error here:
+            // https://github.com/awslabs/aws-lc/blob/main/crypto/fipsmodule/rsa/padding.c#L661
             final int emLen = key_ != null
                 ? (((RSAKey) key_).getModulus().bitLength() + 7) / 8
                 : 2048 / 8;

--- a/src/com/amazon/corretto/crypto/provider/EvpSignatureBase.java
+++ b/src/com/amazon/corretto/crypto/provider/EvpSignatureBase.java
@@ -5,6 +5,7 @@ package com.amazon.corretto.crypto.provider;
 
 import java.math.BigInteger;
 import java.security.AlgorithmParameters;
+import java.security.GeneralSecurityException;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.InvalidParameterException;
@@ -14,7 +15,10 @@ import java.security.PublicKey;
 import java.security.SignatureException;
 import java.security.SignatureSpi;
 import java.security.interfaces.ECKey;
+import java.security.interfaces.RSAKey;
 import java.security.spec.AlgorithmParameterSpec;
+import java.security.spec.MGF1ParameterSpec;
+import java.security.spec.PSSParameterSpec;
 import java.util.Arrays;
 import java.util.Base64;
 
@@ -22,14 +26,16 @@ abstract class EvpSignatureBase extends SignatureSpi {
     // Package visible so main Provider can use it
     static final String P1363_FORMAT_SUFFIX = "inP1363Format";
     protected static final int RSA_PKCS1_PADDING = 1;
+    protected static final int RSA_PKCS1_PSS_PADDING = 6;
     protected final AmazonCorrettoCryptoProvider provider_;
     protected final EvpKeyType keyType_;
-    protected final int paddingType_;
+    protected int paddingType_;
     protected Key untranslatedKey_ = null;
     protected EvpKey key_ = null;
     protected boolean signMode;
     protected int keyUsageCount_ = 0;
     protected String algorithmName_ = null;
+    protected PSSParameterSpec pssParams_ = null;
 
     EvpSignatureBase(
             final AmazonCorrettoCryptoProvider provider,
@@ -39,6 +45,9 @@ abstract class EvpSignatureBase extends SignatureSpi {
         provider_ = provider;
         keyType_ = keyType;
         paddingType_ = paddingType;
+        if (paddingType_ == RSA_PKCS1_PSS_PADDING) {
+            pssParams_ = PSSParameterSpec.DEFAULT;
+        }
     }
 
     protected abstract void engineReset();
@@ -113,13 +122,81 @@ abstract class EvpSignatureBase extends SignatureSpi {
     @Override
     protected synchronized void engineSetParameter(final AlgorithmParameterSpec params)
             throws InvalidAlgorithmParameterException {
-        if (params != null) {
-            throw new InvalidAlgorithmParameterException("No parameters supported by this algorithm");
+        if (params instanceof PSSParameterSpec) {
+            if (!isBufferEmpty()) {
+                throw new IllegalStateException("Cannot update PSS parameters with buffered data, reset Signature.");
+            }
+            final PSSParameterSpec pssParams = (PSSParameterSpec) params;
+            if (keyType_ != EvpKeyType.RSA || paddingType_ != RSA_PKCS1_PSS_PADDING) {
+                throw new InvalidAlgorithmParameterException("PSS params only supported for RSASSA-PSS signatures");
+            }
+            if (!"MGF1".equals(pssParams.getMGFAlgorithm())) {
+                throw new InvalidAlgorithmParameterException("Invalid PSS MGF algorithm");
+            }
+            // 1 is currently the only supported trailer field:
+            //
+            // >  trailerField is the trailer field number, for compatibility with
+            // >  the draft IEEE P1363a [27].  It shall be 1 for this version of the
+            // >  document, which represents the trailer field with hexadecimal
+            // >  value 0xbc.  Other trailer fields (including the trailer field
+            // >  HashID || 0xcc in IEEE P1363a) are not supported in this document
+            //
+            // https://datatracker.ietf.org/doc/html/rfc3447#appendix-A.2.3
+            if (pssParams.getTrailerField() != PSSParameterSpec.DEFAULT.getTrailerField()) {
+                // NOTE: PSSParameterSpec throws IllegalArgumentException instead of InvalidAlgorithmParameterException
+                //       so we match that behavior here.
+                throw new IllegalArgumentException("Invalid PSS trailer field");
+            }
+            if (pssParams.getMGFParameters() == null) {
+                throw new InvalidAlgorithmParameterException("PSS parameters must specify MGF1 parameters");
+            }
+            // Cache MD struct ptrs, validate digest names and salt len, update params
+            try {
+                Utils.getMdPtr(pssParams.getDigestAlgorithm());
+                Utils.getMdPtr(((MGF1ParameterSpec) pssParams.getMGFParameters()).getDigestAlgorithm());
+            } catch (Exception e) {
+                throw new InvalidAlgorithmParameterException();
+            }
+            // RFC 3447 does not specify an explicit max or min on salt lengh,
+            // but does constrain it relative to other parameters:
+            //
+            // > If emLen < hLen + sLen + 2, output "encoding error" and stop.
+            //
+            // https://datatracker.ietf.org/doc/html/rfc3447#section-9.1.1
+            //
+            // Additionally, AWS-LC reserves negative salt lengths:
+            // https://github.com/awslabs/aws-lc/blob/main/crypto/fipsmodule/rsa/padding.c#L649-L662
+            final int saltLen = pssParams.getSaltLength();
+            final int mdLen = Utils.getMdLen(Utils.getMdPtr(pssParams.getDigestAlgorithm()));
+            // If key is not yet set, assume it has a 2048-bit modulus. Even if a smaller key ends up being
+            // used, AWS-LC will detect this and throw an error.
+            final int emLen = key_ != null
+                ? (((RSAKey) key_).getModulus().bitLength() + 7) / 8
+                : 2048 / 8;
+            if (saltLen < 0 || saltLen > emLen - mdLen - 2) {
+                // NOTE: PSSParameterSpec throws IllegalArgumentException instead of InvalidAlgorithmParameterException
+                //       so we match that behavior here.
+                throw new IllegalArgumentException("PSS salt length invalid");
+            }
+            pssParams_ = pssParams;
+        } else if (params != null) {
+            throw new InvalidAlgorithmParameterException("Specified parameters supported by this algorithm");
         }
     }
 
+    protected abstract boolean isBufferEmpty();
+
     @Override
     protected synchronized AlgorithmParameters engineGetParameters() {
+        if (paddingType_ == RSA_PKCS1_PSS_PADDING && pssParams_ != null) {
+            try {
+                final AlgorithmParameters params = AlgorithmParameters.getInstance("RSASSA-PSS");
+                params.init(pssParams_);
+                return params;
+            } catch (final GeneralSecurityException ex) {
+                throw new AssertionError(ex);
+            }
+        }
         return null;
     }
 

--- a/src/com/amazon/corretto/crypto/provider/EvpSignatureBase.java
+++ b/src/com/amazon/corretto/crypto/provider/EvpSignatureBase.java
@@ -123,12 +123,12 @@ abstract class EvpSignatureBase extends SignatureSpi {
     protected synchronized void engineSetParameter(final AlgorithmParameterSpec params)
             throws InvalidAlgorithmParameterException {
         if (params instanceof PSSParameterSpec) {
-            if (!isBufferEmpty()) {
-                throw new IllegalStateException("Cannot update PSS parameters with buffered data, reset Signature.");
-            }
             final PSSParameterSpec pssParams = (PSSParameterSpec) params;
             if (keyType_ != EvpKeyType.RSA || paddingType_ != RSA_PKCS1_PSS_PADDING) {
                 throw new InvalidAlgorithmParameterException("PSS params only supported for RSASSA-PSS signatures");
+            }
+            if (!isBufferEmpty()) {
+                throw new IllegalStateException("Cannot update PSS parameters with buffered data, reset Signature.");
             }
             if (!"MGF1".equals(pssParams.getMGFAlgorithm())) {
                 throw new InvalidAlgorithmParameterException("Invalid PSS MGF algorithm");

--- a/src/com/amazon/corretto/crypto/provider/EvpSignatureRaw.java
+++ b/src/com/amazon/corretto/crypto/provider/EvpSignatureRaw.java
@@ -58,6 +58,10 @@ class EvpSignatureRaw extends EvpSignatureBase {
         }
     }
 
+    protected boolean isBufferEmpty() {
+        return buffer.size() == 0;
+    }
+
     private static native byte[] signRaw(long privateKey, int paddingType, String mgfMd, int saltLen, byte[] message,
             int offset, int length);
 

--- a/src/com/amazon/corretto/crypto/provider/InputBuffer.java
+++ b/src/com/amazon/corretto/crypto/provider/InputBuffer.java
@@ -231,6 +231,15 @@ public class InputBuffer<T, S, X extends Throwable> implements Cloneable {
           @*/
     }
 
+    /*@ public normal_behavior
+      @   assignable size;
+      @   requires true;
+      @   ensures true;
+      @*/
+    public int size() {
+        return buff.size();
+    }
+
     //@ // optional updater, does not change bufferState
     //@ normal_behavior
     //@   requires canSetHandler(bufferState);

--- a/src/com/amazon/corretto/crypto/provider/Utils.java
+++ b/src/com/amazon/corretto/crypto/provider/Utils.java
@@ -78,13 +78,13 @@ final class Utils {
         // invoking the native Utils.getEvpMdFromName can also throw an unchecked exception,
         // so callers already need to handle this.
         if (!name.startsWith("SHA")) {
-            throw new RuntimeException("Unsupported digest algorithm");
+            throw new IllegalArgumentException("Unsupported digest algorithm");
         }
-        return digestPtrByName.computeIfAbsent(name, n -> Utils.getEvpMdFromName(n));
+        return digestPtrByName.computeIfAbsent(name, Utils::getEvpMdFromName);
     }
 
     static int getMdLen(long mdPtr) {
-        return digestLengthByPtr.computeIfAbsent(mdPtr, p -> Utils.getDigestLength(p));
+        return digestLengthByPtr.computeIfAbsent(mdPtr, Utils::getDigestLength);
     }
 
     /**

--- a/src/com/amazon/corretto/crypto/provider/Utils.java
+++ b/src/com/amazon/corretto/crypto/provider/Utils.java
@@ -20,7 +20,7 @@ import java.security.spec.X509EncodedKeySpec;
 import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.Map;
-import java.util.HashMap;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Logger;
 
 import javax.crypto.Cipher;
@@ -38,8 +38,8 @@ final class Utils {
     static final byte[] EMPTY_ARRAY = new byte[0];
     private static final Logger LOG = Logger.getLogger("AmazonCorrettoCryptoProvider");
 
-    private static final Map<String,Long> digestPtrByName = new HashMap<>();
-    private static final Map<Long,Integer> digestLengthByPtr = new HashMap<>();
+    private static final Map<String,Long> digestPtrByName = new ConcurrentHashMap<>();
+    private static final Map<Long,Integer> digestLengthByPtr = new ConcurrentHashMap<>();
 
     /**
      * Returns the difference between the native pointers of a and b. That is, if overlap > 0, then

--- a/tst/com/amazon/corretto/crypto/provider/test/EvpSignatureSpecificTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/EvpSignatureSpecificTest.java
@@ -501,7 +501,7 @@ public final class EvpSignatureSpecificTest {
         // Assert that doFinal (i.e. the native method called in signer.sign()) detects overly large salt len and throws
         byte[] shortMessage = new byte[] { (byte) 0xDE, (byte) 0xAD, (byte) 0xBE, (byte) 0xEF };
         signer.update(shortMessage);
-        assertThrows(RuntimeCryptoException.class, () -> signer.sign());
+        assertThrows(SignatureException.class, () -> signer.sign());
 
         // After re-initializing with minimally secure RSA key, longer salt len set earlier should be fine.
         kg.initialize(minimallySecureKeyLen);

--- a/tst/com/amazon/corretto/crypto/provider/test/EvpSignatureTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/EvpSignatureTest.java
@@ -82,9 +82,7 @@ public class EvpSignatureTest {
             this.paramSpec = paramSpec;
 
             signer = getNativeSigner();
-            if (paramSpec != null) {
-                signer.setParameter(paramSpec);
-            }
+            signer.setParameter(paramSpec);
             signer.initSign(keyPair.getPrivate());
             verifier = getNativeSigner();
             verifier.setParameter(paramSpec);
@@ -114,22 +112,23 @@ public class EvpSignatureTest {
         @Override
         public String toString() {
             final PSSParameterSpec pssParamSpec = (PSSParameterSpec) paramSpec;
-            final String pssParams = pssParamSpec == null
-                ? null
-                : String.format(
+            final String pssParamsStr;
+            if (pssParamSpec != null) {
+                pssParamsStr = String.format(
                     "{PSS md: %s, MGF1 md: %s, saltLen: %d}",
                     pssParamSpec.getDigestAlgorithm(),
-                    pssParamSpec.getMGFParameters() == null
-                        ? null
-                        : ((MGF1ParameterSpec) pssParamSpec.getMGFParameters()).getDigestAlgorithm(),
+                    ((MGF1ParameterSpec) pssParamSpec.getMGFParameters()).getDigestAlgorithm(),
                     pssParamSpec.getSaltLength()
                 );
+            } else {
+                pssParamsStr = null;
+            }
             return String.format("%s length %s. Read-only: %s, Sliced: %s, PSS: %s",
                     algorithm,
                     length,
                     readOnly,
                     slice,
-                    pssParams
+                    pssParamsStr
             );
         }
 
@@ -239,7 +238,8 @@ public class EvpSignatureTest {
                         }
                     }
 
-                    if (base.equals("RSA")) {
+                    // RSASSA-PSS support added in 2.0, skip PSS validation for older versions
+                    if (base.equals("RSA") && versionCompare("2.0.0", NATIVE_PROVIDER) <= 0) {
                         algorithm = "RSASSA-PSS";
                         final List<String> paddingHashes = new ArrayList<>(HASHES);
                         assertFalse(paddingHashes.contains(null));


### PR DESCRIPTION
*Issue #, if available:*

CryptoAlg-1036

*Description of changes:*

# Status
- PR ready to review
- the (many) new parameterized test cases in EvpSignatureTest are causing CodeBuild timeouts in the legacy `accp_github_pr` CodeBuild job that lives in corretto's account
    - this job runs the tests 3 times back-to-back, and will be removed soon in favor of the `accp-ci-pr-*` CodeBuild Batchs that provide the same coverage across a greater number of platforms and CPU architectures.
    - we'll be deleting this check soon, so reviewers can ignore it for the purposes of this review if it's still failing.

# Testing
- new parameterized unit test dimensions added for PSS changes
- for JUnit version bump, I reverted the threadsafety change and was able to reproduce randomly failing EvpSignatureTests under JUnit 5.8. Upon un-reverting the thread safety changes and tunning the tests under JUnit 5.8, the all pass.

# Description

This commit adds a [new flavor of RSA Signatures][1]: `RSASSA-PSS`.
PSS-padded RSA is described in [RFC 8017 section 8.1][2], with relevant
input parameter validation explained in [RFC 3447 section 9.1.1][3]. As
with OAEP RSA cipher padding, we mostly rely on AWS-LC to validate
message digest support, and explicity forbid anything outside of the SHA
family.

PSS allows users to specify the length (in bytes) of the randomly
generated salt. This value may not be less than 0 (JCE doesn't allow
negative salt lengths at all, and AWS-LC reserved them as special flag
values), so we enforce a minimum salt length of 0. The maximum is
specified in [RFC 3447 section 9.1.1][3], but relies on the key modulus
size to determine the maximum length. Since we don't always know the
key size when setParameter is called (key is specified on `init*`, and we
don't enforce ordering between calls to `setParameter` and `init*`), we
assume 2048 bit field size if no key is present. 2048 was selected
because it is the smallest field size that is still considered "secure",
and if a caller ends up using a smaller key, AWS-LC will detect this and
throw an error.

We switch the JCE provider for RSASSA-PSS parameterized tests in
EvpSignatureTest from BouncyCastle (BC) to [the SunRsaSign provider][6],
primarily due to differences in how they handle PSS parameters.
SunRsaSign [allows PSS message digest algorithm and MGF digest
algorithms to differ][4], while BC [does not][5]. So, in order to test
all possible combinations of PSS and MGF digest algorithms, we need to
migrate those tests to use SuncJCE as the JCE provider.

To increase compatibility accross providers, we allow callers to specify
`null` params in calls to `setParameter` (this is [consistent with
BC][7], but [not with SunRsaSign][8]. Similarly, we don't require
`setParameter` to be called on `RSASSA-PSS` instances before `init*` is
called, defaulting to digest algorithms of SHA1 unless otherwise
specified.

One point where we do diverge from SunRsaSign (but _not_ from BC) is
that we throw if callers attempt to update PSS parameters while
building or verifying a signature. We forbid this behavior to avoid
signature corruption due to digest algorithms being changed
while the signature/digest is still being updated.

Finally, @jakemas noted [a criticism][9] of PSS described by Peter
Gutman, the crux of which is:

> Now let's look at what an attacker can do with the above.  The
> immediately obvious, trivial attack is a hash-substitution attack.
> Unlike PKCS #1, PSS doesn't encode the hash algorithm used anywhere in
> the signature. [...] By changing hashAlgorithm to whatever you like, for
> example an algorithm of the same size that you know how to break, you
> can forge the signature.  Change the hash from SHA-2/256 to Streebog,
> Blake2, Keccak, CRC-256, XOR256, whatever you like, PSS won't detect the
> change, making it only as strong as the weakest hash algorithm of the
> same bit width that the victim will accept.

Unfortunately, because PSS is already standardized, there's not much we
can do to mitigate this in our impelementation. The main mitigation we
employ is to explicitly disallow non-SHA hash functions (e.g. MD5). All
SHA-family hash functions are currently believed to be secure for use in
PSS (indeed, the oldest, SHA1, is the default for Java) so no immediate
threat remains. If SHA1 is deemed insecure for use in PSS at some point
in the future, however, we will need to restrict its specification as a
PSS parameter.

[1]: https://docs.oracle.com/en/java/javase/11/docs/specs/security/standard-names.html#signature-algorithms
[2]: https://datatracker.ietf.org/doc/html/rfc8017#section-8.1
[3]: https://datatracker.ietf.org/doc/html/rfc3447#section-9.1.1
[4]: https://github.com/corretto/corretto-11/blob/f2c5b39cdb2afc9a9101620d14cf34c7448f826d/src/java.base/share/classes/sun/security/rsa/RSAPSSSignature.java#L290-L333
[5]: https://github.com/bcgit/bc-java/blob/bc3b92f1f0e78b82e2584c5fb4b226a13e7f8b3b/prov/src/main/java/org/bouncycastle/jcajce/provider/asymmetric/rsa/PSSSignatureSpi.java#L239-L242
[6]: https://docs.oracle.com/javase/7/docs/technotes/guides/security/SunProviders.html#SunRsaSignProvider
[7]: https://github.com/bcgit/bc-java/blob/bc3b92f1f0e78b82e2584c5fb4b226a13e7f8b3b/prov/src/main/java/org/bouncycastle/jcajce/provider/asymmetric/rsa/PSSSignatureSpi.java#L199-L207
[8]: https://github.com/corretto/corretto-11/blob/f2c5b39cdb2afc9a9101620d14cf34c7448f826d/src/java.base/share/classes/sun/security/rsa/RSAPSSSignature.java#L292-L294
[9]: https://marc.info/?l=cryptography&m=157345122116408&w=2


# ToDo
- [x] relax PSS salt lenght restrictions -- neither [the spec](https://datatracker.ietf.org/doc/html/rfc3447#appendix-A.2.3) nor [awslc](https://github.com/awslabs/aws-lc/blob/main/crypto/fipsmodule/rsa/padding.c#L649-L662) appear to enforce a cap on salt len beyond `mLen - hLen -2`
- [x] document above spec/impl. links, as well as [the `RSASSA-PSS` algorithm name required by JCE](https://docs.oracle.com/en/java/javase/11/docs/specs/security/standard-names.html)
- [x] clean up other ToDos
- [x] add `minimal_clean` gradle target that does a `rm build/cmake-coverage/*.jar build/lib/* build/awslc/bin/lib/libcrypto.so build/cmake/*.jar`
- [x] determine if/which KATs we want to add
- [x] parameterize PSS test case to test all SHA digest algorithms, salt lengths, etc.
- [x] add test case described [here](https://github.com/corretto/amazon-corretto-crypto-provider/pull/200/files/2f18616771b35ccde463e38363d06726c7556bea#r873938942)
- [x] Fix readme for both OAEP and PSS algorithms.

- [x] add test case to ensure we disallow MD5 and other "valid" but undesirable hash algorithms
- [x] parameterize more extant tests with new PSS params
- [x] address potential concern from @jakemas around [PSS criticism](https://marc.info/?l=cryptography&m=157345122116408&w=2) of not hashing/authenticating digest algorithm used in the signature. hwo might that affect which digest algorithms we'd support? should SHA-1 be rejected automatically (probably not as it seems to be the default).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
