### PR TITLE
Fix JAVA_HOME config in Dockerfile.dev

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -21,8 +21,8 @@ RUN curl -s https://apt.corretto.aws/corretto.key | apt-key add -
 RUN echo 'deb https://apt.corretto.aws stable main' | tee /etc/apt/sources.list.d/corretto.list
 RUN apt-get update
 RUN apt-get install -y java-11-amazon-corretto-jdk
-ARG JAVA_HOME=/usr/lib/jvm/java-11-amazon-corretto/
-RUN echo 'export JAVA_HOME=/usr/lib/jvm/java-11-amazon-corretto/' >> /home/.bash_rc
+ENV JAVA_HOME=/usr/lib/jvm/java-11-amazon-corretto/
+RUN echo 'export JAVA_HOME=/usr/lib/jvm/java-11-amazon-corretto/' >> /home/.bashrc
 
 # required dependencies for building/testing
 RUN apt-get install -y build-essential


### PR DESCRIPTION
Dockerfile.dev previously didn't set JAVA_HOME correctly,
so CMake would complain with a "Could NOT find JNI" error when trying to run `./gradlew release`.

*Description of changes:*

* Changes the JAVA_HOME variable in Dockerfile.dev from a build-time argument to an environment variable that persists in the image.
* Adds the JAVA_HOME variable to `.bashrc` instead of `.bash_rc`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
