### PR TITLE
Automate platform detection in sample code

### DIFF
--- a/examples/gradle-kt-dsl/README.md
+++ b/examples/gradle-kt-dsl/README.md
@@ -6,12 +6,3 @@
  ./gradlew lib:test
  ```
 
-Setting the environment variables `ARCH` would make the build script use
-different artifacts available on Maven to be used. For example, the following command
-uses ARM 64 build for the sample code:
-
-```bash
-ARCH=aarch_64 ./gradlew lib:test
-```
-
-* If `ARCH` is not set, `x86_64` is used.

--- a/examples/gradle-kt-dsl/lib/build.gradle.kts
+++ b/examples/gradle-kt-dsl/lib/build.gradle.kts
@@ -1,11 +1,9 @@
 val accpVersion = "1.6.1"
-val archEnv = System.getenv("ARCH")?: "x86_64"
-//val fips = if (System.getenv("FIPS") == null) "" else "-FIPS"
-println("ARCH to be used: $archEnv")
 
 plugins {
     // Apply the org.jetbrains.kotlin.jvm Plugin to add support for Kotlin.
     id("org.jetbrains.kotlin.jvm") version "1.6.21"
+    id("com.google.osdetector") version "1.7.0"
 
     // Apply the java-library plugin for API and implementation separation.
     `java-library`
@@ -29,5 +27,5 @@ dependencies {
     // Use the Kotlin JUnit integration.
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit")
 
-    testImplementation("software.amazon.cryptools:AmazonCorrettoCryptoProvider:$accpVersion:linux-$archEnv")
+    testImplementation("software.amazon.cryptools:AmazonCorrettoCryptoProvider:$accpVersion:${osdetector.classifier}")
 }


### PR DESCRIPTION
*Description of changes:*
Using Gradle plugin `com.google.osdetector` to detect platform and avoid using environment variable to pass the architecture explicitly.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
