### PR TITLE
Statically link libc++ and libgcc into libaccp on Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -529,6 +529,15 @@ string(STRIP "${PROBED_LINKED_FLAGS}" PROBED_LINKED_FLAGS)
 MESSAGE(STATUS "probed flags ${PROBED_LINKED_FLAGS}")
 target_link_libraries(amazonCorrettoCryptoProvider ${PROBED_LINKED_FLAGS})
 
+# Statically link libc++ and libgcc on linux to avoid compatibility issues with
+# obsolete system libraries on older platforms. These options don't apply to
+# MacOS/Darwin because its gcc is actually an alias to clang, which does not
+# fully support them.
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+   target_link_libraries(amazonCorrettoCryptoProvider -static-libstdc++)
+   target_link_libraries(amazonCorrettoCryptoProvider -static-libgcc)
+endif()
+
 # Add pthread support
 target_link_libraries(amazonCorrettoCryptoProvider Threads::Threads)
 


### PR DESCRIPTION
# Notes

In the process of migrating our libcrypto linkage from static to dynamic
in 2.0, we also [started to link other dependencies dynamically][1].
This has caused some runtime compatibility issues on older platforms
whose system libraries are very outdated. The issue initially manifested
with exception traces like this:

```
Exception in thread "main" com.amazon.corretto.crypto.provider.RuntimeCryptoException: Unable to load native library
    at com.amazon.corretto.crypto.provider.AmazonCorrettoCryptoProvider.assertHealthy(AmazonCorrettoCryptoProvider.java:382)
    at com.amazon.jdk.CryptoProviderTest.validateAccp(CryptoProviderTest.java:57)
    at com.amazon.jdk.CryptoProviderTest.main(CryptoProviderTest.java:25)
Caused by: java.lang.UnsatisfiedLinkError: /tmp/amazonCorrettoCryptoProviderNativeLibraries.45b91e5d7d44379a/libamazonCorrettoCryptoProvider.so: /usr/lib64/libstdc++.so.6: version `GLIBCXX_3.4.9' not found (required by /tmp/amazonCorrettoCryptoProviderNativeLibraries.45b91e5d7d44379a/libamazonCorrettoCryptoProvider.so)
```

The issue is that libaccp built on newer systems can reference symbols
that aren't available in the system library versions on some older
systems. When libaccp is loaded by the JVM, it tries to find these
symbols, is unable to, and raises a runtime linker error.

The solution we implement in this commit is to simply statically link
libstdc++ into libaccp. The tradeoff is increased portability for an
increase in library size due to libstdc++ now being bundled in the libaccp
shared object. However, that increase is largely mitigated by the ACCP
JAR's compression, and only adds ~200KB to the overall JAR size.

We only do this for linux, because these particular options are not
available on MacOS's "`gcc`", as it's just an alias to `clang`:

```
$ uname; gcc --version
Darwin
Apple clang version 14.0.0 (clang-1400.0.29.202)

$ gcc -static-libstdc++ -static-libgcc csrc/env.h
clang: warning: argument unused during compilation: '-static-libstdc++' [-Wunused-command-line-argument]
clang: warning: argument unused during compilation: '-static-libgcc' [-Wunused-command-line-argument]
csrc/env.h:11:10: fatal error: 'iostream' file not found
         ^~~~~~~~~~
1 error generated.
```

I tested this change on AL2 (x86_64 and aarch64), AL2012, and RHEL5.

Before:

```
$ ldd ./build/cmake/libamazonCorrettoCryptoProvider.so
        linux-vdso.so.1 (0x00007ffdad581000)
        libdl.so.2 => /lib64/libdl.so.2 (0x00007f3219a8b000)
        libcrypto.so => /local/home/childw/workplace/github/corretto/amazon-corretto-crypto-provider/./build/resources/jmh/com/amazon/corretto/crypto/provider/libcrypto.so (0x00007f3219687000)
        libstdc++.so.6 => /lib64/libstdc++.so.6 (0x00007f3219305000)
        libm.so.6 => /lib64/libm.so.6 (0x00007f3218fc5000)
        libgcc_s.so.1 => /lib64/libgcc_s.so.1 (0x00007f3218daf000)
        libpthread.so.0 => /lib64/libpthread.so.0 (0x00007f3218b91000)
        libc.so.6 => /lib64/libc.so.6 (0x00007f32187e4000)
        /lib64/ld-linux-x86-64.so.2 (0x00007f3219ecb000)

$ du -sh ./build/cmake/libamazonCorrettoCryptoProvider.so
260K    ./build/cmake/libamazonCorrettoCryptoProvider.so

$ du -sh ./build/cmake/AmazonCorrettoCryptoProvider.jar
3.1M    ./build/cmake/AmazonCorrettoCryptoProvider.jar
```

After:

```
$ ldd build/cmake/libamazonCorrettoCryptoProvider.so
        linux-vdso.so.1 (0x00007ffe55bd7000)
        libdl.so.2 => /lib64/libdl.so.2 (0x00007fa4478ea000)
        libcrypto.so => /local/home/childw/workplace/github/corretto/amazon-corretto-crypto-provider/build/cmake/libcrypto.so (0x00007fa4474e6000)
        libm.so.6 => /lib64/libm.so.6 (0x00007fa4471a6000)
        libpthread.so.0 => /lib64/libpthread.so.0 (0x00007fa446f88000)
        libc.so.6 => /lib64/libc.so.6 (0x00007fa446bdb000)
        /lib64/ld-linux-x86-64.so.2 (0x00007fa447da2000)

$ du -sh ./build/cmake/libamazonCorrettoCryptoProvider.so
892K    ./build/cmake/libamazonCorrettoCryptoProvider.so

$ du -sh ./build/cmake/AmazonCorrettoCryptoProvider.jar
3.3M    ./build/cmake/AmazonCorrettoCryptoProvider.jar
```

[1]: https://github.com/corretto/amazon-corretto-crypto-provider/commit/7d5b05df49e1296e06cd6e793502a8458b601c3a#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL460


# Testing
- built successfully on all of: mac, AL2 (x86_64 and aarch64), AL2012, and RHEL5
- internal dry runs (links available on request)
- GitHub CI