### PR TITLE
Only use v1.3 for TLS integ test on LTS/supported versions

### DIFF
--- a/tst/com/amazon/corretto/crypto/provider/test/integration/TestHTTPSServer.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/integration/TestHTTPSServer.java
@@ -43,6 +43,7 @@ import java.util.function.Consumer;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 
 import com.amazon.corretto.crypto.provider.AmazonCorrettoCryptoProvider;
+import com.amazon.corretto.crypto.provider.test.TestUtil;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpsConfigurator;
@@ -166,7 +167,8 @@ public class TestHTTPSServer {
         TrustManagerFactory tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
         tmf.init(keyStore);
 
-        SSLContext sslContext = SSLContext.getInstance("TLSv1.3");
+        String tlsVersion = TestUtil.getJavaVersion() == 10 ? "TLS" : "TLSv1.3";
+        SSLContext sslContext = SSLContext.getInstance(tlsVersion);
         sslContext.init(new KeyManager[] { new SNIKeyManager() }, tmf.getTrustManagers(), null);
 
         HttpsServer server = HttpsServer.create();


### PR DESCRIPTION
Due to legacy build constraints, we still need to be able to test and run on JDK10, even though it hasn't recieved a security patch in years and we only officially support LTS Java releases (8, 11, 17 at the moment). We first noticed this behavior when a ToD run of integration tests on JDK10 started failing consistently with the following exception, indicating that the older JDK10 w/o any of the backports enjoyed by e.g. JDK8 simply doesn't have the more modern 1.3 SSL context (and has no path to getting it, as JDK10 is EoL).

```
Exception in thread "main" java.security.NoSuchAlgorithmException: TLSv1.3 SSLContext not available
        at java.base/sun.security.jca.GetInstance.getInstance(GetInstance.java:159)
        at java.base/javax.net.ssl.SSLContext.getInstance(SSLContext.java:168)
        at com.amazon.corretto.crypto.provider.test.integration.TestHTTPSServer.runServer(TestHTTPSServer.java:169)
        at com.amazon.corretto.crypto.provider.test.integration.TestHTTPSServer.main(TestHTTPSServer.java:227)
```

Public ACCP [added TLSv1.3 integ test coverage about a year ago][2], but the PR's testing documentation indicates it was only tested on LTS java versions. So, instead of skipping the test entirely for 10, we simply test generic TLS instead of 1.3 specifically.

[2]: https://github.com/corretto/amazon-corretto-crypto-provider/pull/169

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
