### PR TITLE
Change EvpKey to not use EvpKeyContext and become stateless

### DIFF
--- a/csrc/auto_free.h
+++ b/csrc/auto_free.h
@@ -114,6 +114,14 @@
             }                                           \
             return PTR_NAME(name);                      \
         }                                               \
+        name* get()                                     \
+        {                                               \
+            return PTR_NAME(name);                      \
+        }                                               \
+        name** getAddressOfPtr()                        \
+        {                                               \
+            return &PTR_NAME(name);                     \
+        }                                               \
     }
 
 OPENSSL_auto(RSA);
@@ -122,6 +130,7 @@ OPENSSL_auto(EC_GROUP);
 OPENSSL_auto(EC_POINT);
 OPENSSL_auto(EC_KEY);
 OPENSSL_auto(BN_CTX);
+OPENSSL_auto(EVP_MD_CTX);
 OPENSSL_auto(EVP_PKEY);
 OPENSSL_auto(EVP_PKEY_CTX);
 

--- a/csrc/keyutils.h
+++ b/csrc/keyutils.h
@@ -12,61 +12,44 @@
 #include <openssl/x509.h>
 #include "util.h"
 #include "env.h"
+#include "auto_free.h"
 
 namespace AmazonCorrettoCryptoProvider {
 
+// This class should generally not be used for new development
+// as it has been replaced by the *_auto classes in auto_free.h
+// The only time this class should be used is when you *need* to keep various EVP objects together.
+// The only currently known *good* use for this class is tracking state when signing/verifying data.
+//
+// Since all but EVP_PKEY are stateful and likely to mutate while being used, this class is not threadsafe.
 class EvpKeyContext {
 public:
-    EvpKeyContext()
-        : digestCtx_(NULL), keyCtx_(NULL), key_(NULL) {}
-
-    virtual ~EvpKeyContext() {
-        if (digestCtx_) {
-            EVP_MD_CTX_destroy(digestCtx_);
-        }
-        if (keyCtx_) {
-            EVP_PKEY_CTX_free(keyCtx_);
-        }
-        if (key_) {
-            EVP_PKEY_free(key_);
-        }
-    }
-
-    EVP_MD_CTX* getDigestCtx() const { return digestCtx_; }
-    EVP_PKEY_CTX* getKeyCtx() const { return keyCtx_; }
-    EVP_PKEY* getKey() const { return key_; }
-    EVP_PKEY* get1Key() const {
+    EvpKeyContext() {} // Since we explicitly deleted constructors, the implicit one isn't generated for us.
+    EVP_MD_CTX* getDigestCtx() { return digestCtx_.get(); }
+    EVP_PKEY_CTX* getKeyCtx() { return keyCtx_.get(); }
+    EVP_PKEY* getKey() { return key_.get(); }
+    EVP_PKEY* get1Key() {
         EVP_PKEY_up_ref(key_);
-        return key_;
+        return getKey();
     }
-    EVP_PKEY** getKeyPtr() { return &key_; }
+    EVP_PKEY** getKeyPtr() { return key_.getAddressOfPtr(); }
 
     // If there was an old ctx, it is freed
     EVP_MD_CTX* setDigestCtx(EVP_MD_CTX* digestCtx) {
-        if (digestCtx_) {
-            EVP_MD_CTX_destroy(digestCtx_);
-        }
-        digestCtx_ = digestCtx;
-        return digestCtx_;
+        digestCtx_.set(digestCtx);
+        return getDigestCtx();
     }
 
     // If there was an old ctx, it is freed
     EVP_PKEY_CTX* setKeyCtx(EVP_PKEY_CTX* keyCtx) {
-        if (keyCtx_) {
-            EVP_PKEY_CTX_free(keyCtx_);
-        }
-
-        keyCtx_ = keyCtx;
-        return keyCtx_;
+        keyCtx_.set(keyCtx);
+        return getKeyCtx();
     }
 
     // If there was an old key, it is freed
     EVP_PKEY* setKey(EVP_PKEY* key) {
-        if (key_) {
-            EVP_PKEY_free(key_);
-        }
-        key_ = key;
-        return key_;
+        key_.set(key);
+        return getKey();
     }
 
     // Allocates a copy of this object on the heap and zeros
@@ -74,21 +57,18 @@ public:
     // to the new copy of this EvpKeyContext.
     EvpKeyContext* moveToHeap() {
         EvpKeyContext* result = new EvpKeyContext();
-        result->setKey(key_);
-        result->setDigestCtx(digestCtx_);
-        result->setKeyCtx(keyCtx_);
+        // Move the pointers and ownership to the new object.
+        result->setKey(key_.take());
+        result->setDigestCtx(digestCtx_.take());
+        result->setKeyCtx(keyCtx_.take());
 
-        // Zero our pointers so we don't free anything upon destruction
-        digestCtx_ = NULL;
-        keyCtx_ = NULL;
-        key_ = NULL;
         return result;
     }
 
 private:
-    EVP_MD_CTX* digestCtx_;
-    EVP_PKEY_CTX* keyCtx_;
-    EVP_PKEY* key_;
+    EVP_MD_CTX_auto digestCtx_;
+    EVP_PKEY_CTX_auto keyCtx_;
+    EVP_PKEY_auto key_;
 
     // Disable copy & copy-assignment
     EvpKeyContext(const EvpKeyContext&) DELETE_IMPLICIT;

--- a/csrc/rsa_gen.cpp
+++ b/csrc/rsa_gen.cpp
@@ -39,12 +39,11 @@ JNIEXPORT jlong JNICALL Java_com_amazon_corretto_crypto_provider_RsaGen_generate
             throw_openssl("Key failed consistency check");
         }
 
-        EvpKeyContext ctx;
-        ctx.setKey(EVP_PKEY_new());
-        CHECK_OPENSSL(ctx.getKey());
-        CHECK_OPENSSL(EVP_PKEY_set1_RSA(ctx.getKey(), r));
+        EVP_PKEY_auto result = EVP_PKEY_auto::from(EVP_PKEY_new());
+        CHECK_OPENSSL(result.isInitialized());
+        CHECK_OPENSSL(EVP_PKEY_set1_RSA(result, r));
 
-        return reinterpret_cast<jlong>(ctx.moveToHeap());
+        return reinterpret_cast<jlong>(result.take());
     }
     catch (java_ex &ex)
     {


### PR DESCRIPTION
*Description of changes:*

Java `EvpKey` is currently backed by a native `EvpKeyContext` object. These contain `EVP_PKEY_CTX` and `EVP_MD_CTX` structures which are stateful, mutable, and thus not thread-safe. Thus, the current implementation of `EvpKey` is not thread safe. This changes `EvpKey` to be backed by `EVP_PKEY` directly (which is never mutated in our code and thus thread safe).

This also has minor related refactors to move us off of `EvpKeyContext` more generally and move `EvpKeyContext` onto our new `*_auto` classes to simplify our pointer management logic.

This is a fast follow for #200 where this issue was identified.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
