### PR TITLE
Fix libaccp builds for GCC 4.1.2

### DIFF
--- a/csrc/bn.cpp
+++ b/csrc/bn.cpp
@@ -55,12 +55,12 @@ namespace AmazonCorrettoCryptoProvider
 
     jbyteArray bn2jarr(raii_env &env, const BIGNUM *bn)
     {
-        int bnLen = BN_num_bytes(bn);
+        const size_t bnLen = BN_num_bytes(bn);
         if (unlikely(bnLen < 0))
         {
             throw_java_ex(EX_ERROR, "Bad bignum length");
         }
-        std::vector<uint8_t, SecureAlloc<uint8_t>> tmp(static_cast<size_t>(bnLen));
+        std::vector<uint8_t, SecureAlloc<uint8_t> > tmp(bnLen);
 
         BN_bn2bin(bn, &tmp[0]);
 

--- a/csrc/bn.h
+++ b/csrc/bn.h
@@ -109,7 +109,7 @@ namespace AmazonCorrettoCryptoProvider
 
         BigNumObj &operator=(BigNumObj &&bn)
         {
-            std::move(bn);
+            move(bn);
             return *this;
         }
 
@@ -122,7 +122,8 @@ namespace AmazonCorrettoCryptoProvider
         {
             BigNumObj &other = const_cast<BigNumObj &>(other_const);
 
-            std::move(other);
+            // No std::move before C++11, use this class's implementation.
+            move(other);
 
             return *this;
         }

--- a/csrc/ec_gen.cpp
+++ b/csrc/ec_gen.cpp
@@ -115,7 +115,7 @@ JNIEXPORT long JNICALL Java_com_amazon_corretto_crypto_provider_EcGen_generateEv
     jbyteArray paramsDer,
     jboolean checkConsistency)
 {
-    std::vector<uint8_t, SecureAlloc<uint8_t>> derBuf;
+    std::vector<uint8_t, SecureAlloc<uint8_t> > derBuf;
     EC_KEY_auto ecParams;
     EVP_PKEY_auto params_as_pkey = EVP_PKEY_auto::from(EVP_PKEY_new());
     EVP_PKEY_auto key;


### PR DESCRIPTION
*Issue #, if available:* [CryptoAlg-1161](https://sim.amazon.com/issues/CryptoAlg-1161)

*Description of changes:*

# Notes

This commit fixes builds for ACCP's native library on GCC 4.1.2, which
only supports a subset of C++11. This issue was first discovered while
trying to build ACCP internally on RHEL5, which failed. Two of the
changes in this commit are trivial syntax/const semantics changes.

Another change accounts for C++ not having added [`std::move` to the
standard library until C++11][1], and also fixes a subtle "bug" that was
introcuded [here][2] (prompted by [this][3]). The change to using
`BigNumObj::move` instead of `std::move` under C++11 shouldn't make a
significant difference -- the two behave the same in that they both give
ownership of the passed BN to the calling instance. In C++ versions less
than 11, however, `std::move` doesn't exist so the code doesn't compile.

Finally, we update our AWS-LC dependency commit to incorporate [a recent
change][4] fixing AWS-LC C++ builds on GCC 4.1.2.

[1]: https://en.cppreference.com/w/cpp/utility/move
[2]: https://github.com/corretto/amazon-corretto-crypto-provider/pull/132/commits/b285ff31cf5474b6834d43c870455cfcfffbbd50#diff-3c12dad8524f0f17ae8b278d84f58fa405409117925d51bb9d08fc9758ae1382
[3]: https://github.com/corretto/amazon-corretto-crypto-provider/pull/132#discussion_r861967037
[4]: https://github.com/awslabs/aws-lc/commit/42a8dbacd473d2ad95f9d0d5e47ba95a4e92f4c3

# Testing
- CI on this PR for modern GCC
- for brazil testing on RHEL 5, see below:

```
$ # NOTE PLATFORM OVERRIDE

$ brazil ws show
Workspace:              childw_accp_import
    Root:               /local/home/childw/workplace/brazil/accp_import
    Version Set:        AmazonCorrettoCryptoProvider/import@6085387855
    Platform Override:  RHEL5_64
    Packages:
                        AWS-LC-0.x -> .
                        NativeJCEBindings-1.1 -> .
                        RubinAwsCrypToolsTools-1.0 -> .

$ rde :brazil sandbox-build --target clean && rde :brazil sandbox-build --target release
...
Status: Image is up to date for 011465881737.dkr.ecr.us-west-2.amazonaws.com/sandboxed-builds:rhel5_64-1.0-latest
...
Test run finished after 377782 ms
[       139 containers found      ]
[         0 containers skipped    ]
[       139 containers started    ]
[         0 containers aborted    ]
[       139 containers successful ]
[         0 containers failed     ]
[     14277 tests found           ]
[         0 tests skipped         ]
[     14277 tests started         ]
[        75 tests aborted         ]
[     14202 tests successful      ]
[         0 tests failed          ]
...
BUILD SUCCEEDED
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
