### PR TITLE
Trim slippage between internal changes and external

### DIFF
--- a/tst/com/amazon/corretto/crypto/provider/test/EvpKeyFactoryTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/EvpKeyFactoryTest.java
@@ -530,13 +530,16 @@ public class EvpKeyFactoryTest {
         // expect byte-for-byte compatibility of encoded EC private keys in Java 10, but do expect the
         // private value S to be logically equivalent.
         final boolean expectJceEncodingCompatibility = !(
-                (TestUtil.getJavaVersion() == 10 && jceSample instanceof ECPrivateKey)
+                    (TestUtil.getJavaVersion() == 10
+                        && ((jceSample instanceof ECPrivateKeySpec) || (jceSample instanceof ECPrivateKey)))
                     || RSAPrivateKeySpec.class.equals(specKlass)
         );
         if (expectJceEncodingCompatibility) {
             assertArrayEquals(jceKey.getEncoded(), nativeKey.getEncoded(), "Encoded");
         } else if (jceSample instanceof ECPrivateKey) {
             assertEquals(((ECPrivateKey) jceSample).getS(), ((ECPrivateKey) nativeSample).getS());
+        } else if (jceSample instanceof ECPrivateKeySpec) {
+            assertEquals(((ECPrivateKeySpec) jceSample).getS(), ((ECPrivateKeySpec) nativeSample).getS());
         }
         return new Samples<T>(nativeSample, jceSample);
     }

--- a/tst/com/amazon/corretto/crypto/provider/test/NativeTestHooks.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/NativeTestHooks.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.extension.ExtensionContext;
  */
 public class NativeTestHooks {
     // Note: Since we're not sealing this package by including it in the JAR, any native functions in here need to be
-    // generally safe to call. Unsafe functions should go in PrivilegedTestHooks instead.
+    // generally safe to call.
 
     public static native void throwException();
     public static native void getBytes(byte[] array, int offset, int length, int off2, int len2);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

It looks like some changes were made to our internal version of EvpKeyFactoryTest without properly updating our external repo. This change closes that gap.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
