### PR TITLE
Create temp directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@
 *.iml
 *.orig
 /.classpath
+tests/ci/cdk/.idea
+tests/ci/cdk/venv

--- a/src/com/amazon/corretto/crypto/provider/Loader.java
+++ b/src/com/amazon/corretto/crypto/provider/Loader.java
@@ -412,9 +412,6 @@ final class Loader {
      */
     private static synchronized Path createPrivateTmpDir(final String prefix) throws IOException {
         final Path systemTempDir = Paths.get(System.getProperty("java.io.tmpdir"));
-        if (!Files.isDirectory(systemTempDir)) {
-            throw new AssertionError("java.io.tmpdir is not valid: " + systemTempDir);
-        }
 
         final int RETRY_LIMIT = 10;
         int attempt = 0;
@@ -436,15 +433,15 @@ final class Loader {
 
                 final Path privateDirFullPath = systemTempDir.resolve(privateTempDir.toString());
 
-                final Path result = Files.createDirectory(privateDirFullPath, SELF_OWNER_FILE_PERMISSIONS);
+                final Path result = Files.createDirectories(privateDirFullPath, SELF_OWNER_FILE_PERMISSIONS);
                 if (DebugFlag.VERBOSELOGS.isEnabled()) {
                     LOG.log(Level.FINE, "Created temporary library directory");
                 }
 
                 result.toFile().deleteOnExit();
                 return result;
-            } catch (final FileAlreadyExistsException ex) {
-                // We ignore and retry this exception
+            } catch (final IOException ex) {
+                // We ignore and retry this IOException
             } catch (final Exception ex) {
                 // Any other exception is bad and we may need to quash.
                 throw new AssertionError("Unable to create temporary directory");


### PR DESCRIPTION
*Create temp directory*

The temporary directory used by ACCP is passed via `java.io.tmpdir`. There are cases where another operation may delete this folder before ACCP has a chance to use it. We try to create that directory in case it has been deleted.

The [Files.createDirectories](https://docs.oracle.com/javase/8/docs/api/java/nio/file/Files.html#createDirectories-java.nio.file.Path-java.nio.file.attribute.FileAttribute...-) does not fail in case the directories already exist.