### PR TITLE
Skip tests that rely on JCE RSASSA-PSS for JDKs that don't support it

### DIFF
--- a/src/com/amazon/corretto/crypto/provider/EvpSignatureBase.java
+++ b/src/com/amazon/corretto/crypto/provider/EvpSignatureBase.java
@@ -10,6 +10,7 @@ import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.InvalidParameterException;
 import java.security.Key;
+import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.SignatureException;
@@ -223,6 +224,10 @@ abstract class EvpSignatureBase extends SignatureSpi {
                 final AlgorithmParameters params = AlgorithmParameters.getInstance("RSASSA-PSS");
                 params.init(pssParams_);
                 return params;
+            } catch (final NoSuchAlgorithmException ex) {
+                // NOTE: this method can only throw unchecked exceptions, and UnsupportedOperationException
+                // seems like the most appropriate for JDK platforms that don't support RSASSA-PSS.
+                throw new UnsupportedOperationException("RSASSA-PSS unsupported.", ex);
             } catch (final GeneralSecurityException ex) {
                 throw new AssertionError(ex);
             }

--- a/tst/com/amazon/corretto/crypto/provider/test/EvpKeyFactoryTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/EvpKeyFactoryTest.java
@@ -69,8 +69,8 @@ import org.junit.jupiter.params.provider.MethodSource;
 @Execution(ExecutionMode.CONCURRENT)
 @ResourceLock(value = TestUtil.RESOURCE_GLOBAL, mode = ResourceAccessMode.READ)
 public class EvpKeyFactoryTest {
-    private static Set<String> ALGORITHMS = new HashSet<>();
-    private static Map<String, List<Arguments>> KEYPAIRS = new HashMap<>();
+    private static final Set<String> ALGORITHMS = new HashSet<>();
+    private static final Map<String, List<Arguments>> KEYPAIRS = new HashMap<>();
 
     @BeforeAll
     public static void setupParameters() throws Exception {
@@ -118,11 +118,11 @@ public class EvpKeyFactoryTest {
     }
 
     public static List<Arguments> rsaPairs() {
-        return KEYPAIRS.get("RSA");
+        return new ArrayList<>(KEYPAIRS.get("RSA"));
     }
 
     public static List<Arguments> ecPairs() {
-        return KEYPAIRS.get("EC");
+        return new ArrayList<>(KEYPAIRS.get("EC"));
     }
 
     public static List<Arguments> badEcPublicKeys() throws Exception {


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*

# Notes
## Skip tests that rely on JCE RSASSA-PSS for JDKs that don't support it

JDK10 doesn't seem to ship with RSASSA-PSS support by default, so skip
tests that rely on comparisons against JCE PSS implementations for JDK
versions that don't support them.

We also adjust EvpSignature.engineGetParameters to throw an
InvalidArgumentException (from the java.security package) when PSS
parameters are requested on a JDK platform that doesn't support them.

## Use copies of static member vars in EvpKeyFactoryTest

We've been seeing a number of intermittent test EvpKeyFactoryTest
failures in dryrun builds (such as [this one][1]) that appear to be due
to thread safety issues in the test runner. This commit returns _copies_
of static hashmap entries rather than shared references for
parameterized test parameters, so concurrent test case threads
accessing/using/potentially overwriting those values should be totally
independent. Confidence in this change was bolstered by two successful
dryruns:

- [AmazonCorrettoCryptoProvider/import][2]
- [AWSCryptoTools/native-jce-bindings][3]
  + NB: KMSCryptoCommon is failing in this dryrun for [known reasons][4]
    and can be ignored for the purposes of this commit.

[1]: https://build.amazon.com/6026895824
[2]: https://build.amazon.com/6026902091
[3]: https://build.amazon.com/6026903374
[4]: https://sim.amazon.com/issues/f81ed0df-6cc5-4c61-a385-d0f699f40576?selectedConversation=b126847d-41b6-4c5c-a9f8-ba28cb4479d7


# Testing
See CI checks for external validation. For internal validation, in a local brazil workspace I ran:

```
$ bb clean && bb release
...
BUILD SUCCEEDED
```

Dry runs against a few versionsets:

- [AmazonCorrettoCryptoProvider/import](https://build.amazon.com/6027001760)
- [AWSCryptoTools/njce-pre-sign](https://build.amazon.com/6027002969)
   + NB: KMSCryptoCommon is failing in this dryrun for [known reasons][4]
    and can be ignored for the purposes of this commit.
---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
