### PR TITLE
Report coverage in CodeBuild

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,48 +130,16 @@ add_custom_command(
     COMMENT "Generating hash function SPI classes..."
     )
 
-set(ACCP_SRC
-        src/com/amazon/corretto/crypto/provider/AccessibleByteArrayOutputStream.java
-        src/com/amazon/corretto/crypto/provider/AesGcmSpi.java
-        src/com/amazon/corretto/crypto/provider/ConstantTime.java
-        src/com/amazon/corretto/crypto/provider/DebugFlag.java
-        src/com/amazon/corretto/crypto/provider/EcGen.java
-        src/com/amazon/corretto/crypto/provider/EvpHmac.java
-        src/com/amazon/corretto/crypto/provider/EvpKeyAgreement.java
-        src/com/amazon/corretto/crypto/provider/EvpKey.java
-        src/com/amazon/corretto/crypto/provider/EvpEcKey.java
-        src/com/amazon/corretto/crypto/provider/EvpEcPublicKey.java
-        src/com/amazon/corretto/crypto/provider/EvpEcPrivateKey.java
-        src/com/amazon/corretto/crypto/provider/EvpRsaKey.java
-        src/com/amazon/corretto/crypto/provider/EvpRsaPublicKey.java
-        src/com/amazon/corretto/crypto/provider/EvpRsaPrivateKey.java
-        src/com/amazon/corretto/crypto/provider/EvpRsaPrivateCrtKey.java
-        src/com/amazon/corretto/crypto/provider/EvpKeyFactory.java
-        src/com/amazon/corretto/crypto/provider/EvpKeyType.java
-        src/com/amazon/corretto/crypto/provider/EvpSignature.java
-        src/com/amazon/corretto/crypto/provider/EvpSignatureBase.java
-        src/com/amazon/corretto/crypto/provider/EvpSignatureRaw.java
-        src/com/amazon/corretto/crypto/provider/EcUtils.java
-        src/com/amazon/corretto/crypto/provider/ExtraCheck.java
-        src/com/amazon/corretto/crypto/provider/InputBuffer.java
-        src/com/amazon/corretto/crypto/provider/Janitor.java
-        src/com/amazon/corretto/crypto/provider/LibCryptoRng.java
-        src/com/amazon/corretto/crypto/provider/Loader.java
-        src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
-        src/com/amazon/corretto/crypto/provider/NativeResource.java
-        src/com/amazon/corretto/crypto/provider/MiscInterfaces.java
-        src/com/amazon/corretto/crypto/provider/ReflectiveTools.java
-        src/com/amazon/corretto/crypto/provider/RsaCipher.java
-        src/com/amazon/corretto/crypto/provider/RsaGen.java
-        src/com/amazon/corretto/crypto/provider/RuntimeCryptoException.java
-        src/com/amazon/corretto/crypto/provider/SelfTestFailureException.java
-        src/com/amazon/corretto/crypto/provider/SelfTestResult.java
-        src/com/amazon/corretto/crypto/provider/SelfTestStatus.java
-        src/com/amazon/corretto/crypto/provider/SelfTestSuite.java
-        src/com/amazon/corretto/crypto/provider/ServiceProviderFactory.java
-        src/com/amazon/corretto/crypto/provider/Utils.java
-        ${GENERATED_JAVA_SRC}
-)
+# NOTE: CMake introduced the CONFIGURE_DEPENDS feature in 3.12, so condition
+#       its use on CMake version. If the feature is not available, you may need
+#       to `touch CMakeLists.txt` after adding/removing files for them to be
+#       detected by CMake.
+if (${CMAKE_VERSION} VERSION_LESS "3.12.0")
+    file(GLOB ACCP_SRC "src/com/amazon/corretto/crypto/provider/*.java")
+else()
+    file(GLOB ACCP_SRC CONFIGURE_DEPENDS "src/com/amazon/corretto/crypto/provider/*.java")
+endif()
+set(ACCP_SRC ${ACCP_SRC} ${GENERATED_JAVA_SRC})
 
 set(BASE_JAVA_COMPILE_FLAGS ${CMAKE_JAVA_COMPILE_FLAGS} -h "${JNI_HEADER_DIR}" -Werror -Xlint)
 
@@ -553,59 +521,21 @@ target_link_libraries(amazonCorrettoCryptoProvider Threads::Threads)
 # Take a dependency on our libcrypto.so file
 target_link_libraries(amazonCorrettoCryptoProvider ${OPENSSL_CRYPTO_LIBRARY})
 
+# NOTE: CMake introduced the CONFIGURE_DEPENDS feature in 3.12, so condition
+#       its use on CMake version. If the feature is not available, you may need
+#       to `touch CMakeLists.txt` after adding/removing files for them to be
+#       detected by CMake.
+if (${CMAKE_VERSION} VERSION_LESS "3.12.0")
+    file(GLOB_RECURSE ACCP_TEST_SRC "tst/com/amazon/corretto/crypto/provider/*.java")
+else()
+    file(GLOB_RECURSE ACCP_TEST_SRC CONFIGURE_DEPENDS "tst/com/amazon/corretto/crypto/provider/*.java")
+endif()
+
+
 ## Tests
 add_jar(
     tests-code-jar
-    SOURCES
-        tst/com/amazon/corretto/crypto/provider/test/AccessibleByteArrayOutputStreamTest.java
-        tst/com/amazon/corretto/crypto/provider/test/AESGenerativeTest.java
-        tst/com/amazon/corretto/crypto/provider/test/AesTest.java
-        tst/com/amazon/corretto/crypto/provider/test/ConstantTimeTests.java
-        tst/com/amazon/corretto/crypto/provider/test/EcGenTest.java
-        tst/com/amazon/corretto/crypto/provider/test/EvpKeyAgreementTest.java
-        tst/com/amazon/corretto/crypto/provider/test/EvpKeyAgreementSpecificTest.java
-        tst/com/amazon/corretto/crypto/provider/test/EvpSignatureSpecificTest.java
-        tst/com/amazon/corretto/crypto/provider/test/EvpSignatureTest.java
-        tst/com/amazon/corretto/crypto/provider/test/HashFunctionTester.java
-        tst/com/amazon/corretto/crypto/provider/test/HmacTest.java
-        tst/com/amazon/corretto/crypto/provider/test/InputBufferTest.java
-        tst/com/amazon/corretto/crypto/provider/test/JanitorTest.java
-        tst/com/amazon/corretto/crypto/provider/test/EvpKeyFactoryTest.java
-        tst/com/amazon/corretto/crypto/provider/test/LibCryptoRngTest.java
-        tst/com/amazon/corretto/crypto/provider/test/MD5Test.java
-        tst/com/amazon/corretto/crypto/provider/test/MiscSingleThreadedTests.java
-        tst/com/amazon/corretto/crypto/provider/test/NativeTestHooks.java
-        tst/com/amazon/corretto/crypto/provider/test/NativeTest.java
-        tst/com/amazon/corretto/crypto/provider/test/RecursiveInitializationTest.java
-        tst/com/amazon/corretto/crypto/provider/test/RsaCipherTest.java
-        tst/com/amazon/corretto/crypto/provider/test/RsaGenTest.java
-        tst/com/amazon/corretto/crypto/provider/test/SecurityPropertyTester.java
-        tst/com/amazon/corretto/crypto/provider/test/SecurityPropertyRecursiveTester.java
-        tst/com/amazon/corretto/crypto/provider/test/SHA1Test.java
-        tst/com/amazon/corretto/crypto/provider/test/SHA256Test.java
-        tst/com/amazon/corretto/crypto/provider/test/SHA384Test.java
-        tst/com/amazon/corretto/crypto/provider/test/SHA512Test.java
-        tst/com/amazon/corretto/crypto/provider/test/SecurityManagerTest.java
-        tst/com/amazon/corretto/crypto/provider/test/SelfTestSuiteTest.java
-        tst/com/amazon/corretto/crypto/provider/test/ServiceSelfTestMetaTest.java
-        tst/com/amazon/corretto/crypto/provider/test/TestProviderInstallation.java
-        tst/com/amazon/corretto/crypto/provider/test/TestResultLogger.java
-        tst/com/amazon/corretto/crypto/provider/test/TestUtil.java
-        tst/com/amazon/corretto/crypto/provider/test/ThrowingRunnable.java
-        tst/com/amazon/corretto/crypto/provider/test/UtilsTest.java
-        tst/com/amazon/corretto/crypto/provider/test/integration/CustomTrustManager.java
-        tst/com/amazon/corretto/crypto/provider/test/integration/ExternalHTTPSIntegrationTest.java
-        tst/com/amazon/corretto/crypto/provider/test/integration/HTTPSTestParameters.java
-        tst/com/amazon/corretto/crypto/provider/test/integration/LocalHTTPSIntegrationTest.java
-        tst/com/amazon/corretto/crypto/provider/test/integration/TestCertificateGenerator.java
-        tst/com/amazon/corretto/crypto/provider/test/integration/TestHTTPSServer.java
-        # Not tests, but things we need related to tests
-        tst/com/amazon/corretto/crypto/provider/test/AESBench.java
-        tst/com/amazon/corretto/crypto/provider/test/Benchmark.java
-        tst/com/amazon/corretto/crypto/provider/coverage/ReportGenerator.java
-        tst/com/amazon/corretto/crypto/provider/test/RspTestEntry.java
-        tst/com/amazon/corretto/crypto/provider/test/SecureRandomGenerator.java
-
+    SOURCES ${ACCP_TEST_SRC}
     INCLUDE_JARS ${TEST_CLASSPATH_LIST} code-only-jar
 )
 set_target_properties(tests-code-jar PROPERTIES EXCLUDE_FROM_ALL 1)

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -25,10 +25,13 @@ ENV JAVA_HOME=/usr/lib/jvm/java-11-amazon-corretto/
 RUN echo 'export JAVA_HOME=/usr/lib/jvm/java-11-amazon-corretto/' >> /home/.bashrc
 
 # required dependencies for building/testing
+RUN apt-get update
 RUN apt-get install -y build-essential
 RUN apt-get install -y cmake
 RUN apt-get install -y dieharder
 RUN apt-get install -y lcov
+RUN apt-get install -y python3-pip
+RUN pip3 install gcovr
 
 # developement niceties
 RUN apt-get install -y ninja-build

--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Building this provider requires a 64 bit Linux build system with the following p
 * [cmake](https://cmake.org/) 3.8 or newer
 * C++ build chain
 * [lcov](http://ltp.sourceforge.net/coverage/lcov.php) for coverage metrics
+* [gcovr](https://gcovr.com/en/stable/) for reporting coverage metrics in CodeBuild
 * [dieharder](http://webhome.phy.duke.edu/~rgb/General/dieharder.php) for entropy tests
 
 1. Download the repository via `git clone --recurse-submodules`

--- a/build.gradle
+++ b/build.gradle
@@ -435,7 +435,6 @@ task coverage_cmake(type: Exec) {
         args '-DSINGLE_TEST=' + System.properties['SINGLE_TEST']
 
     }
-
 }
 
 task coverage_exec(type: Exec) {
@@ -480,6 +479,11 @@ task coverage_cpp_report {
             workingDir "${buildDir}/cmake-coverage"
             commandLine 'lcov', '-e', "${buildDir}/cmake-coverage/coverage.info", 'csrc/*', '--rc', 'lcov_branch_coverage=1'
             standardOutput = new FileOutputStream("${buildDir}/reports/cpp/coverage.info")
+        }
+        exec {
+            workingDir "${buildDir}/cmake-coverage"
+            commandLine 'gcovr', '-r', "${projectDir}", '--cobertura-pretty'
+            standardOutput = new FileOutputStream("${buildDir}/reports/cpp/cobertura.xml")
         }
         exec {
              workingDir projectDir

--- a/tests/ci/codebuild/run_accp_basic_tests.yml
+++ b/tests/ci/codebuild/run_accp_basic_tests.yml
@@ -13,3 +13,11 @@ reports:
       - 'build/reports/unit-tests/**'
     discard-paths: yes
     file-format: JunitXml
+  java-coverage-report:
+    files:
+      - 'build/cmake-coverage/coverage/results/coverage-report.xml'
+    file-format: 'JACOCOXML'
+  cpp-coverage-report:
+    files:
+      - 'build/reports/cpp/cobertura.xml'
+    file-format: 'COBERTURAXML'

--- a/tests/ci/codebuild/run_accp_basic_tests_fips.yml
+++ b/tests/ci/codebuild/run_accp_basic_tests_fips.yml
@@ -13,3 +13,11 @@ reports:
       - 'build/reports/unit-tests/**'
     discard-paths: yes
     file-format: JunitXml
+  java-coverage-report:
+    files:
+      - 'build/cmake-coverage/coverage/results/coverage-report.xml'
+    file-format: 'JACOCOXML'
+  cpp-coverage-report:
+    files:
+      - 'build/reports/cpp/cobertura.xml'
+    file-format: 'COBERTURAXML'

--- a/tests/ci/docker_images/linux-arm/amazonlinux-2_accp_base/Dockerfile
+++ b/tests/ci/docker_images/linux-arm/amazonlinux-2_accp_base/Dockerfile
@@ -12,6 +12,7 @@ RUN set -ex && \
     make \
     ninja-build \
     perl \
+    python3-pip \
     golang \
     which \
     git \
@@ -22,6 +23,8 @@ RUN set -ex && \
     yum clean all && \
     rm -rf /tmp/* && \
     rm -rf /var/cache/yum
+
+RUN pip3 install gcovr
 
 # Get lcov from source because AL2 doesn't have support for installing directly.
 RUN wget http://downloads.sourceforge.net/ltp/lcov-1.14-1.noarch.rpm && \

--- a/tests/ci/docker_images/linux-arm/ubuntu-20.04_accp_base/Dockerfile
+++ b/tests/ci/docker_images/linux-arm/ubuntu-20.04_accp_base/Dockerfile
@@ -17,6 +17,8 @@ RUN apt-get install -y cmake
 RUN apt-get install -y dieharder
 RUN apt-get install -y lcov
 RUN apt-get install -y wget
+RUN apt-get install -y python3-pip
+RUN pip3 install gcovr
 
 # developement niceties
 RUN apt-get install -y ninja-build

--- a/tests/ci/docker_images/linux-x86/amazonlinux-2_accp_base/Dockerfile
+++ b/tests/ci/docker_images/linux-x86/amazonlinux-2_accp_base/Dockerfile
@@ -12,6 +12,7 @@ RUN set -ex && \
     make \
     ninja-build \
     perl \
+    python3-pip \
     golang \
     which \
     git \
@@ -22,6 +23,8 @@ RUN set -ex && \
     yum clean all && \
     rm -rf /tmp/* && \
     rm -rf /var/cache/yum
+
+RUN pip3 install gcovr
 
 # Get lcov from source because AL2 doesn't have support for installing directly.
 RUN wget http://downloads.sourceforge.net/ltp/lcov-1.14-1.noarch.rpm && \

--- a/tests/ci/docker_images/linux-x86/ubuntu-20.04_accp_base/Dockerfile
+++ b/tests/ci/docker_images/linux-x86/ubuntu-20.04_accp_base/Dockerfile
@@ -17,6 +17,8 @@ RUN apt-get install -y cmake
 RUN apt-get install -y dieharder
 RUN apt-get install -y lcov
 RUN apt-get install -y wget
+RUN apt-get install -y python3-pip
+RUN pip3 install gcovr
 
 # developement niceties
 RUN apt-get install -y ninja-build

--- a/tests/ci/run_accp_basic_tests.sh
+++ b/tests/ci/run_accp_basic_tests.sh
@@ -25,7 +25,7 @@ version=$($TEST_JAVA_HOME/bin/java -version 2>&1 | head -1 | cut -d'"' -f2 | sed
 # The JDK version should be least 10 for a regular ACCP build. We can
 # still test on older versions with the TEST_JAVA_HOME property.
 if (( "$version" <= "10" )); then
-	./gradlew -DTEST_JAVA_HOME=$TEST_JAVA_HOME -DTEST_JAVA_MAJOR_VERSION=$version -DFIPS=$testing_fips test
+	./gradlew -DTEST_JAVA_HOME=$TEST_JAVA_HOME -DTEST_JAVA_MAJOR_VERSION=$version -DFIPS=$testing_fips coverage test
 	exit $?
 fi
 


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*

This commit configures coverage reports for CodeBuild, as documented
[here][1]. This is very straightforward for our Jacoco java coverage
reports, as CodeBuild natively supports that report format. For our gcov
C++ coverage reports for libaccp, however, we need to install and use
[`gcovr`][2] to convert gcov reports to a compatible format. Coverage is
only reported for our basic tests (either via the `release` target or,
in the case of Java8, explicitly specifying the `coverage` target
alongside `test`).

CodeCommit's coverage reports should be useful for PR reviewers, but
they do not provide granular, line-by-line coverage information or a
diff overlay view. If we want something more granular, we may need to
evaluate 3rd party tools [like codecov][3].

This commit also addresses [Issue #239][4], using CMake's [`file(GLOB`
function][5] to find relevant src and test files, automatically
generating the file of files to include java in builds. This eliminates
the need to manually enumerate our src/tst files in CMakeLists.txt. We
use the `CONFIGURE_DEPENDS` flag, instructing CMake to watch for new (or
removed) files in those directories, and regenerate the build system if
it detects a change. However, this feature is not available until 3.12,
so we need to condition its use on CMake version (per @sacchaing, RHEL5
only supports up to CMake 3.9).

[1]: https://docs.aws.amazon.com/codebuild/latest/userguide/code-coverage-report.html
[2]: https://gcovr.com/en/stable/
[3]: https://docs.codecov.com/docs/github-checks
[4]: https://github.com/corretto/amazon-corretto-crypto-provider/issues/239
[5]: https://cmake.org/cmake/help/latest/command/file.html#glob

---

# Testing

Checks are currently failing on this PR because the CI Docker images need to be rebuilt in order to incorporate a new tool dependency, `gcovr`. I've rebuilt the images in my dev account, and have run the checks successfully as part of [PR #1 on my fork](https://github.com/WillChilds-Klein/amazon-corretto-crypto-provider/pull/1). I'll hold off on rebuilding images in our CI account until these changes are approved.

Here are some isenlinks to the reports:

- [successful build batch in my dev account](https://tiny.amazon.com/1d41k7ob9/IsenLink)
- [sample report set for above batch (unit tests, java coverage, and cpp coverage reports)](https://tiny.amazon.com/xi3k3gx9/IsenLink)



Here are some sample screenshots of an individual java report and coverage trends across builds:

![Screen Shot 2022-08-01 at 10 36 46 AM](https://user-images.githubusercontent.com/3589880/182174387-94824598-1554-4ca3-82c8-7ece45bb3565.png)


![Screen Shot 2022-08-01 at 10 36 20 AM](https://user-images.githubusercontent.com/3589880/182174197-d3dc9cb6-d3a4-4cf4-a0ec-c8bccbe68da2.png)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
