### PR TITLE
Enforce write lock on MiscSingleThreadedTests

### DIFF
--- a/tst/com/amazon/corretto/crypto/provider/test/EvpSignatureTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/EvpSignatureTest.java
@@ -36,7 +36,6 @@ import java.util.function.BiFunction;
 import java.util.stream.Stream;
 
 import com.amazon.corretto.crypto.provider.AmazonCorrettoCryptoProvider;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.parallel.Execution;

--- a/tst/com/amazon/corretto/crypto/provider/test/MiscSingleThreadedTests.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/MiscSingleThreadedTests.java
@@ -33,6 +33,7 @@ import java.security.Signature;
 @ExtendWith(TestResultLogger.class)
 @Execution(ExecutionMode.SAME_THREAD)
 @ResourceLock(value = TestUtil.RESOURCE_GLOBAL, mode = ResourceAccessMode.READ_WRITE)
+@ResourceLock(value = TestUtil.RESOURCE_PROVIDER, mode = ResourceAccessMode.READ_WRITE)
 public class MiscSingleThreadedTests {
 
     @AfterAll

--- a/tst/com/amazon/corretto/crypto/provider/test/MiscSingleThreadedTests.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/MiscSingleThreadedTests.java
@@ -5,12 +5,14 @@ package com.amazon.corretto.crypto.provider.test;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static com.amazon.corretto.crypto.provider.test.TestUtil.assumeMinimumVersion;
 import static com.amazon.corretto.crypto.provider.test.TestUtil.saveProviders;
 import static com.amazon.corretto.crypto.provider.test.TestUtil.restoreProviders;
 import static com.amazon.corretto.crypto.provider.test.TestUtil.NATIVE_PROVIDER;
 
 import com.amazon.corretto.crypto.provider.AmazonCorrettoCryptoProvider;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.parallel.Execution;
@@ -22,6 +24,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.Provider;
+import java.security.Security;
 import java.security.Signature;
 
 /**
@@ -29,9 +32,16 @@ import java.security.Signature;
  */
 @ExtendWith(TestResultLogger.class)
 @Execution(ExecutionMode.SAME_THREAD)
-@ResourceLock(value = TestUtil.RESOURCE_GLOBAL, mode = ResourceAccessMode.READ)
+@ResourceLock(value = TestUtil.RESOURCE_GLOBAL, mode = ResourceAccessMode.READ_WRITE)
 public class MiscSingleThreadedTests {
 
+    @AfterAll
+    public static void cleanup() {
+        Security.removeProvider(NATIVE_PROVIDER.getName());
+        for (Provider provider : Security.getProviders()) {
+            assertFalse(NATIVE_PROVIDER.equals(provider.getName()));
+        }
+    }
 
     /**
      * We do not (currently) support the signature NONEwithRSA, but the JCE implements it internally with

--- a/tst/com/amazon/corretto/crypto/provider/test/TestProviderInstallation.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/TestProviderInstallation.java
@@ -6,18 +6,21 @@ package com.amazon.corretto.crypto.provider.test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static com.amazon.corretto.crypto.provider.test.TestUtil.NATIVE_PROVIDER;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.security.MessageDigest;
+import java.security.Provider;
 import java.security.Security;
 
 import com.amazon.corretto.crypto.provider.AmazonCorrettoCryptoProvider;
 import org.junit.jupiter.api.Test;
 
 import com.amazon.corretto.crypto.provider.SelfTestStatus;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
@@ -29,6 +32,15 @@ import org.junit.jupiter.api.parallel.ResourceLock;
 @ResourceLock(value = TestUtil.RESOURCE_PROVIDER, mode = ResourceAccessMode.READ_WRITE)
 @ResourceLock(value = TestUtil.RESOURCE_GLOBAL, mode = ResourceAccessMode.READ_WRITE)
 public class TestProviderInstallation {
+
+    @AfterAll
+    public static void cleanup() {
+        Security.removeProvider(NATIVE_PROVIDER.getName());
+        for (Provider provider : Security.getProviders()) {
+            assertFalse(NATIVE_PROVIDER.equals(provider.getName()));
+        }
+    }
+
     @Test
     public void testProviderInstallation() throws Exception {
         Security.removeProvider("AmazonCorrettoCryptoProvider");


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*

We've been seeing some intermittent CI failures (both internally and
externally). These failures manifest in a few ways: assertions that keys
translated by different providers aren't the same, buffer lengths
differing from expected size, etc. These failures are consistent with
unexpected providers performing intended operations. One way this can
happen is a race in our tests. Some of our tests install ACCP as a
JVM-global provider, while the rest of our tests assume that ACCP is not
installed. Because we run our JUnit tests in parallel within the same
JVM process, if one of the installing tests wins the race, subsequent
losing tests will have their uninstalled-ACCP assumptions violated.

Taking a look at which tests install ACCP:

```
$ ag -l '\.install\(\)' tst/
tst/com/amazon/corretto/crypto/provider/test/RecursiveInitializationTest.java
tst/com/amazon/corretto/crypto/provider/test/integration/TestCertificateGenerator.java
tst/com/amazon/corretto/crypto/provider/test/MiscSingleThreadedTests.java
tst/com/amazon/corretto/crypto/provider/test/SecureRandomBench.java
tst/com/amazon/corretto/crypto/provider/test/SecureRandomGenerator.java
tst/com/amazon/corretto/crypto/provider/test/SecurityPropertyRecursiveTester.java
tst/com/amazon/corretto/crypto/provider/test/TestProviderInstallation.java
tst/com/amazon/corretto/crypto/provider/test/integration/TestHTTPSServer.java
```

All installing tests other than `TestProviderInstallation.java` and
`MiscSingleThreadedTests.java` are run as standalone tests in a separate
process from our tests run by the JUnit test runner.
`TestProviderInstallation.java` already had a write lock installed, but
`MiscSingleThreadedTests.java` hadn't. So, we add a write lock to ensure
that it does not run concurrently (and thus potentially interfere) with
any other tests.

Finally, we add `@AfterClass` methods to installing JUnit tests to
ensure that ACCP is not installed if these tests are run before any
others.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
