### PR TITLE
Add configuration security file for JDKs newer than 11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Current values are:
    This may require deleting `build/cmake` prior to running.
    [PR #191](https://github.com/corretto/amazon-corretto-crypto-provider/pull/191)
 * Add `KeyFactory` implementations for RSA and EC keys. This also includes our own implementations of keys for the same algorithms. [PR #132](https://github.com/corretto/amazon-corretto-crypto-provider/pull/132)
+* Added `amazon-corretto-crypto-provider-jdk15.security` to support JDK15+.
 
 ### Patches
 * Improve zeroization of DRBG output. [PR #162](https://github.com/corretto/amazon-corretto-crypto-provider/pull/162)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -721,6 +721,12 @@ add_custom_target(check-recursive-init
 
     DEPENDS accp-jar tests-jar)
 
+if (TEST_JAVA_MAJOR_VERSION VERSION_GREATER 11)
+    set(INSTALL_PROPERTY_FILE ${ORIG_SRCROOT}/etc/amazon-corretto-crypto-provider-jdk15.security)
+else()
+    set(INSTALL_PROPERTY_FILE ${ORIG_SRCROOT}/etc/amazon-corretto-crypto-provider.security)
+endif()
+
 add_custom_target(check-install-via-properties
     COMMAND ${TEST_JAVA_EXECUTABLE}
         ${COVERAGE_ARGUMENTS}
@@ -729,7 +735,7 @@ add_custom_target(check-install-via-properties
         ${EXTERNAL_LIB_PROPERTY}
         -Dcom.amazon.corretto.crypto.provider.inTestSuite=hunter2
         -Dtest.data.dir=${TEST_DATA_DIR}
-        -Djava.security.properties=${ORIG_SRCROOT}/etc/amazon-corretto-crypto-provider.security
+        -Djava.security.properties=${INSTALL_PROPERTY_FILE}
         ${TEST_JAVA_ARGS}
         com.amazon.corretto.crypto.provider.test.SecurityPropertyTester
 
@@ -747,7 +753,7 @@ add_custom_target(check-external-lib
         -Dcom.amazon.corretto.crypto.provider.useExternalLib=true
         -Dcom.amazon.corretto.crypto.provider.inTestSuite=hunter2
         -Dtest.data.dir=${TEST_DATA_DIR}
-        -Djava.security.properties=${ORIG_SRCROOT}/etc/amazon-corretto-crypto-provider.security
+        -Djava.security.properties=${INSTALL_PROPERTY_FILE}
         ${TEST_JAVA_ARGS}
         com.amazon.corretto.crypto.provider.test.SecurityPropertyTester
 
@@ -761,7 +767,7 @@ add_custom_target(check-install-via-properties-recursive
         ${EXTERNAL_LIB_PROPERTY}
         -Dcom.amazon.corretto.crypto.provider.inTestSuite=hunter2
         -Dtest.data.dir=${TEST_DATA_DIR}
-        -Djava.security.properties=${ORIG_SRCROOT}/etc/amazon-corretto-crypto-provider.security
+        -Djava.security.properties=${INSTALL_PROPERTY_FILE}
         ${TEST_JAVA_ARGS}
         com.amazon.corretto.crypto.provider.test.SecurityPropertyRecursiveTester
 
@@ -775,7 +781,7 @@ add_custom_target(check-install-via-properties-with-debug
         ${EXTERNAL_LIB_PROPERTY}
         -Dcom.amazon.corretto.crypto.provider.inTestSuite=hunter2
         -Dtest.data.dir=${TEST_DATA_DIR}
-        -Djava.security.properties=${ORIG_SRCROOT}/etc/amazon-corretto-crypto-provider.security
+        -Djava.security.properties=${INSTALL_PROPERTY_FILE}
         -Djava.security.debug=all
         ${TEST_JAVA_ARGS}
         com.amazon.corretto.crypto.provider.test.SecurityPropertyTester

--- a/README.md
+++ b/README.md
@@ -190,10 +190,16 @@ There are several ways to configure the ACCP as the highest priority provider in
 Run the following method early in program start up: `com.amazon.corretto.crypto.provider.AmazonCorrettoCryptoProvider.install()`
 
 ### Via Security Properties
-Add the following Java property to your programs command line: `-Djava.security.properties=/path/to/amazon-corretto-crypto-provider.security` where amazon-corretto-crypto-provider.security is [downloaded from](https://github.com/corretto/amazon-corretto-crypto-provider/blob/master/etc/amazon-corretto-crypto-provider.security) our repository.
+Add the following Java property to your programs command line: `-Djava.security.properties=/path/to/amazon-corretto-crypto-provider.security` where amazon-corretto-crypto-provider.security is downloaded from
+[amazon-corretto-crypto-provider.security](./etc/amazon-corretto-crypto-provider.security) (for JDK versions older than JDK15)
+or [amazon-corretto-crypto-provider-jdk15.security](./etc/amazon-corretto-crypto-provider-jdk15.security) (for JDK15 or newer)
+in our repository.
 
 ### Modify the JVM settings
-Modify the `java.security` file provided by your JVM so that the highest priority provider is the Amazon Corretto Crypto Provider. Look at [amazon-corretto-crypto-provider.security](https://github.com/corretto/amazon-corretto-crypto-provider/blob/master/etc/amazon-corretto-crypto-provider.security) for an example of what this change will look like.
+Modify the `java.security` file provided by your JVM so that the highest priority provider is the Amazon Corretto Crypto Provider.
+Look at [amazon-corretto-crypto-provider.security](./etc/amazon-corretto-crypto-provider.security) (JDKs 11 and older)
+or [amazon-corretto-crypto-provider-jdk15.security](./etc/amazon-corretto-crypto-provider-modules.security) (for JDKs newer than 11)
+for an example of what this change will look like.
 
 ### Verification (Optional)
 If you want to check to verify that ACCP is properly working on your system, you can do any of the following:

--- a/etc/amazon-corretto-crypto-provider-jdk15.security
+++ b/etc/amazon-corretto-crypto-provider-jdk15.security
@@ -1,0 +1,36 @@
+#
+# List of providers and their preference orders
+
+# Note that we can't just insert ours at the top - we need to restate all
+# providers that are being shifted down to a different index (which is to say,
+# all of them).
+#
+# To ensure this file works on all possible platforms we do include platform specific providers.
+
+security.provider.1=com.amazon.corretto.crypto.provider.AmazonCorrettoCryptoProvider
+security.provider.2=SUN
+security.provider.3=SunRsaSign
+security.provider.4=SunEC
+security.provider.5=SunJSSE
+security.provider.6=SunJCE
+security.provider.7=SunJGSS
+security.provider.8=SunSASL
+security.provider.9=XMLDSig
+security.provider.10=SunPCSC
+security.provider.11=JdkLDAP
+security.provider.12=JdkSASL
+security.provider.13=SunMSCAPI
+security.provider.14=Apple
+security.provider.15=SunPKCS11
+
+#
+# A list of known strong SecureRandom implementations.
+#
+# To help guide applications in selecting a suitable strong
+# java.security.SecureRandom implementation, Java distributions should
+# indicate a list of known strong implementations using the property.
+#
+# This is a comma-separated list of algorithm and/or algorithm:provider
+# entries.
+#
+securerandom.strongAlgorithms=NIST800-90A/AES-CTR-256:AmazonCorrettoCryptoProvider,NativePRNGBlocking:SUN,DRBG:SUN

--- a/etc/amazon-corretto-crypto-provider-jdk15.security
+++ b/etc/amazon-corretto-crypto-provider-jdk15.security
@@ -33,4 +33,4 @@ security.provider.15=SunPKCS11
 # This is a comma-separated list of algorithm and/or algorithm:provider
 # entries.
 #
-securerandom.strongAlgorithms=NIST800-90A/AES-CTR-256:AmazonCorrettoCryptoProvider,NativePRNGBlocking:SUN,DRBG:SUN
+securerandom.strongAlgorithms=DEFAULT:AmazonCorrettoCryptoProvider,NativePRNGBlocking:SUN,DRBG:SUN

--- a/etc/amazon-corretto-crypto-provider.security
+++ b/etc/amazon-corretto-crypto-provider.security
@@ -59,4 +59,4 @@ security.provider.22=SunPKCS11
 # This is a comma-separated list of algorithm and/or algorithm:provider
 # entries.
 #
-securerandom.strongAlgorithms=NIST800-90A/AES-CTR-256:AmazonCorrettoCryptoProvider,NativePRNGBlocking:SUN,DRBG:SUN
+securerandom.strongAlgorithms=DEFAULT:AmazonCorrettoCryptoProvider,NativePRNGBlocking:SUN,DRBG:SUN

--- a/etc/amazon-corretto-crypto-provider.security
+++ b/etc/amazon-corretto-crypto-provider.security
@@ -43,7 +43,11 @@ security.provider.14=sun.security.smartcardio.SunPCSC
 security.provider.15=SunPCSC
 security.provider.16=JdkLDAP
 security.provider.17=JdkSASL
-security.provider.18=SunPKCS11
+security.provider.18=sun.security.mscapi.SunMSCAPI
+security.provider.19=SunMSCAPI
+security.provider.20=apple.security.AppleProvider
+security.provider.21=Apple
+security.provider.22=SunPKCS11
 
 #
 # A list of known strong SecureRandom implementations.

--- a/tests/ci/run_accp_basic_tests.sh
+++ b/tests/ci/run_accp_basic_tests.sh
@@ -25,7 +25,7 @@ version=$($TEST_JAVA_HOME/bin/java -version 2>&1 | head -1 | cut -d'"' -f2 | sed
 # The JDK version should be least 10 for a regular ACCP build. We can
 # still test on older versions with the TEST_JAVA_HOME property.
 if (( "$version" <= "10" )); then
-	./gradlew -DTEST_JAVA_HOME=$TEST_JAVA_HOME -DFIPS=$testing_fips test
+	./gradlew -DTEST_JAVA_HOME=$TEST_JAVA_HOME -DTEST_JAVA_MAJOR_VERSION=$version -DFIPS=$testing_fips test
 	exit $?
 fi
 
@@ -35,6 +35,4 @@ fi
 export JAVA_HOME=$TEST_JAVA_HOME
 export PATH=$JAVA_HOME/bin:$PATH
 
-# TEST_JAVA_MAJOR_VERSION is necessary in Java17+ for certain unit tests to
-# perform deep reflection on nonpublic members.
-./gradlew -DTEST_JAVA_MAJOR_VERSION=$version -DFIPS=$testing_fips release
+./gradlew -DFIPS=$testing_fips release

--- a/tests/ci/run_accp_test_integration.sh
+++ b/tests/ci/run_accp_test_integration.sh
@@ -25,7 +25,7 @@ version=$($TEST_JAVA_HOME/bin/java -version 2>&1 | head -1 | cut -d'"' -f2 | sed
 # The JDK version should be least 10 for a regular ACCP build. We can
 # still test on older versions with the TEST_JAVA_HOME property.
 if (( "$version" <= "10" )); then
-	./gradlew -DTEST_JAVA_HOME=$TEST_JAVA_HOME -DFIPS=$testing_fips test_integration
+	./gradlew -DTEST_JAVA_HOME=$TEST_JAVA_HOME -DTEST_JAVA_MAJOR_VERSION=$version -DFIPS=$testing_fips test_integration
 	exit $?
 fi
 
@@ -35,6 +35,4 @@ fi
 export JAVA_HOME=$TEST_JAVA_HOME
 export PATH=$JAVA_HOME/bin:$PATH
 
-# TEST_JAVA_MAJOR_VERSION is necessary in Java17+ for certain unit tests to
-# perform deep reflection on nonpublic members.
-./gradlew -DTEST_JAVA_MAJOR_VERSION=$version -DFIPS=$testing_fips test_integration
+./gradlew -DFIPS=$testing_fips test_integration

--- a/tst/com/amazon/corretto/crypto/provider/test/SecurityPropertyTester.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/SecurityPropertyTester.java
@@ -12,6 +12,8 @@ import java.security.Security;
 import java.util.HashSet;
 import java.util.Set;
 
+import javax.net.ssl.SSLContext;
+
 /**
  * This is a special stand-alone test case which asserts that AmazonCorrettoCryptoProvider is installed
  * as the highest priority provider and is functional.
@@ -25,6 +27,9 @@ public final class SecurityPropertyTester {
 
     final Provider provider = Security.getProviders()[0];
     assertEquals(NATIVE_PROVIDER.getName(), provider.getName());
+
+    // Ensure that TLS works as expected
+    SSLContext.getInstance("TLS"); // Throws exception on problem
 
     // We know that Java has the SunEC provider which can generate EC keys.
     // We try to grab it to show that the nothing interfered with proper provider loading.

--- a/tst/com/amazon/corretto/crypto/provider/test/SecurityPropertyTester.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/SecurityPropertyTester.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.security.KeyPairGenerator;
 import java.security.Provider;
+import java.security.SecureRandom;
 import java.security.Security;
 import java.util.HashSet;
 import java.util.Set;
@@ -35,6 +36,11 @@ public final class SecurityPropertyTester {
     // We try to grab it to show that the nothing interfered with proper provider loading.
     @SuppressWarnings("unused")
     KeyPairGenerator kpg = KeyPairGenerator.getInstance("EC", "SunEC");
+
+    // Ensure we properly configured ourselves as "strong" instance of SecureRandom
+    // Applications should never use getInstanceStrong as it is an anti-pattern.
+    final SecureRandom strongRng = SecureRandom.getInstanceStrong();
+    assertEquals(NATIVE_PROVIDER.getName(), strongRng.getProvider().getName());
 
     // Also ensure that nothing shows up twice
     Set<String> names = new HashSet<>();


### PR DESCRIPTION
*Issue:* Fixes #175

*Description of changes:*
General fixes to existing `java.security` configuration file. Introduces a new version of JDKs newer than 11 (tested on 17). Updates tests to use the new file as well as introduces a regression test which detects if we break TLS in the future.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
