### PR TITLE
Add FIPS support to ACCP CI

### DIFF
--- a/.github/workflows/macos_ci_fips.yml
+++ b/.github/workflows/macos_ci_fips.yml
@@ -45,15 +45,15 @@ jobs:
       env:
         TEST_JAVA_HOME: ${{ env.JAVA8_HOME }}
       run: |
-        ./tests/ci/run_accp_basic_tests.sh --fips true
-        ./tests/ci/run_accp_test_integration.sh --fips true
+        ./tests/ci/run_accp_basic_tests.sh --fips
+        ./tests/ci/run_accp_test_integration.sh --fips
      # Test on Corretto 11.
     - name: Build and run tests for ${{ env.PACKAGE_NAME }} in corretto 11
       env:
         TEST_JAVA_HOME: ${{ env.JAVA_HOME }}
       run: |
-        ./tests/ci/run_accp_basic_tests.sh --fips true
-        ./tests/ci/run_accp_test_integration.sh --fips true
+        ./tests/ci/run_accp_basic_tests.sh --fips
+        ./tests/ci/run_accp_test_integration.sh --fips
 
     # Test on Corretto 17.
     - name: Set up corretto 17
@@ -65,5 +65,5 @@ jobs:
       env:
         TEST_JAVA_HOME: ${{ env.JAVA_HOME }}
       run: |
-        ./tests/ci/run_accp_basic_tests.sh --fips true
-        ./tests/ci/run_accp_test_integration.sh --fips true
+        ./tests/ci/run_accp_basic_tests.sh --fips
+        ./tests/ci/run_accp_test_integration.sh --fips

--- a/.github/workflows/macos_ci_fips.yml
+++ b/.github/workflows/macos_ci_fips.yml
@@ -1,0 +1,69 @@
+name: ACCP macOS CI FIPS
+
+# Workflow syntax.
+# https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions
+on:
+  pull_request:
+    branches:
+      - '*'
+
+permissions:
+  contents: read
+
+env:
+  PACKAGE_NAME: ACCP-FIPS
+
+jobs:
+  # Job to run FIPS version of ACCP tests on MacOS.
+  macOS:
+    runs-on: macos-11 # latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+
+    # Set up Corretto 8. The JDK version should be least 10 for a regular ACCP build,
+    # but JAVA_HOME will be overwritten with subsequent versions we set up, so we save
+    # the path here beforehand.
+    - name: Set up corretto 8
+      uses: actions/setup-java@v3
+      with:
+        java-version: '8'
+        distribution: 'corretto'
+    - name: Get JAVA_HOME variable for correto 8
+      run: |
+        echo "JAVA8_HOME=${{ env.JAVA_HOME }}" >> $GITHUB_ENV
+    # Set up Corretto 11.
+    - name: Set up corretto 11
+      uses: actions/setup-java@v3
+      with:
+        java-version: '11'
+        distribution: 'corretto'
+
+    # Test on Corretto 8. Built with JDK11, but tested with JDK8.
+    - name: Build and run tests for ${{ env.PACKAGE_NAME }} in corretto 8
+      env:
+        TEST_JAVA_HOME: ${{ env.JAVA8_HOME }}
+      run: |
+        ./tests/ci/run_accp_basic_tests.sh --fips true
+        ./tests/ci/run_accp_test_integration.sh --fips true
+     # Test on Corretto 11.
+    - name: Build and run tests for ${{ env.PACKAGE_NAME }} in corretto 11
+      env:
+        TEST_JAVA_HOME: ${{ env.JAVA_HOME }}
+      run: |
+        ./tests/ci/run_accp_basic_tests.sh --fips true
+        ./tests/ci/run_accp_test_integration.sh --fips true
+
+    # Test on Corretto 17.
+    - name: Set up corretto 17
+      uses: actions/setup-java@v3
+      with:
+        java-version: '17'
+        distribution: 'corretto'
+    - name: Build and run tests for ${{ env.PACKAGE_NAME }} in corretto 17
+      env:
+        TEST_JAVA_HOME: ${{ env.JAVA_HOME }}
+      run: |
+        ./tests/ci/run_accp_basic_tests.sh --fips true
+        ./tests/ci/run_accp_test_integration.sh --fips true

--- a/tests/ci/README.md
+++ b/tests/ci/README.md
@@ -37,10 +37,15 @@ Runs tests for:
 * release
 * test_integration
 
-CI Tool|C Compiler|Java Compiler|CPU platform|OS
------------- | -------------| -------------| -------------|-------------
-CodeBuild|gcc 7|corretto 8,11,17|x86-64|Ubuntu 20.04
-CodeBuild|gcc 7|corretto 8,11,17|aarch|Ubuntu 20.04
+CI Tool|C Compiler|Java Compiler|CPU platform|OS|Dimensions
+------------ | -------------| -------------| -------------|-------------|-------------
+CodeBuild|gcc 7|corretto 8|x86-64|Ubuntu 20.04|FIPS/non-FIPS
+CodeBuild|gcc 7|corretto 11|x86-64|Ubuntu 20.04|FIPS/non-FIPS
+CodeBuild|gcc 7|corretto 17|x86-64|Ubuntu 20.04|FIPS/non-FIPS
+CodeBuild|gcc 7|corretto 8|aarch|Ubuntu 20.04|FIPS/non-FIPS
+CodeBuild|gcc 7|corretto 11|aarch|Ubuntu 20.04|FIPS/non-FIPS
+CodeBuild|gcc 7|corretto 17|aarch|Ubuntu 20.04|FIPS/non-FIPS
+
 
 
 ### Dieharder & Overkill tests
@@ -49,7 +54,7 @@ Runs tests for:
 * test_integration_extra_checks
 * dieharder_threads
 
-CI Tool|C Compiler|Java Compiler|CPU platform|OS
------------- | -------------| -------------| -------------|-------------
-CodeBuild|gcc 7|corretto 8,11,17|x86-64|Ubuntu 20.04
-CodeBuild|gcc 7|corretto 8,11,17|aarch|Ubuntu 20.04
+CI Tool|C Compiler|Java Compiler|CPU platform|OS|Dimensions
+------------ | -------------| -------------| -------------|-------------|-------------
+CodeBuild|gcc 7|corretto 11|x86-64|Ubuntu 20.04|both FIPS/non-FIPS
+CodeBuild|gcc 7|corretto 11|aarch|Ubuntu 20.04|both FIPS/non-FIPS, no dieharder

--- a/tests/ci/README.md
+++ b/tests/ci/README.md
@@ -45,7 +45,9 @@ CodeBuild|gcc 7|corretto 17|x86-64|Ubuntu 20.04|FIPS/non-FIPS
 CodeBuild|gcc 7|corretto 8|aarch|Ubuntu 20.04|FIPS/non-FIPS
 CodeBuild|gcc 7|corretto 11|aarch|Ubuntu 20.04|FIPS/non-FIPS
 CodeBuild|gcc 7|corretto 17|aarch|Ubuntu 20.04|FIPS/non-FIPS
-~~GitHub Workflow~~|~~AppleClang 13.0.0~~|~~x86-64~~|~~macOS 11~~
+~~GitHub Workflow~~|~~AppleClang 13.0.0~~|~~corretto 8~~|~~x86-64~~|~~macOS 11~~|~~FIPS/non-FIPS~~
+~~GitHub Workflow~~|~~AppleClang 13.0.0~~|~~corretto 11~~|~~x86-64~~|~~macOS 11~~|~~FIPS/non-FIPS~~
+~~GitHub Workflow~~|~~AppleClang 13.0.0~~|~~corretto 17~~|~~x86-64~~|~~macOS 11~~|~~FIPS/non-FIPS~~
 
 (macOS CI dimension is currently disabled, go to the Actions tab in the main repo to enable it when its ready.)
 

--- a/tests/ci/cdk/cdk/codebuild/dieharder_overkill_omnibus.yaml
+++ b/tests/ci/cdk/cdk/codebuild/dieharder_overkill_omnibus.yaml
@@ -38,3 +38,28 @@ batch:
         privileged-mode: false
         compute-type: BUILD_GENERAL1_LARGE
         image: ECR_REPO_PLACEHOLDER:ubuntu-20.04_gcc-7x_corretto_arm_latest
+
+    # ACCP FIPS dimensions.
+    - identifier: ubuntu2004_gcc7x_corretto_dieharder_x86_fips
+      buildspec: ./tests/ci/codebuild/run_accp_dieharder_fips.yml
+      env:
+        type: LINUX_CONTAINER
+        privileged-mode: false
+        compute-type: BUILD_GENERAL1_LARGE
+        image: ECR_REPO_PLACEHOLDER:ubuntu-20.04_gcc-7x_corretto_x86_latest
+
+    - identifier: ubuntu2004_gcc7x_corretto_overkill_x86_fips
+      buildspec: ./tests/ci/codebuild/run_accp_overkill_fips.yml
+      env:
+        type: LINUX_CONTAINER
+        privileged-mode: false
+        compute-type: BUILD_GENERAL1_LARGE
+        image: ECR_REPO_PLACEHOLDER:ubuntu-20.04_gcc-7x_corretto_x86_latest
+
+    - identifier: ubuntu2004_gcc7x_corretto_overkill_arm_fips
+      buildspec: ./tests/ci/codebuild/run_accp_overkill_fips.yml
+      env:
+        type: ARM_CONTAINER
+        privileged-mode: false
+        compute-type: BUILD_GENERAL1_LARGE
+        image: ECR_REPO_PLACEHOLDER:ubuntu-20.04_gcc-7x_corretto_arm_latest

--- a/tests/ci/cdk/cdk/codebuild/pr_integration_linux_arm_omnibus.yaml
+++ b/tests/ci/cdk/cdk/codebuild/pr_integration_linux_arm_omnibus.yaml
@@ -65,3 +65,65 @@ batch:
         image: ECR_REPO_PLACEHOLDER:ubuntu-20.04_gcc-7x_corretto_arm_latest
         variables:
           TEST_JAVA_HOME: /usr/lib/jvm/java-17-amazon-corretto
+
+
+    # ACCP FIPS dimensions.
+    - identifier: ubuntu2004_gcc7x_corretto8_pr_arm_fips
+      buildspec: ./tests/ci/codebuild/run_accp_basic_tests_fips.yml
+      env:
+        type: ARM_CONTAINER
+        privileged-mode: false
+        compute-type: BUILD_GENERAL1_LARGE
+        image: ECR_REPO_PLACEHOLDER:ubuntu-20.04_gcc-7x_corretto_arm_latest
+        variables:
+          TEST_JAVA_HOME: /usr/lib/jvm/java-1.8.0-amazon-corretto
+
+    - identifier: ubuntu2004_gcc7x_corretto11_pr_arm_fips
+      buildspec: ./tests/ci/codebuild/run_accp_basic_tests_fips.yml
+      env:
+        type: ARM_CONTAINER
+        privileged-mode: false
+        compute-type: BUILD_GENERAL1_LARGE
+        image: ECR_REPO_PLACEHOLDER:ubuntu-20.04_gcc-7x_corretto_arm_latest
+        variables:
+          TEST_JAVA_HOME: /usr/lib/jvm/java-11-amazon-corretto
+
+    - identifier: ubuntu2004_gcc7x_corretto17_pr_arm_fips
+      buildspec: ./tests/ci/codebuild/run_accp_basic_tests_fips.yml
+      env:
+        type: ARM_CONTAINER
+        privileged-mode: false
+        compute-type: BUILD_GENERAL1_LARGE
+        image: ECR_REPO_PLACEHOLDER:ubuntu-20.04_gcc-7x_corretto_arm_latest
+        variables:
+          TEST_JAVA_HOME: /usr/lib/jvm/java-17-amazon-corretto
+
+    - identifier: ubuntu2004_gcc7x_corretto8_test_integration_arm_fips
+      buildspec: ./tests/ci/codebuild/run_accp_test_integration_fips.yml
+      env:
+        type: ARM_CONTAINER
+        privileged-mode: false
+        compute-type: BUILD_GENERAL1_LARGE
+        image: ECR_REPO_PLACEHOLDER:ubuntu-20.04_gcc-7x_corretto_arm_latest
+        variables:
+          TEST_JAVA_HOME: /usr/lib/jvm/java-1.8.0-amazon-corretto
+
+    - identifier: ubuntu2004_gcc7x_corretto11_test_integration_arm_fips
+      buildspec: ./tests/ci/codebuild/run_accp_test_integration_fips.yml
+      env:
+        type: ARM_CONTAINER
+        privileged-mode: false
+        compute-type: BUILD_GENERAL1_LARGE
+        image: ECR_REPO_PLACEHOLDER:ubuntu-20.04_gcc-7x_corretto_arm_latest
+        variables:
+          TEST_JAVA_HOME: /usr/lib/jvm/java-11-amazon-corretto
+
+    - identifier: ubuntu2004_gcc7x_corretto17_test_integration_arm_fips
+      buildspec: ./tests/ci/codebuild/run_accp_test_integration_fips.yml
+      env:
+        type: ARM_CONTAINER
+        privileged-mode: false
+        compute-type: BUILD_GENERAL1_LARGE
+        image: ECR_REPO_PLACEHOLDER:ubuntu-20.04_gcc-7x_corretto_arm_latest
+        variables:
+          TEST_JAVA_HOME: /usr/lib/jvm/java-17-amazon-corretto

--- a/tests/ci/cdk/cdk/codebuild/pr_integration_linux_x86_omnibus.yaml
+++ b/tests/ci/cdk/cdk/codebuild/pr_integration_linux_x86_omnibus.yaml
@@ -65,3 +65,65 @@ batch:
         image: ECR_REPO_PLACEHOLDER:ubuntu-20.04_gcc-7x_corretto_x86_latest
         variables:
           TEST_JAVA_HOME: /usr/lib/jvm/java-17-amazon-corretto
+
+
+    # ACCP FIPS dimensions.
+    - identifier: ubuntu2004_gcc7x_corretto8_pr_x86_fips
+      buildspec: ./tests/ci/codebuild/run_accp_basic_tests_fips.yml
+      env:
+        type: LINUX_CONTAINER
+        privileged-mode: false
+        compute-type: BUILD_GENERAL1_LARGE
+        image: ECR_REPO_PLACEHOLDER:ubuntu-20.04_gcc-7x_corretto_x86_latest
+        variables:
+          TEST_JAVA_HOME: /usr/lib/jvm/java-1.8.0-amazon-corretto
+
+    - identifier: ubuntu2004_gcc7x_corretto11_pr_x86_fips
+      buildspec: ./tests/ci/codebuild/run_accp_basic_tests_fips.yml
+      env:
+        type: LINUX_CONTAINER
+        privileged-mode: false
+        compute-type: BUILD_GENERAL1_LARGE
+        image: ECR_REPO_PLACEHOLDER:ubuntu-20.04_gcc-7x_corretto_x86_latest
+        variables:
+          TEST_JAVA_HOME: /usr/lib/jvm/java-11-amazon-corretto
+
+    - identifier: ubuntu2004_gcc7x_corretto17_pr_x86_fips
+      buildspec: ./tests/ci/codebuild/run_accp_basic_tests_fips.yml
+      env:
+        type: LINUX_CONTAINER
+        privileged-mode: false
+        compute-type: BUILD_GENERAL1_LARGE
+        image: ECR_REPO_PLACEHOLDER:ubuntu-20.04_gcc-7x_corretto_x86_latest
+        variables:
+          TEST_JAVA_HOME: /usr/lib/jvm/java-17-amazon-corretto
+
+    - identifier: ubuntu2004_gcc7x_corretto8_test_integration_x86_fips
+      buildspec: ./tests/ci/codebuild/run_accp_test_integration_fips.yml
+      env:
+        type: LINUX_CONTAINER
+        privileged-mode: false
+        compute-type: BUILD_GENERAL1_LARGE
+        image: ECR_REPO_PLACEHOLDER:ubuntu-20.04_gcc-7x_corretto_x86_latest
+        variables:
+          TEST_JAVA_HOME: /usr/lib/jvm/java-1.8.0-amazon-corretto
+
+    - identifier: ubuntu2004_gcc7x_corretto11_test_integration_x86_fips
+      buildspec: ./tests/ci/codebuild/run_accp_test_integration_fips.yml
+      env:
+        type: LINUX_CONTAINER
+        privileged-mode: false
+        compute-type: BUILD_GENERAL1_LARGE
+        image: ECR_REPO_PLACEHOLDER:ubuntu-20.04_gcc-7x_corretto_x86_latest
+        variables:
+          TEST_JAVA_HOME: /usr/lib/jvm/java-11-amazon-corretto
+
+    - identifier: ubuntu2004_gcc7x_corretto17_test_integration_x86_fips
+      buildspec: ./tests/ci/codebuild/run_accp_test_integration_fips.yml
+      env:
+        type: LINUX_CONTAINER
+        privileged-mode: false
+        compute-type: BUILD_GENERAL1_LARGE
+        image: ECR_REPO_PLACEHOLDER:ubuntu-20.04_gcc-7x_corretto_x86_latest
+        variables:
+          TEST_JAVA_HOME: /usr/lib/jvm/java-17-amazon-corretto

--- a/tests/ci/codebuild/run_accp_basic_tests_fips.yml
+++ b/tests/ci/codebuild/run_accp_basic_tests_fips.yml
@@ -1,0 +1,9 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+version: 0.2
+
+phases:
+  build:
+    commands:
+      - ./tests/ci/run_accp_basic_tests.sh --fips

--- a/tests/ci/codebuild/run_accp_basic_tests_fips.yml
+++ b/tests/ci/codebuild/run_accp_basic_tests_fips.yml
@@ -6,4 +6,4 @@ version: 0.2
 phases:
   build:
     commands:
-      - ./tests/ci/run_accp_basic_tests.sh --fips
+      - ./tests/ci/run_accp_basic_tests.sh --fips true

--- a/tests/ci/codebuild/run_accp_basic_tests_fips.yml
+++ b/tests/ci/codebuild/run_accp_basic_tests_fips.yml
@@ -6,4 +6,4 @@ version: 0.2
 phases:
   build:
     commands:
-      - ./tests/ci/run_accp_basic_tests.sh --fips true
+      - ./tests/ci/run_accp_basic_tests.sh --fips

--- a/tests/ci/codebuild/run_accp_dieharder_fips.yml
+++ b/tests/ci/codebuild/run_accp_dieharder_fips.yml
@@ -6,4 +6,4 @@ version: 0.2
 phases:
   build:
     commands:
-      - ./tests/ci/run_accp_dieharder.sh --fips true
+      - ./tests/ci/run_accp_dieharder.sh --fips

--- a/tests/ci/codebuild/run_accp_dieharder_fips.yml
+++ b/tests/ci/codebuild/run_accp_dieharder_fips.yml
@@ -1,0 +1,9 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+version: 0.2
+
+phases:
+  build:
+    commands:
+      - ./tests/ci/run_accp_dieharder.sh --fips

--- a/tests/ci/codebuild/run_accp_dieharder_fips.yml
+++ b/tests/ci/codebuild/run_accp_dieharder_fips.yml
@@ -6,4 +6,4 @@ version: 0.2
 phases:
   build:
     commands:
-      - ./tests/ci/run_accp_dieharder.sh --fips
+      - ./tests/ci/run_accp_dieharder.sh --fips true

--- a/tests/ci/codebuild/run_accp_overkill_fips.yml
+++ b/tests/ci/codebuild/run_accp_overkill_fips.yml
@@ -6,4 +6,4 @@ version: 0.2
 phases:
   build:
     commands:
-      - ./tests/ci/run_accp_overkill.sh --fips
+      - ./tests/ci/run_accp_overkill.sh --fips true

--- a/tests/ci/codebuild/run_accp_overkill_fips.yml
+++ b/tests/ci/codebuild/run_accp_overkill_fips.yml
@@ -1,0 +1,9 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+version: 0.2
+
+phases:
+  build:
+    commands:
+      - ./tests/ci/run_accp_overkill.sh --fips

--- a/tests/ci/codebuild/run_accp_overkill_fips.yml
+++ b/tests/ci/codebuild/run_accp_overkill_fips.yml
@@ -6,4 +6,4 @@ version: 0.2
 phases:
   build:
     commands:
-      - ./tests/ci/run_accp_overkill.sh --fips true
+      - ./tests/ci/run_accp_overkill.sh --fips

--- a/tests/ci/codebuild/run_accp_test_integration_fips.yml
+++ b/tests/ci/codebuild/run_accp_test_integration_fips.yml
@@ -6,4 +6,4 @@ version: 0.2
 phases:
   build:
     commands:
-      - ./tests/ci/run_accp_test_integration.sh --fips
+      - ./tests/ci/run_accp_test_integration.sh --fips true

--- a/tests/ci/codebuild/run_accp_test_integration_fips.yml
+++ b/tests/ci/codebuild/run_accp_test_integration_fips.yml
@@ -1,0 +1,9 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+version: 0.2
+
+phases:
+  build:
+    commands:
+      - ./tests/ci/run_accp_test_integration.sh --fips

--- a/tests/ci/codebuild/run_accp_test_integration_fips.yml
+++ b/tests/ci/codebuild/run_accp_test_integration_fips.yml
@@ -6,4 +6,4 @@ version: 0.2
 phases:
   build:
     commands:
-      - ./tests/ci/run_accp_test_integration.sh --fips true
+      - ./tests/ci/run_accp_test_integration.sh --fips

--- a/tests/ci/docker_images/linux-arm/ubuntu-20.04_accp_base/Dockerfile
+++ b/tests/ci/docker_images/linux-arm/ubuntu-20.04_accp_base/Dockerfile
@@ -6,6 +6,7 @@ FROM arm64v8/ubuntu:20.04
 SHELL ["/bin/bash", "-c"]
 
 ENV DEBIAN_FRONTEND=noninteractive
+ENV GO_TAG=go1.18.3
 
 # required dependencies for building/testing
 RUN apt-get update
@@ -28,8 +29,8 @@ RUN apt-get update
 
 # AWS-LC FIPS requires golang.
 RUN cd /tmp && \
-    wget https://dl.google.com/go/go1.15.2.linux-arm64.tar.gz && \
-    tar -xvf go1.15.2.linux-arm64.tar.gz && \
+    wget https://dl.google.com/go/$GO_TAG.linux-arm64.tar.gz && \
+    tar -xvf $GO_TAG.linux-arm64.tar.gz && \
     mv go /usr/local && \
     rm -rf /tmp/*
 

--- a/tests/ci/docker_images/linux-arm/ubuntu-20.04_accp_base/Dockerfile
+++ b/tests/ci/docker_images/linux-arm/ubuntu-20.04_accp_base/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get install -y build-essential
 RUN apt-get install -y cmake
 RUN apt-get install -y dieharder
 RUN apt-get install -y lcov
+RUN apt-get install -y wget
 
 # developement niceties
 RUN apt-get install -y ninja-build
@@ -24,3 +25,14 @@ RUN apt-get install -y git
 RUN curl -s https://apt.corretto.aws/corretto.key | apt-key add -
 RUN echo 'deb https://apt.corretto.aws stable main' | tee /etc/apt/sources.list.d/corretto.list
 RUN apt-get update
+
+# AWS-LC FIPS requires golang.
+RUN cd /tmp && \
+    wget https://dl.google.com/go/go1.15.2.linux-arm64.tar.gz && \
+    tar -xvf go1.15.2.linux-arm64.tar.gz && \
+    mv go /usr/local && \
+    rm -rf /tmp/*
+
+ENV GOROOT=/usr/local/go
+ENV GO111MODULE=on
+ENV PATH="$GOROOT/bin:$PATH"

--- a/tests/ci/docker_images/linux-x86/ubuntu-20.04_accp_base/Dockerfile
+++ b/tests/ci/docker_images/linux-x86/ubuntu-20.04_accp_base/Dockerfile
@@ -6,6 +6,7 @@ FROM ubuntu:20.04
 SHELL ["/bin/bash", "-c"]
 
 ENV DEBIAN_FRONTEND=noninteractive
+ENV GO_TAG=go1.18.3
 
 # required dependencies for building/testing
 RUN apt-get update
@@ -28,8 +29,8 @@ RUN apt-get update
 
 # AWS-LC FIPS requires golang.
 RUN cd /tmp && \
-    wget https://dl.google.com/go/go1.13.12.linux-amd64.tar.gz && \
-    tar -xvf go1.13.12.linux-amd64.tar.gz && \
+    wget https://dl.google.com/go/$GO_TAG.linux-amd64.tar.gz && \
+    tar -xvf $GO_TAG.linux-amd64.tar.gz && \
     mv go /usr/local && \
     rm -rf /tmp/*
 

--- a/tests/ci/docker_images/linux-x86/ubuntu-20.04_accp_base/Dockerfile
+++ b/tests/ci/docker_images/linux-x86/ubuntu-20.04_accp_base/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get install -y build-essential
 RUN apt-get install -y cmake
 RUN apt-get install -y dieharder
 RUN apt-get install -y lcov
+RUN apt-get install -y wget
 
 # developement niceties
 RUN apt-get install -y ninja-build
@@ -24,3 +25,14 @@ RUN apt-get install -y git
 RUN curl -s https://apt.corretto.aws/corretto.key | apt-key add -
 RUN echo 'deb https://apt.corretto.aws stable main' | tee /etc/apt/sources.list.d/corretto.list
 RUN apt-get update
+
+# AWS-LC FIPS requires golang.
+RUN cd /tmp && \
+    wget https://dl.google.com/go/go1.13.12.linux-amd64.tar.gz && \
+    tar -xvf go1.13.12.linux-amd64.tar.gz && \
+    mv go /usr/local && \
+    rm -rf /tmp/*
+
+ENV GOROOT=/usr/local/go
+ENV GO111MODULE=on
+ENV PATH="$GOROOT/bin:$PATH"

--- a/tests/ci/run_accp_basic_tests.sh
+++ b/tests/ci/run_accp_basic_tests.sh
@@ -3,13 +3,19 @@ set -exo pipefail
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+# Testing non-FIPS is the default.
+testing_fips=false
+if [[ "${1}" == "--fips" ]]; then
+	testing_fips=true
+fi
+
 # Parse and check which JDK version we're testing upon.
 version=$($TEST_JAVA_HOME/bin/java -version 2>&1 | head -1 | cut -d'"' -f2 | sed '/^1\./s///' | cut -d'.' -f1)
 
 # The JDK version should be least 10 for a regular ACCP build. We can
 # still test on older versions with the TEST_JAVA_HOME property.
 if (( "$version" <= "10" )); then
-	./gradlew -DTEST_JAVA_HOME=$TEST_JAVA_HOME test
+	./gradlew -DTEST_JAVA_HOME=$TEST_JAVA_HOME -DFIPS=$testing_fips test
 	exit $?
 fi
 
@@ -21,4 +27,4 @@ export PATH=$JAVA_HOME/bin:$PATH
 
 # TEST_JAVA_MAJOR_VERSION is necessary in Java17+ for certain unit tests to
 # perform deep reflection on nonpublic members.
-./gradlew -DTEST_JAVA_MAJOR_VERSION=$version release
+./gradlew -DTEST_JAVA_MAJOR_VERSION=$version -DFIPS=$testing_fips release

--- a/tests/ci/run_accp_basic_tests.sh
+++ b/tests/ci/run_accp_basic_tests.sh
@@ -9,7 +9,7 @@ while [[ $# -gt 0 ]]; do
     case ${1} in
     --fips)
       testing_fips=${2}
-	  shift
+      shift
       ;;
     *)
       echo "${1} is not supported."

--- a/tests/ci/run_accp_basic_tests.sh
+++ b/tests/ci/run_accp_basic_tests.sh
@@ -8,8 +8,7 @@ testing_fips=false
 while [[ $# -gt 0 ]]; do
     case ${1} in
     --fips)
-      testing_fips=${2}
-      shift
+      testing_fips=true
       ;;
     *)
       echo "${1} is not supported."

--- a/tests/ci/run_accp_basic_tests.sh
+++ b/tests/ci/run_accp_basic_tests.sh
@@ -5,9 +5,20 @@ set -exo pipefail
 
 # Testing non-FIPS is the default.
 testing_fips=false
-if [[ "${1}" == "--fips" ]]; then
-	testing_fips=true
-fi
+while [[ $# -gt 0 ]]; do
+    case ${1} in
+    --fips)
+      testing_fips=${2}
+	  shift
+      ;;
+    *)
+      echo "${1} is not supported."
+      exit 1
+      ;;
+    esac
+    # Check next option -- key/value.
+    shift
+done
 
 # Parse and check which JDK version we're testing upon.
 version=$($TEST_JAVA_HOME/bin/java -version 2>&1 | head -1 | cut -d'"' -f2 | sed '/^1\./s///' | cut -d'.' -f1)

--- a/tests/ci/run_accp_dieharder.sh
+++ b/tests/ci/run_accp_dieharder.sh
@@ -9,7 +9,7 @@ while [[ $# -gt 0 ]]; do
     case ${1} in
     --fips)
       testing_fips=${2}
-	  shift
+      shift
       ;;
     *)
       echo "${1} is not supported."

--- a/tests/ci/run_accp_dieharder.sh
+++ b/tests/ci/run_accp_dieharder.sh
@@ -8,8 +8,7 @@ testing_fips=false
 while [[ $# -gt 0 ]]; do
     case ${1} in
     --fips)
-      testing_fips=${2}
-      shift
+      testing_fips=true
       ;;
     *)
       echo "${1} is not supported."

--- a/tests/ci/run_accp_dieharder.sh
+++ b/tests/ci/run_accp_dieharder.sh
@@ -3,5 +3,11 @@ set -exo pipefail
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+# Testing non-FIPS is the default.
+testing_fips=false
+if [[ "${1}" == "--fips" ]]; then
+	testing_fips=true
+fi
+
 echo "Testing ACCP dieharder tests."
-./gradlew dieharder
+./gradlew -DFIPS=$testing_fips dieharder

--- a/tests/ci/run_accp_dieharder.sh
+++ b/tests/ci/run_accp_dieharder.sh
@@ -5,9 +5,20 @@ set -exo pipefail
 
 # Testing non-FIPS is the default.
 testing_fips=false
-if [[ "${1}" == "--fips" ]]; then
-	testing_fips=true
-fi
+while [[ $# -gt 0 ]]; do
+    case ${1} in
+    --fips)
+      testing_fips=${2}
+	  shift
+      ;;
+    *)
+      echo "${1} is not supported."
+      exit 1
+      ;;
+    esac
+    # Check next option -- key/value.
+    shift
+done
 
 echo "Testing ACCP dieharder tests."
 ./gradlew -DFIPS=$testing_fips dieharder

--- a/tests/ci/run_accp_overkill.sh
+++ b/tests/ci/run_accp_overkill.sh
@@ -5,9 +5,20 @@ set -exo pipefail
 
 # Testing non-FIPS is the default.
 testing_fips=false
-if [[ "${1}" == "--fips" ]]; then
-	testing_fips=true
-fi
+while [[ $# -gt 0 ]]; do
+    case ${1} in
+    --fips)
+      testing_fips=${2}
+	  shift
+      ;;
+    *)
+      echo "${1} is not supported."
+      exit 1
+      ;;
+    esac
+    # Check next option -- key/value.
+    shift
+done
 
 echo "Testing ACCP overkill tests."
 

--- a/tests/ci/run_accp_overkill.sh
+++ b/tests/ci/run_accp_overkill.sh
@@ -9,7 +9,7 @@ while [[ $# -gt 0 ]]; do
     case ${1} in
     --fips)
       testing_fips=${2}
-	  shift
+      shift
       ;;
     *)
       echo "${1} is not supported."

--- a/tests/ci/run_accp_overkill.sh
+++ b/tests/ci/run_accp_overkill.sh
@@ -3,11 +3,17 @@ set -exo pipefail
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+# Testing non-FIPS is the default.
+testing_fips=false
+if [[ "${1}" == "--fips" ]]; then
+	testing_fips=true
+fi
+
 echo "Testing ACCP overkill tests."
 
 # dieharder_threads are not supported on ARM for now.
 if [[ ("$(uname -p)" == 'aarch64'*) || ("$(uname -p)" == 'arm'*) ]]; then
-	./gradlew test_extra_checks test_integration_extra_checks
+	./gradlew -DFIPS=$testing_fips test_extra_checks test_integration_extra_checks
 else
-	./gradlew test_extra_checks test_integration_extra_checks dieharder_threads
+	./gradlew -DFIPS=$testing_fips test_extra_checks test_integration_extra_checks dieharder_threads
 fi

--- a/tests/ci/run_accp_overkill.sh
+++ b/tests/ci/run_accp_overkill.sh
@@ -8,8 +8,7 @@ testing_fips=false
 while [[ $# -gt 0 ]]; do
     case ${1} in
     --fips)
-      testing_fips=${2}
-      shift
+      testing_fips=true
       ;;
     *)
       echo "${1} is not supported."

--- a/tests/ci/run_accp_test_integration.sh
+++ b/tests/ci/run_accp_test_integration.sh
@@ -9,7 +9,7 @@ while [[ $# -gt 0 ]]; do
     case ${1} in
     --fips)
       testing_fips=${2}
-	  shift
+      shift
       ;;
     *)
       echo "${1} is not supported."

--- a/tests/ci/run_accp_test_integration.sh
+++ b/tests/ci/run_accp_test_integration.sh
@@ -8,8 +8,7 @@ testing_fips=false
 while [[ $# -gt 0 ]]; do
     case ${1} in
     --fips)
-      testing_fips=${2}
-      shift
+      testing_fips=true
       ;;
     *)
       echo "${1} is not supported."

--- a/tests/ci/run_accp_test_integration.sh
+++ b/tests/ci/run_accp_test_integration.sh
@@ -5,9 +5,20 @@ set -exo pipefail
 
 # Testing non-FIPS is the default.
 testing_fips=false
-if [[ "${1}" == "--fips" ]]; then
-	testing_fips=true
-fi
+while [[ $# -gt 0 ]]; do
+    case ${1} in
+    --fips)
+      testing_fips=${2}
+	  shift
+      ;;
+    *)
+      echo "${1} is not supported."
+      exit 1
+      ;;
+    esac
+    # Check next option -- key/value.
+    shift
+done
 
 # Parse and check which JDK version we're testing upon.
 version=$($TEST_JAVA_HOME/bin/java -version 2>&1 | head -1 | cut -d'"' -f2 | sed '/^1\./s///' | cut -d'.' -f1)

--- a/tests/ci/run_accp_test_integration.sh
+++ b/tests/ci/run_accp_test_integration.sh
@@ -3,13 +3,19 @@ set -exo pipefail
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+# Testing non-FIPS is the default.
+testing_fips=false
+if [[ "${1}" == "--fips" ]]; then
+	testing_fips=true
+fi
+
 # Parse and check which JDK version we're testing upon.
 version=$($TEST_JAVA_HOME/bin/java -version 2>&1 | head -1 | cut -d'"' -f2 | sed '/^1\./s///' | cut -d'.' -f1)
 
 # The JDK version should be least 10 for a regular ACCP build. We can
 # still test on older versions with the TEST_JAVA_HOME property.
 if (( "$version" <= "10" )); then
-	./gradlew -DTEST_JAVA_HOME=$TEST_JAVA_HOME test_integration
+	./gradlew -DTEST_JAVA_HOME=$TEST_JAVA_HOME -DFIPS=$testing_fips test_integration
 	exit $?
 fi
 
@@ -21,4 +27,4 @@ export PATH=$JAVA_HOME/bin:$PATH
 
 # TEST_JAVA_MAJOR_VERSION is necessary in Java17+ for certain unit tests to
 # perform deep reflection on nonpublic members.
-./gradlew -DTEST_JAVA_MAJOR_VERSION=$version test_integration
+./gradlew -DTEST_JAVA_MAJOR_VERSION=$version -DFIPS=$testing_fips test_integration


### PR DESCRIPTION
*Issue #, if available:*
`CryptoAlg-1105`

*Description of changes:*
After merging https://github.com/corretto/amazon-corretto-crypto-provider/commit/084363e964d33d00b4e5a52e1043c7550e300365, we now have support for FIPS in ACCP. This PR adds FIPS support to our CI to ensure we have continuous integration tests running on the FIPS dimension. CI Readme has also been updated to reflect the newest state.

Example of run here: https://github.com/samuel40791765/amazon-corretto-crypto-provider/pull/13
Links to build can be found under the SIM ticket.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
