### PR TITLE
Fix ARM dieharder/overkill CI dimension mistake

### DIFF
--- a/tests/ci/cdk/cdk/codebuild/dieharder_overkill_omnibus.yaml
+++ b/tests/ci/cdk/cdk/codebuild/dieharder_overkill_omnibus.yaml
@@ -22,13 +22,14 @@ batch:
         compute-type: BUILD_GENERAL1_LARGE
         image: ECR_REPO_PLACEHOLDER:ubuntu-20.04_gcc-7x_corretto_x86_latest
 
-    - identifier: ubuntu2004_gcc7x_corretto_dieharder_arm
-      buildspec: ./tests/ci/codebuild/run_accp_dieharder.yml
-      env:
-        type: ARM_CONTAINER
-        privileged-mode: false
-        compute-type: BUILD_GENERAL1_LARGE
-        image: ECR_REPO_PLACEHOLDER:ubuntu-20.04_gcc-7x_corretto_arm_latest
+    # Dieharder tests are not supported on ARM for now.
+    # - identifier: ubuntu2004_gcc7x_corretto_dieharder_arm
+    #   buildspec: ./tests/ci/codebuild/run_accp_dieharder.yml
+    #   env:
+    #     type: ARM_CONTAINER
+    #     privileged-mode: false
+    #     compute-type: BUILD_GENERAL1_LARGE
+    #     image: ECR_REPO_PLACEHOLDER:ubuntu-20.04_gcc-7x_corretto_arm_latest
 
     - identifier: ubuntu2004_gcc7x_corretto_overkill_arm
       buildspec: ./tests/ci/codebuild/run_accp_overkill.yml

--- a/tests/ci/cdk/cdk/codebuild/dieharder_overkill_omnibus.yaml
+++ b/tests/ci/cdk/cdk/codebuild/dieharder_overkill_omnibus.yaml
@@ -23,7 +23,7 @@ batch:
         image: ECR_REPO_PLACEHOLDER:ubuntu-20.04_gcc-7x_corretto_x86_latest
 
     - identifier: ubuntu2004_gcc7x_corretto_dieharder_arm
-      buildspec: ./tests/ci/codebuild/run_accp_basic_tests.yml
+      buildspec: ./tests/ci/codebuild/run_accp_dieharder.yml
       env:
         type: ARM_CONTAINER
         privileged-mode: false
@@ -31,7 +31,7 @@ batch:
         image: ECR_REPO_PLACEHOLDER:ubuntu-20.04_gcc-7x_corretto_arm_latest
 
     - identifier: ubuntu2004_gcc7x_corretto_overkill_arm
-      buildspec: ./tests/ci/codebuild/run_accp_test_integration.yml
+      buildspec: ./tests/ci/codebuild/run_accp_overkill.yml
       env:
         type: ARM_CONTAINER
         privileged-mode: false

--- a/tests/ci/run_accp_dieharder.sh
+++ b/tests/ci/run_accp_dieharder.sh
@@ -3,8 +3,5 @@ set -exo pipefail
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Dieharder tests are only supported on x86_64 for now.
-if [[ ("$(uname -p)" == 'x86_64'*) ]]; then
-	echo "Testing ACCP dieharder tests."
-	./gradlew dieharder
-fi
+echo "Testing ACCP dieharder tests."
+./gradlew dieharder

--- a/tests/ci/run_accp_dieharder.sh
+++ b/tests/ci/run_accp_dieharder.sh
@@ -3,5 +3,8 @@ set -exo pipefail
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-echo "Testing ACCP dieharder tests."
-./gradlew dieharder
+# Dieharder tests are only supported on x86_64.
+if [[ ("$(uname -p)" == 'x86_64'*) ]]; then
+	echo "Testing ACCP dieharder tests."
+	./gradlew dieharder
+fi

--- a/tests/ci/run_accp_dieharder.sh
+++ b/tests/ci/run_accp_dieharder.sh
@@ -3,7 +3,7 @@ set -exo pipefail
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Dieharder tests are only supported on x86_64.
+# Dieharder tests are only supported on x86_64 for now.
 if [[ ("$(uname -p)" == 'x86_64'*) ]]; then
 	echo "Testing ACCP dieharder tests."
 	./gradlew dieharder

--- a/tests/ci/run_accp_overkill.sh
+++ b/tests/ci/run_accp_overkill.sh
@@ -4,4 +4,10 @@ set -exo pipefail
 # SPDX-License-Identifier: Apache-2.0
 
 echo "Testing ACCP overkill tests."
-./gradlew test_extra_checks test_integration_extra_checks dieharder_threads
+
+# dieharder_threads are not supported on ARM for now.
+if [[ ("$(uname -p)" == 'aarch64'*) || ("$(uname -p)" == 'arm'*) ]]; then
+	./gradlew test_extra_checks test_integration_extra_checks
+else
+	./gradlew test_extra_checks test_integration_extra_checks dieharder_threads
+fi


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Apparently I made a mistake with the ACCP ARM dieharder/overkill dimensions calling the wrong test script in the new CI. This fixes that.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
