### PR TITLE
Fix gcovr reports on legacy ubuntu 10 build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -482,7 +482,7 @@ task coverage_cpp_report {
         }
         exec {
             workingDir "${buildDir}/cmake-coverage"
-            commandLine 'gcovr', '-r', "${projectDir}", '--cobertura-pretty'
+            commandLine 'gcovr', '-r', "${projectDir}", '--xml'
             standardOutput = new FileOutputStream("${buildDir}/reports/cpp/cobertura.xml")
         }
         exec {

--- a/tests/ci/docker_images/linux-x86/build_legacy_image.sh
+++ b/tests/ci/docker_images/linux-x86/build_legacy_image.sh
@@ -17,6 +17,7 @@ cd dependencies
 wget -O cmake-3.9.6.tar.gz https://cmake.org/files/v3.9/cmake-3.9.6.tar.gz
 wget -O amazon-corretto-11-x64-linux-jdk.deb https://corretto.aws/downloads/latest/amazon-corretto-11-x64-linux-jdk.deb
 wget -O lcov-1.14-1.noarch.rpm http://downloads.sourceforge.net/ltp/lcov-1.14-1.noarch.rpm
+wget -O gcovr-2.0.tar.gz https://files.pythonhosted.org/packages/57/58/f57a3ab2df4b504156ae440880ce3432c85190e3050c6d8000a59978ef51/gcovr-2.0.tar.gz
 cd ..
 docker build -t ubuntu-10.04:gcc-4.1x_corretto -f ${docker_name}/Dockerfile ../../../../
 

--- a/tests/ci/docker_images/linux-x86/ubuntu-10.04_gcc-4.1x_corretto/Dockerfile
+++ b/tests/ci/docker_images/linux-x86/ubuntu-10.04_gcc-4.1x_corretto/Dockerfile
@@ -18,6 +18,7 @@ RUN sed -i -re 's/([a-z]{2}\.)?archive.ubuntu.com|security.ubuntu.com/old-releas
     g++-4.1 \
     make \
     perl \
+    python-pip \
     java-common \
     alien
 
@@ -32,6 +33,11 @@ COPY tests/ci/docker_images/linux-x86/dependencies/lcov-1.14-1.noarch.rpm /tmp/l
 RUN cd /tmp && \
     alien lcov-1.14-1.noarch.rpm && \
     dpkg --install lcov_1.14-2_all.deb
+
+# Pull gcovr as an external pip package due to obsolete wget.
+COPY tests/ci/docker_images/linux-x86/dependencies/gcovr-2.0.tar.gz /tmp/gcovr-2.0.tar.gz
+RUN cd /tmp && \
+    pip install /tmp/gcovr-2.0.tar.gz
 
 # Pull cmake as an external source since the wget version
 # on this image is too old to access the cmake repo.

--- a/tst/com/amazon/corretto/crypto/provider/test/integration/CustomTrustManager.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/integration/CustomTrustManager.java
@@ -57,7 +57,8 @@ class CustomTrustManager implements X509TrustManager {
         for (X509Certificate cert: chain) {
             final Date notAfter = cert.getNotAfter();
             final String subjectName = cert.getSubjectX500Principal().getName(X500Principal.RFC2253);
-            if (subjectName.contains(".badssl.com,") && notAfter.before(now)) {
+            if ((subjectName.contains(".badssl.com,") || subjectName.endsWith(".badssl.com"))
+                    && notAfter.before(now)) {
                 getLogger("CustomTrustManager").warning(String.format("%s has expired as of %s. Skipping validation.",
                         subjectName, notAfter));
                 return;


### PR DESCRIPTION
# Overview

## Fix gcovr reports on legacy ubuntu 10 build

Ubuntu 10 is very outdated, so we have to work around some constraints.
Firstly, while python3.1 is available on ubuntu 10 via `apt-get`, pip3
is not. So, we need to use legacy pip. Secondly, that legacy pip can't
install packages over the network so we need to download the tarball as
a copied dependency and install it from the filesystem (as we do with
other packages in that build). Finally, only gcovr 2.0 will build on
our legacy ubuntu image (we use gcovr 5.x elsewhere), so we need to
switch to using the `--xml` output configuration flag. Thankfully,
`--cobertura` in later versions is just an alias to `--xml`, so we can
use the same flag across versions.

## Fix failing TLS connection integration test

Apparently the ECC subdomains of badssl.com recently changed their
subject common name to a single wildcarded subdomain instead of a
comma-separated list of common names. Here's what the subdomain's
common name looks like as of the time of this writing:

```
root@3871ca5041dd:/accp# openssl s_client -connect ecc384.badssl.com:443 |& grep subject
subject=CN = *.badssl.com
```

We want to match either singular or plural subdomain common names for
badssl.com, so we do an "or" with the first (plural) clause checking for
the comma and the second (singular) checking with `endsWith`. This will
preserve compatibility should badssl.com revert to the old CN structure
and prevent matching something like `foo.badssl.commandeer-your-server.lol`.

# Note to Reviewers

If the docker build changes in this PR look OK, please indicate as such with a
comment on the PR, and I'll re-build the CI account's images, then allow the CI
to re-run.

# Testing

Currently, the CI test `ubuntu1004_gcc4_1x_corretto11_pr_x86` is failing
because the legacy ubuntu 10 image doesn't have `gcovr` (a tool we use for
coverage reporting) bundled with its image. Using the contents of this commit,
I rebuilt the docker images in my dev account at posted [a PR][3].  over-all CI
checks are failing, but due to an unrelated failure of
`ExternalHTTPSIntegrationTest:testHTTPSConnectivity`. 4 parameterized version
of that test (with/without BouncyCastle enabled for sites
`https://ecc384.badssl.com/` and `https://ecc256.badssl.com/`). Those failures
look like this:

```
  JUnit Jupiter:ExternalHTTPSIntegrationTest:testHTTPSConnectivity(boolean, String):HTTPS integration test: URL=https://ecc384.badssl.com/ BCEnabled=true
    MethodSource [className = 'com.amazon.corretto.crypto.provider.test.integration.ExternalHTTPSIntegrationTest', methodName = 'testHTTPSConnectivity', methodParameterTypes = 'boolean, java.lang.String']
    => javax.net.ssl.SSLHandshakeException: PKIX path building failed: java.security.cert.CertPathBuilderException: No issuer certificate for certificate in certification path found.
       sun.security.ssl.Alert.createSSLException(Alert.java:131)
       sun.security.ssl.TransportContext.fatal(TransportContext.java:324)
       sun.security.ssl.TransportContext.fatal(TransportContext.java:267)
       sun.security.ssl.TransportContext.fatal(TransportContext.java:262)
       sun.security.ssl.CertificateMessage$T12CertificateConsumer.checkServerCerts(CertificateMessage.java:654)
       [...]
     Caused by: sun.security.validator.ValidatorException: PKIX path building failed: java.security.cert.CertPathBuilderException: No issuer certificate for certificate in certification path found.
       sun.security.validator.PKIXValidator.doBuild(PKIXValidator.java:456)
       sun.security.validator.PKIXValidator.engineValidate(PKIXValidator.java:323)
       sun.security.validator.Validator.validate(Validator.java:271)
       sun.security.ssl.X509TrustManagerImpl.validate(X509TrustManagerImpl.java:315)
       sun.security.ssl.X509TrustManagerImpl.checkTrusted(X509TrustManagerImpl.java:234)
       [...]
     Caused by: java.security.cert.CertPathBuilderException: No issuer certificate for certificate in certification path found.
       org.bouncycastle.jce.provider.PKIXCertPathBuilderSpi_8.engineBuild(PKIXCertPathBuilderSpi_8.java:126)
       java.security.cert.CertPathBuilder.build(CertPathBuilder.java:280)
       sun.security.validator.PKIXValidator.doBuild(PKIXValidator.java:451)
       [...]
```

However, the CI run in that PR shows that the ubuntu 10 CI run now passes after
a docker image re-build:

![Screen Shot 2022-08-09 at 11 05 43 AM](https://user-images.githubusercontent.com/3589880/183686492-7d58512c-e94b-4aba-8bfe-9b8e8c596e45.png)


I'm currently working on a fix for the expired certs issue, and may include that
commit in this PR.

[1]: https://github.com/WillChilds-Klein/amazon-corretto-crypto-provider/pull/3



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
