### PR TITLE
MacOS CI in ACCP with Github Actions

### DIFF
--- a/.github/workflows/macos_ci.yml
+++ b/.github/workflows/macos_ci.yml
@@ -21,38 +21,28 @@ jobs:
       with:
         submodules: true
 
+    # Test on Corretto 11.
     - name: Set up corretto 11
       uses: actions/setup-java@v3
       with:
         java-version: '11'
         distribution: 'corretto'
-    - name: Build ${{ env.PACKAGE_NAME }} in corretto 11
+    - name: Build and run tests for ${{ env.PACKAGE_NAME }} in corretto 11
+      env:
+        TEST_JAVA_HOME: ${{ env.JAVA_HOME }}
       run: |
         ./tests/ci/run_accp_basic_tests.sh
-    - name: Run integration tests for ${{ env.PACKAGE_NAME }} in corretto 11
-      run: |
         ./tests/ci/run_accp_test_integration.sh
 
-    - name: Set up corretto 8
-      uses: actions/setup-java@v3
-      with:
-        java-version: '8'
-        distribution: 'corretto'
-    - name: Build ${{ env.PACKAGE_NAME }} in corretto 8
-      run: |
-        ./tests/ci/run_accp_basic_tests.sh
-    - name: Run integration tests for ${{ env.PACKAGE_NAME }} in corretto 8
-      run: |
-        ./tests/ci/run_accp_test_integration.sh
-
+    # Test on Corretto 17.
     - name: Set up corretto 17
       uses: actions/setup-java@v3
       with:
         java-version: '17'
         distribution: 'corretto'
-    - name: Build ${{ env.PACKAGE_NAME }} in corretto 17
+    - name: Build and run tests for ${{ env.PACKAGE_NAME }} in corretto 17
+      env:
+        TEST_JAVA_HOME: ${{ env.JAVA_HOME }}
       run: |
         ./tests/ci/run_accp_basic_tests.sh
-    - name: Run integration tests for ${{ env.PACKAGE_NAME }} in corretto 17
-      run: |
         ./tests/ci/run_accp_test_integration.sh

--- a/.github/workflows/macos_ci.yml
+++ b/.github/workflows/macos_ci.yml
@@ -33,24 +33,24 @@ jobs:
     - name: Get JAVA_HOME variable for correto 8
       run: |
         echo "JAVA8_HOME=${{ env.JAVA_HOME }}" >> $GITHUB_ENV
-
-    # Test on Corretto 11.
+    # Set up Corretto 11.
     - name: Set up corretto 11
       uses: actions/setup-java@v3
       with:
         java-version: '11'
         distribution: 'corretto'
-    - name: Build and run tests for ${{ env.PACKAGE_NAME }} in corretto 11
-      env:
-        TEST_JAVA_HOME: ${{ env.JAVA_HOME }}
-      run: |
-        ./tests/ci/run_accp_basic_tests.sh
-        ./tests/ci/run_accp_test_integration.sh
 
-    # Test on Corretto 8.
+    # Test on Corretto 8. Built with JDK11, but tested with JDK8.
     - name: Build and run tests for ${{ env.PACKAGE_NAME }} in corretto 8
       env:
         TEST_JAVA_HOME: ${{ env.JAVA8_HOME }}
+      run: |
+        ./tests/ci/run_accp_basic_tests.sh
+        ./tests/ci/run_accp_test_integration.sh
+     # Test on Corretto 11.
+    - name: Build and run tests for ${{ env.PACKAGE_NAME }} in corretto 11
+      env:
+        TEST_JAVA_HOME: ${{ env.JAVA_HOME }}
       run: |
         ./tests/ci/run_accp_basic_tests.sh
         ./tests/ci/run_accp_test_integration.sh

--- a/.github/workflows/macos_ci.yml
+++ b/.github/workflows/macos_ci.yml
@@ -14,12 +14,25 @@ env:
   PACKAGE_NAME: ACCP
 
 jobs:
+  # Job to run regular ACCP tests on MacOS.
   macOS:
     runs-on: macos-11 # latest
     steps:
     - uses: actions/checkout@v3
       with:
         submodules: true
+
+    # Set up Corretto 8. The JDK version should be least 10 for a regular ACCP build,
+    # but JAVA_HOME will be overwritten with subsequent versions we set up, so we save
+    # the path here beforehand.
+    - name: Set up corretto 8
+      uses: actions/setup-java@v3
+      with:
+        java-version: '8'
+        distribution: 'corretto'
+    - name: Get JAVA_HOME variable for correto 8
+      run: |
+        echo "JAVA8_HOME=${{ env.JAVA_HOME }}" >> $GITHUB_ENV
 
     # Test on Corretto 11.
     - name: Set up corretto 11
@@ -30,6 +43,14 @@ jobs:
     - name: Build and run tests for ${{ env.PACKAGE_NAME }} in corretto 11
       env:
         TEST_JAVA_HOME: ${{ env.JAVA_HOME }}
+      run: |
+        ./tests/ci/run_accp_basic_tests.sh
+        ./tests/ci/run_accp_test_integration.sh
+
+    # Test on Corretto 8.
+    - name: Build and run tests for ${{ env.PACKAGE_NAME }} in corretto 8
+      env:
+        TEST_JAVA_HOME: ${{ env.JAVA8_HOME }}
       run: |
         ./tests/ci/run_accp_basic_tests.sh
         ./tests/ci/run_accp_test_integration.sh

--- a/.github/workflows/macos_ci.yml
+++ b/.github/workflows/macos_ci.yml
@@ -1,0 +1,58 @@
+name: ACCP macOS CI
+
+# Workflow syntax.
+# https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions
+on:
+  pull_request:
+    branches:
+      - '*'
+
+permissions:
+  contents: read
+
+env:
+  PACKAGE_NAME: ACCP
+
+jobs:
+  macOS:
+    runs-on: macos-11 # latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+
+    - name: Set up corretto 11
+      uses: actions/setup-java@v3
+      with:
+        java-version: '11'
+        distribution: 'corretto'
+    - name: Build ${{ env.PACKAGE_NAME }} in corretto 11
+      run: |
+        ./tests/ci/run_accp_basic_tests.sh
+    - name: Run integration tests for ${{ env.PACKAGE_NAME }} in corretto 11
+      run: |
+        ./tests/ci/run_accp_test_integration.sh
+
+    - name: Set up corretto 8
+      uses: actions/setup-java@v3
+      with:
+        java-version: '8'
+        distribution: 'corretto'
+    - name: Build ${{ env.PACKAGE_NAME }} in corretto 8
+      run: |
+        ./tests/ci/run_accp_basic_tests.sh
+    - name: Run integration tests for ${{ env.PACKAGE_NAME }} in corretto 8
+      run: |
+        ./tests/ci/run_accp_test_integration.sh
+
+    - name: Set up corretto 17
+      uses: actions/setup-java@v3
+      with:
+        java-version: '17'
+        distribution: 'corretto'
+    - name: Build ${{ env.PACKAGE_NAME }} in corretto 17
+      run: |
+        ./tests/ci/run_accp_basic_tests.sh
+    - name: Run integration tests for ${{ env.PACKAGE_NAME }} in corretto 17
+      run: |
+        ./tests/ci/run_accp_test_integration.sh

--- a/tests/ci/README.md
+++ b/tests/ci/README.md
@@ -41,6 +41,9 @@ CI Tool|C Compiler|Java Compiler|CPU platform|OS
 ------------ | -------------| -------------| -------------|-------------
 CodeBuild|gcc 7|corretto 8,11,17|x86-64|Ubuntu 20.04
 CodeBuild|gcc 7|corretto 8,11,17|aarch|Ubuntu 20.04
+~~GitHub Workflow~~|~~AppleClang 13.0.0~~|~~x86-64~~|~~macOS 11~~
+
+(macOS CI dimension is currently disabled, go to the Actions tab in the main repo to enable it when its ready.)
 
 
 ### Dieharder & Overkill tests


### PR DESCRIPTION
*Issue #, if available:*
`CryptoAlg-1103`

*Description of changes:*
Sets up the MacOS CI framework for ACCP. Functionality will be disabled for now, and should be enabled when support is added. Corretto 8 hasn't been included in the workflow file because retrieving and saving the `JAVA_HOME` variable installed by corretto8 will result in added complications to the workflow. We can look to add it if it's absolutely needed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
