### PR TITLE
Expose a way to re-run self tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,11 @@ Thus, these should all be set on the JVM command line using `-D`.
    Takes *positive integer value* which is the requested minimum number of "stripes" used by the `Janitor` for dividing cleaning tasks (messes) among its workers.
    (Current behavior is to default this value to 4 times the CPU core count and then round the value up to the nearest power of two.)
    See `Janitor.java` for for more information.
+* `com.amazon.corretto.crypto.provider.cacheselftestresults` Takes in `true` or `false`
+  (defaults to `true`). If set to `true`, the results of running tests are cached,
+  and the subsequent calls to `AmazonCorrettoCryptoProvider::runSelfTests`
+  would avoid re-running tests; otherwise, each call to `AmazonCorrettoCryptoProvider::runSelfTests`
+  re-run the tests.
 
 
 # License

--- a/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
+++ b/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
@@ -351,8 +351,7 @@ public final class AmazonCorrettoCryptoProvider extends java.security.Provider {
      * The result of running tests are cached, and the subsequent calls would
      * avoid re-running tests. To modify this behaviour, one can set the system
      * property <em>com.amazon.corretto.crypto.provider.cacheselftestresults=false</em>
-     * so that every call to this method would result in re-running tests, or explicity
-     * invoking {@link #reRunSelfTests()}}.
+     * so that every call to this method would result in re-running tests.
      *
      * @see #getSelfTestStatus()
      */
@@ -360,21 +359,6 @@ public final class AmazonCorrettoCryptoProvider extends java.security.Provider {
         if (!relyOnCachedSelfTestResults) {
             resetAllSelfTests();
         }
-        return selfTestSuite.runTests();
-    }
-
-    /**
-     * Runs all available self-tests and returns the result.
-     * Please see {@link #getSelfTestStatus()} for the algorithms tested and
-     * the possible return values. (though this method will never return
-     * {@link SelfTestStatus#NOT_RUN}).
-     * This method does not rely on cached test results, and each invocation would
-     * re-running tests.
-     *
-     * @see #getSelfTestStatus()
-     */
-    public SelfTestStatus reRunSelfTests() {
-        resetAllSelfTests();
         return selfTestSuite.runTests();
     }
 

--- a/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
+++ b/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
@@ -39,6 +39,9 @@ public final class AmazonCorrettoCryptoProvider extends java.security.Provider {
     public static final String PROVIDER_NAME = "AmazonCorrettoCryptoProvider";
 
     private final EnumSet<ExtraCheck> extraChecks = EnumSet.noneOf(ExtraCheck.class);
+
+    private final boolean relyOnCachedSelfTestResults;
+
     private transient SelfTestSuite selfTestSuite = new SelfTestSuite();
 
     static {
@@ -265,6 +268,7 @@ public final class AmazonCorrettoCryptoProvider extends java.security.Provider {
     @SuppressWarnings({"deprecation"})
     public AmazonCorrettoCryptoProvider() {
         super("AmazonCorrettoCryptoProvider", PROVIDER_VERSION, "");
+        this.relyOnCachedSelfTestResults = Utils.getCacheSelfTestResultsProperty();
 
         Utils.optionsFromProperty(ExtraCheck.class, extraChecks, "extrachecks");
 
@@ -344,10 +348,33 @@ public final class AmazonCorrettoCryptoProvider extends java.security.Provider {
      * Please see {@link #getSelfTestStatus()} for the algorithms tested and
      * the possible return values. (though this method will never return
      * {@link SelfTestStatus#NOT_RUN}).
+     * The result of running tests are cached, and the subsequent calls would
+     * avoid re-running tests. To modify this behaviour, one can set the system
+     * property <em>com.amazon.corretto.crypto.provider.cacheselftestresults=false</em>
+     * so that every call to this method would result in re-running tests, or explicity
+     * invoking {@link #reRunSelfTests()}}.
      *
      * @see #getSelfTestStatus()
      */
     public SelfTestStatus runSelfTests() {
+        if (!relyOnCachedSelfTestResults) {
+            resetAllSelfTests();
+        }
+        return selfTestSuite.runTests();
+    }
+
+    /**
+     * Runs all available self-tests and returns the result.
+     * Please see {@link #getSelfTestStatus()} for the algorithms tested and
+     * the possible return values. (though this method will never return
+     * {@link SelfTestStatus#NOT_RUN}).
+     * This method does not rely on cached test results, and each invocation would
+     * re-running tests.
+     *
+     * @see #getSelfTestStatus()
+     */
+    public SelfTestStatus reRunSelfTests() {
+        resetAllSelfTests();
         return selfTestSuite.runTests();
     }
 

--- a/src/com/amazon/corretto/crypto/provider/Utils.java
+++ b/src/com/amazon/corretto/crypto/provider/Utils.java
@@ -32,6 +32,7 @@ import javax.crypto.spec.SecretKeySpec;
  * Miscellaneous utility methods.
  */
 final class Utils {
+    private static final String CACHE_SELF_TEST_RESULTS = "cacheselftestresults";
     private Utils() {
         // Prevent instantiation
     }
@@ -523,6 +524,15 @@ final class Utils {
             JAVA_VERSION = 8; // fallback to something safe
         }
         return JAVA_VERSION;
+    }
+
+    static boolean getCacheSelfTestResultsProperty() {
+        final String relyOnCacheSelfTestResultsStr = Loader.getProperty(CACHE_SELF_TEST_RESULTS, "true").toLowerCase();
+        if (!relyOnCacheSelfTestResultsStr.equals("true") && !relyOnCacheSelfTestResultsStr.equals("false")) {
+            System.err.format("Valid values for %s are false and true, with true as default", CACHE_SELF_TEST_RESULTS);
+            return true;
+        }
+        return Boolean.parseBoolean(relyOnCacheSelfTestResultsStr);
     }
 }
 

--- a/src/com/amazon/corretto/crypto/provider/Utils.java
+++ b/src/com/amazon/corretto/crypto/provider/Utils.java
@@ -529,7 +529,7 @@ final class Utils {
     static boolean getCacheSelfTestResultsProperty() {
         final String relyOnCacheSelfTestResultsStr = Loader.getProperty(CACHE_SELF_TEST_RESULTS, "true").toLowerCase();
         if (!relyOnCacheSelfTestResultsStr.equals("true") && !relyOnCacheSelfTestResultsStr.equals("false")) {
-            System.err.format("Valid values for %s are false and true, with true as default", CACHE_SELF_TEST_RESULTS);
+            LOG.warning(String.format("Valid values for %s are false and true, with true as default", CACHE_SELF_TEST_RESULTS));
             return true;
         }
         return Boolean.parseBoolean(relyOnCacheSelfTestResultsStr);

--- a/tst/com/amazon/corretto/crypto/provider/test/ServiceSelfTestMetaTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/ServiceSelfTestMetaTest.java
@@ -157,4 +157,13 @@ public class ServiceSelfTestMetaTest {
 
         assertEquals(SelfTestStatus.PASSED, ((SelfTestResult)sneakyInvoke(selfTest, "runTest")).getStatus());
     }
+
+    @Test
+    public void givenACCPCacheSelfTestResultsPropertySetToFalse_whenRunTests_ExpectReset() throws Throwable  {
+        reset();
+        System.setProperty("com.amazon.corretto.crypto.provider.cacheselftestresults", "false");
+        accp = new AmazonCorrettoCryptoProvider();
+        assertTrue(SelfTestStatus.FAILED != accp.runSelfTests());
+        assertTrue(SelfTestStatus.FAILED != accp.reRunSelfTests());
+    }
 }

--- a/tst/com/amazon/corretto/crypto/provider/test/ServiceSelfTestMetaTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/ServiceSelfTestMetaTest.java
@@ -164,6 +164,13 @@ public class ServiceSelfTestMetaTest {
         System.setProperty("com.amazon.corretto.crypto.provider.cacheselftestresults", "false");
         accp = new AmazonCorrettoCryptoProvider();
         assertTrue(SelfTestStatus.FAILED != accp.runSelfTests());
-        assertTrue(SelfTestStatus.FAILED != accp.reRunSelfTests());
+        // Let's force a failure and re run the tests
+        Class<?> spiClass = Class.forName(NATIVE_PROVIDER_PACKAGE + ".EvpHmac$SHA256");
+        Object selfTest = TestUtil.sneakyGetField(spiClass, "SELF_TEST");
+        sneakyInvoke(selfTest, "forceFailure");
+        assertTrue(SelfTestStatus.FAILED == accp.getSelfTestStatus());
+        // re-run the tests and confirm that they don't fail anymore
+        assertTrue(SelfTestStatus.FAILED != accp.runSelfTests());
+        assertTrue(SelfTestStatus.FAILED != accp.getSelfTestStatus());
     }
 }

--- a/tst/com/amazon/corretto/crypto/provider/test/UtilsTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/UtilsTest.java
@@ -175,5 +175,16 @@ public class UtilsTest {
         assertFalse(arraysOverlap(arr1, 5, arr1, 0, 5));
         assertTrue(arraysOverlap(arr1, 5, arr1, 1, 5));
     }
-}
 
+    @Test
+    public void givenInvalidValueForCacheSelfTestResultsProperty_whenGetCacheSelfTestResultsProperty_expectTrue() throws Throwable {
+        System.setProperty("com.amazon.corretto.crypto.provider.cacheselftestresults", "dummy");
+        assertTrue((Boolean) sneakyInvoke(UTILS_CLASS, "getCacheSelfTestResultsProperty"));
+    }
+
+    @Test
+    public void givenFalseForCacheSelfTestResultsProperty_whenGetCacheSelfTestResultsProperty_expectFalse() throws Throwable {
+        System.setProperty("com.amazon.corretto.crypto.provider.cacheselftestresults", "False");
+        assertFalse((Boolean) sneakyInvoke(UTILS_CLASS, "getCacheSelfTestResultsProperty"));
+    }
+}


### PR DESCRIPTION
## *Issue #7*

## Expose a way to re-run self tests
The result of self tests are cached and subsequent calls to `runSelfTests` would rely on the cached results. In this PR, we allow clients to re-run tests by setting a system property.

### Testing
* CI in personal account
* Unit tests and ensured the new code has coverage by looking into coverage report generated in `build/cmake-coverage/coverage/results/html`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
