### PR TITLE
Use --disable-new-dtags if available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -472,6 +472,11 @@ CHECK_LINKER_FLAG_SUPPORT(USE_GC_SECTIONS "-Wl,--gc-sections")
 # Otherwise, on linux, loading our library will mark the stack as executable.
 CHECK_LINKER_FLAG_SUPPORT(USE_NOEXECSTACK "-Wl,-z -Wl,noexecstack")
 
+# Disabling New DTags ensures that RPath is used instead of RunPath (which has lower priority). Since it's likely that
+# other libcrypto.so files will be in LD_LIBRARY_PATH, we need to ensure that we're using RPath so that our copy of
+# libcrypto.so that is extracted into a temp directory at startup is loaded *before* LD_LIBRARY_PATH is checked.
+CHECK_LINKER_FLAG_SUPPORT(USE_DISABLE_NEW_DTAGS "-Wl,--disable-new-dtags")
+
 ### CXX flag tests
 
 CHECK_ENABLE_CXX_FLAG(CXX_FLAG_WALL -Wall)


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Some platforms use the `--enable-new-dtags` Linker flag by default. This flag causes the resulting build artifacts to have RunPath values instead of RPath values. The difference between these values is that RPath is checked *before* LD_LIBRARY_PATH, whereas RunPath is checked *afterwards*. This means that when looking for a libcrypto.so to load, if RunPath is used and a different libcrypto.so is in the LD_LIBRARY_PATH, then the other libcrypto.so (likely some version of Openssl) will be attempted to be used instead of our copy of AWS-LC libcrypto.so that is inside our JAR file and extracted to a temporary directory. This can lead to runtime loading failures due to missing AWS-LC symbols. 

The fix for this is for ACCP's CMakeLists.txt script to check if the linker being used supports the `--disable-new-dtags` flag, and if it does, to automatically enable that flag in order to ensure that RPath is used instead of Runpath. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
