### PR TITLE
fix: avoid NPE in AesGcmSpi engineGetIV when not-yet-initialized

### DIFF
--- a/src/com/amazon/corretto/crypto/provider/AesGcmSpi.java
+++ b/src/com/amazon/corretto/crypto/provider/AesGcmSpi.java
@@ -268,7 +268,7 @@ final class AesGcmSpi extends CipherSpi {
 
     @Override
     protected byte[] engineGetIV() {
-        return iv.clone();
+        return (iv == null) ? null : iv.clone();
     }
 
     @Override


### PR DESCRIPTION
This adds a defensive check to avoid a NPE when calling getIV on a Cipher that has not yet been initialized, which is expected per [the CipherSpi](https://github.com/openjdk/jdk/blob/7ad74d82d7/src/java.base/share/classes/javax/crypto/CipherSpi.java#L286-L296).

```
    /**
     * Returns the initialization vector (IV) in a new buffer.
...
     *
     * @return the initialization vector in a new buffer, or null if the
     * underlying algorithm does not use an IV, or if the IV has not yet
     * been set.
     */
    protected abstract byte[] engineGetIV();
```