### PR TITLE
Support MacOS

### DIFF
--- a/.github/workflows/macos_ci.yml
+++ b/.github/workflows/macos_ci.yml
@@ -22,6 +22,18 @@ jobs:
       with:
         submodules: true
 
+    - name: Install lcov
+      run: |
+        env HOMEBREW_NO_AUTO_UPDATE=1 brew install lcov
+    - name: Setup pip
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.9'
+        cache: 'pip'
+    - name: Install gcovr
+      run: |
+        pip install gcovr
+
     # Set up Corretto 8. The JDK version should be least 10 for a regular ACCP build,
     # but JAVA_HOME will be overwritten with subsequent versions we set up, so we save
     # the path here beforehand.

--- a/.github/workflows/macos_ci_fips.yml
+++ b/.github/workflows/macos_ci_fips.yml
@@ -22,6 +22,18 @@ jobs:
       with:
         submodules: true
 
+    - name: Install lcov
+      run: |
+        env HOMEBREW_NO_AUTO_UPDATE=1 brew install lcov
+    - name: Setup pip
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.9'
+        cache: 'pip'
+    - name: Install gcovr
+      run: |
+        pip install gcovr
+
     # Set up Corretto 8. The JDK version should be least 10 for a regular ACCP build,
     # but JAVA_HOME will be overwritten with subsequent versions we set up, so we save
     # the path here beforehand.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Current values are:
    [PR #191](https://github.com/corretto/amazon-corretto-crypto-provider/pull/191)
 * Add `KeyFactory` implementations for RSA and EC keys. This also includes our own implementations of keys for the same algorithms. [PR #132](https://github.com/corretto/amazon-corretto-crypto-provider/pull/132)
 * Added `amazon-corretto-crypto-provider-jdk15.security` to support JDK15+.
+* Add support for MacOS
 
 ### Patches
 * Improve zeroization of DRBG output. [PR #162](https://github.com/corretto/amazon-corretto-crypto-provider/pull/162)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -269,7 +269,15 @@ add_library(
 # We MUST set ACCP's RPATH to "$ORIGIN" so that the runtime dynamic loader will look in the same directory as ACCP for
 # any shared library dependencies BEFORE looking for a system-installed depencencies (such as libcrypto). If RPath is
 # not set, the loader may attempt to load an incompatible system-installed libcrypto and cause runtime crashes.
-set_target_properties(amazonCorrettoCryptoProvider PROPERTIES LINK_FLAGS "-Wl,-rpath,\$ORIGIN")
+if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    set(CMAKE_MACOSX_RPATH TRUE)
+    set(RPATH_ORIGIN "@loader_path")
+elseif(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+    set(RPATH_ORIGIN "\$ORIGIN")
+else()
+    message( FATAL_ERROR "Unsupported OS, need to determine OS-specific analog of linux rpath's $ORIGIN")
+endif()
+set_target_properties(amazonCorrettoCryptoProvider PROPERTIES LINK_FLAGS "-Wl,-rpath,${RPATH_ORIGIN}")
 
 add_custom_command(
     OUTPUT ${ACCP_JAR_SOURCE}
@@ -286,7 +294,7 @@ if(ENABLE_NATIVE_TEST_HOOKS)
   add_executable(test_keyutils EXCLUDE_FROM_ALL
         csrc/test_keyutils.cpp
     )
-    set_target_properties(test_keyutils PROPERTIES LINK_FLAGS "-Wl,-rpath,\$ORIGIN")
+    set_target_properties(test_keyutils PROPERTIES LINK_FLAGS "-Wl,-rpath,${RPATH_ORIGIN}")
     target_link_libraries(test_keyutils ${OPENSSL_CRYPTO_LIBRARY})
     target_link_libraries(test_keyutils amazonCorrettoCryptoProvider)
 endif()
@@ -723,7 +731,7 @@ add_custom_target(check-install-via-properties-with-debug
     DEPENDS accp-jar tests-jar)
 
 add_custom_target(check
-    DEPENDS check-recursive-init check-install-via-properties check-install-via-properties-with-debug check-junit check-junit-SecurityManager check-external-lib)
+    DEPENDS check-recursive-init check-install-via-properties check-install-via-properties-with-debug check-junit check-junit-SecurityManager check-external-lib check-libaccp-rpath)
 
 add_custom_target(checkstyle
     WORKING_DIRECTORY ${ORIG_SRCROOT}
@@ -837,5 +845,34 @@ add_custom_target(check-dieharder-threads
 
     DEPENDS run-dieharder-libcrypto-rng-threads run-dieharder-libcrypto-rng-threads-tail)
 endif() # End of Dieharder targets
+
+# Add a target to assert that the libaccp shared object's rpath meets 2 conditions:
+#   1. rpath contains only a single entry
+#   2. that entry is set to $ORIGIN on linux or @loader_path on mac
+if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    add_custom_target(check-libaccp-rpath
+        COMMAND otool -l $<TARGET_FILE:amazonCorrettoCryptoProvider>
+            | grep 'cmd LC_RPATH'
+            | wc -l
+            | tr -d '[:blank:]'
+            | xargs test 1 -eq
+        COMMAND otool -l $<TARGET_FILE:amazonCorrettoCryptoProvider>
+            | grep -A2 'cmd LC_RPATH'
+            | tail -1
+            | grep '@loader_path'
+        )
+elseif(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+    add_custom_target(check-libaccp-rpath
+        COMMAND objdump -x $<TARGET_FILE:amazonCorrettoCryptoProvider>
+            | grep -E 'RPATH|RUNPATH'   # RPATH on AL, RUNPATH on Ubuntu
+            | grep -v ':'
+        COMMAND objdump -x $<TARGET_FILE:amazonCorrettoCryptoProvider>
+            | grep -E 'RPATH|RUNPATH'   # RPATH on AL, RUNPATH on Ubuntu
+            | grep -E "\$ORIGIN"
+        )
+else()
+    message( FATAL_ERROR "Unsupported OS, need to validate OS-specific rpath $ORIGIN")
+endif()
+
 # Do this at the end, after we finish all our feature tests, or it'll be missing flags
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/csrc/config.h.in ${JNI_HEADER_DIR}/config.h)

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ KeyFactory algorithms:
 # Compatibility & Requirements
 ACCP has the following requirements:
 * JDK8 or newer (This includes both OracleJDK and [Amazon Corretto](https://aws.amazon.com/corretto/))
-* 64-bit Linux running on x86_64 (also known as x64 or AMD64)
+* 64-bit Linux or MacOs running on x86_64 (also known as x64 or AMD64)
 
 If ACCP is used/installed on a system it does not support, it will disable itself and the JVM will behave as if ACCP weren't installed at all.
 
@@ -100,7 +100,8 @@ in the latest version for best performance and bug-fixes.
 
 Whether you're using Maven, Gradle, or some other build system that also pulls
 packages from Maven Central, it's important to specify `linux-x86_64` as the
-classifier. You'll get an empty package otherwise.
+classifier. You'll get an empty package otherwise. Note that ACCP will not be
+available for MacOS on Maven Central until 2.0 is released.
 
 Regardless of how you acquire ACCP (Maven, manual build, etc.) you will still need to follow the guidance in the [Configuration section](#configuration) to enable ACCP in your application.
 
@@ -147,7 +148,7 @@ The OracleJDK requires that JCA providers be cryptographically signed by a trust
 The JARs we publish via Maven and our official [releases](https://github.com/corretto/amazon-corretto-crypto-provider/releases) are signed by our private key,
 but yours will not be.*
 
-Building this provider requires a 64 bit Linux build system with the following prerequisites installed:
+Building this provider requires a 64 bit Linux or MacOS build system with the following prerequisites installed:
 * OpenJDK 10 or newer
 * [cmake](https://cmake.org/) 3.8 or newer
 * C++ build chain

--- a/etc/amazon-corretto-crypto-provider.security
+++ b/etc/amazon-corretto-crypto-provider.security
@@ -23,8 +23,14 @@
 # JDK8 will determine that there is no class with the short provider name and skip it.
 # JDK9+ will determine that the fully-qualified class is not visible and will skip it.
 #
-# This results in a single list with proper behavior on both JDK8 and JDK9+ systems.
+# Some providers are specified by name only, meaning that they may not work
+# properly on JDK 8. In the case of the Apple provider, this is because our CI
+# Mac images allowed duplicate installs of the Apple provider on Java 8. We use
+# the name-only variant of the provider because the apple.security.AppleProvider
+# is not exported from its module in JDK 11.
 #
+# This results in a single list with proper behavior on both JDK8 and JDK9+ systems
+# for most providers.
 
 security.provider.1=com.amazon.corretto.crypto.provider.AmazonCorrettoCryptoProvider
 security.provider.2=sun.security.provider.Sun
@@ -45,9 +51,8 @@ security.provider.16=JdkLDAP
 security.provider.17=JdkSASL
 security.provider.18=sun.security.mscapi.SunMSCAPI
 security.provider.19=SunMSCAPI
-security.provider.20=apple.security.AppleProvider
-security.provider.21=Apple
-security.provider.22=SunPKCS11
+security.provider.20=Apple
+security.provider.21=SunPKCS11
 
 #
 # A list of known strong SecureRandom implementations.


### PR DESCRIPTION
*Issue #, if available:* #41

# Notes
This commit adds functional and CI support for MacOS. The main blocker
on supporting MacOS was a runtime linking error caused by libaccp trying
to load a `libcrypto` it found in some `/usr` system directory on MacOS,
instead of the temporary directory that ACCP creates and restricts
`rpath` to during linking. The reason for this is that the `rpath` value
of `$ORIGIN` is specific to linux's linker, and is meaningless on MacOS.
So, the MacOS linker consulted a non-existent `rpath`, didn't find
anything, and fell back to system library directories. The fix is to
detect OS type at build time and use the appropriate value for `rpath`
(on MacOS that's `@loader_path`, see the "Locating External Resources"
section of [this documentation page][1]).  We also explicity set
`CMAKE_MACOSX_RPATH` on MacOS, which is documented [here][2].

To prevent regressions expanding RPATH beyond one entry, we add a
test check that asserts that libaccp only has a single RPATH entry
that's set to the appropriate value on all supported platforms.

The other pieces of this commit are related to CI. In order for the
coverate steps to pass, we need to install `lcov` and `gcovr`
dependencies on the GitHub Actions MacOS CI images. Lastly, now that
this runs on Mac the Apple JCE providers in our pre-baked properties
files are actually used (they're ignored on Linux, where they're
unavailable). This resulted in the same provider being installed twice,
causing SecurityPropertiesTester failures. We resolve this issue by
removing the class-specified entry in favor of the name-specified entry.
Because the [AppleProvider][3] is [not exported][4] from its module in
JDK 11, we cannot use the fully qualified class specification (see
comment in `etc/amazon-corretto-crypto-provider.security`) on JDK 9+. By
using only the name specification, there may be some issues on JDK8 on
Mac when using this providers file, but the impact should be minor -- no
regressions (because we didn't support MacOS before). Users are
encouraged to upgrade to more moder JDKs or manually modify/override the
supplied properties file.

This commit resolves [Issue #41][5].

[1]: https://developer.apple.com/library/archive/documentation/DeveloperTools/Conceptual/DynamicLibraries/100-Articles/DynamicLibraryDesignGuidelines.html#//apple_ref/doc/uid/TP40002013-SW21
[2]: https://cmake.org/cmake/help/latest/prop_tgt/MACOSX_RPATH.html
[3]: https://docs.oracle.com/javase/8/docs/technotes/guides/security/crypto/CryptoSpec.html#Provider
[4]: https://github.com/corretto/corretto-11/blob/develop/src/java.base/macosx/classes/module-info.java.extra
[5]: https://github.com/corretto/amazon-corretto-crypto-provider/issues/41

# Testing

## Manual Inspection of libaccp RPATH

On MacOS:

```
$ sw_vers
ProductName:    macOS
ProductVersion: 12.5.1
BuildVersion:   21G83

$ uname -a
Darwin 08f8bc77642e.ant.amazon.com 21.6.0 Darwin Kernel Version 21.6.0: Wed Aug 10 14:25:27 PDT 2022; root:xnu-8020.141.5~2/RELEASE_X86_64 x86_64

$ otool -l ./build/cmake/libamazonCorrettoCryptoProvider.dylib | grep -A2 ' cmd LC_RPATH'
          cmd LC_RPATH
      cmdsize 32
         path @loader_path (offset 12)
```

On Ubuntu:

```
root@817bfef6156a:/accp# cat /etc/os-release
NAME="Ubuntu"
VERSION="20.04.4 LTS (Focal Fossa)"
ID=ubuntu
ID_LIKE=debian
PRETTY_NAME="Ubuntu 20.04.4 LTS"
VERSION_ID="20.04"
HOME_URL="https://www.ubuntu.com/"
SUPPORT_URL="https://help.ubuntu.com/"
BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
VERSION_CODENAME=focal
UBUNTU_CODENAME=focal

root@817bfef6156a:/accp# chrpath -l ./build/cmake/libamazonCorrettoCryptoProvider.so
./build/cmake/libamazonCorrettoCryptoProvider.so: RUNPATH=$ORIGIN
```

On AL2:

```
$ cat /etc/os-release
NAME="Amazon Linux"
VERSION="2"
ID="amzn"
ID_LIKE="centos rhel fedora"
VERSION_ID="2"
PRETTY_NAME="Amazon Linux 2"
ANSI_COLOR="0;33"
CPE_NAME="cpe:2.3:o:amazon:amazon_linux:2:-:internal"
HOME_URL="https://amazonlinux.com/"
VARIANT="internal"

$ chrpath -l ./build/cmake/libamazonCorrettoCryptoProvider.so
./build/cmake/libamazonCorrettoCryptoProvider.so: RPATH=$ORIGIN
```

## RPATH Regression Testing Mechanism

Modified local code to include an extra RPATH entry.

Local changes:

```
$ git diff
diff --git a/CMakeLists.txt b/CMakeLists.txt
index 0252625..da83da3 100644
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,8 +86,6 @@ string(REPLACE ":" ";" TEST_CLASSPATH_LIST "${TEST_CLASSPATH}")

 # Needed as we abuse some of the test compile macros to test shared lib links
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
-# CMake's default RPath handling includes the full build directory path, which isn't needed. Turn it off.
-set(CMAKE_SKIP_RPATH TRUE)
 set(GENERATE_HASHERS ${CMAKE_CURRENT_SOURCE_DIR}/build-tools/bin/generate-java-hash-spi)
 set(GENERATED_JAVA_DIR ${CMAKE_CURRENT_BINARY_DIR}/generated-java/com/amazon/corretto/crypto/provider)
 set(JNI_HEADER_DIR ${CMAKE_CURRENT_BINARY_DIR}/generated-include)
```

On MacOS:

```
$ ./gradlew clean && ./gradlew test
...
/Library/Developer/CommandLineTools/usr/bin/make  -f CMakeFiles/check-libaccp-rpath.dir/build.make CMakeFiles/check-libaccp-rpath.dir/build
otool -l /Users/childw/workplace/github/corretto/amazon-corretto-crypto-provider/build/cmake/libamazonCorrettoCryptoProvider.dylib | grep 'cmd LC_RPATH' | wc -l | tr -d '[:blank:]' | xargs test 1 -eq
...
BUILD FAILED in 54s
3 actionable tasks: 2 executed, 1 up-to-date
```


On Ubuntu:

```
$ ./gradlew clean && ./gradlew test
...
make[3]: Entering directory '/accp/build/cmake'
objdump -x /accp/build/cmake/libamazonCorrettoCryptoProvider.so | grep -E 'RPATH|RUNPATH' | grep -v ':'
make[3]: *** [CMakeFiles/check-libaccp-rpath.dir/build.make:60: CMakeFiles/check-libaccp-rpath] Error 1
...
BUILD FAILED in 1m 28s
3 actionable tasks: 2 executed, 1 up-to-date
```

On AL2:

```
$ ./gradlew clean && ./gradlew test
...
make[3]: Entering directory `/local/home/childw/workplace/github/corretto/amazon-corretto-crypto-provider/build/cmake'
objdump -x /local/home/childw/workplace/github/corretto/amazon-corretto-crypto-provider/build/cmake/libamazonCorrettoCryptoProvider.so | grep -E 'RPATH|RUNPATH' | grep -v ':'
...
BUILD FAILED in 1m 31s
3 actionable tasks: 3 executed
```

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
