### PR TITLE
Use Amazon ECR instead of Docker Hub

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -9,8 +9,7 @@
 # $ SINGLE_TEST=com.amazon.corretto.crypto.provider.test.EvpSignatureTest
 # $ ./gradlew minimal_clean && ./gradlew single_test -DSINGLE_TEST=${SINGLE_TEST}
 
-
-FROM ubuntu:20.04
+FROM public.ecr.aws/ubuntu/ubuntu:20.04_stable
 
 # install corretto JDK
 ARG DEBIAN_FRONTEND=noninteractive

--- a/tests/ci/docker_images/linux-arm/amazonlinux-2_accp_base/Dockerfile
+++ b/tests/ci/docker_images/linux-arm/amazonlinux-2_accp_base/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM arm64v8/amazonlinux:2
+FROM --platform=linux/arm64/v8 public.ecr.aws/amazonlinux/amazonlinux:2
 
 SHELL ["/bin/bash", "-c"]
 

--- a/tests/ci/docker_images/linux-arm/ubuntu-20.04_accp_base/Dockerfile
+++ b/tests/ci/docker_images/linux-arm/ubuntu-20.04_accp_base/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM arm64v8/ubuntu:20.04
+FROM --platform=linux/arm64/v8 public.ecr.aws/ubuntu/ubuntu:20.04_stable
 
 SHELL ["/bin/bash", "-c"]
 

--- a/tests/ci/docker_images/linux-x86/amazonlinux-2_accp_base/Dockerfile
+++ b/tests/ci/docker_images/linux-x86/amazonlinux-2_accp_base/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM amazonlinux:2
+FROM public.ecr.aws/amazonlinux/amazonlinux:2
 
 SHELL ["/bin/bash", "-c"]
 

--- a/tests/ci/docker_images/linux-x86/ubuntu-20.04_accp_base/Dockerfile
+++ b/tests/ci/docker_images/linux-x86/ubuntu-20.04_accp_base/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM ubuntu:20.04
+FROM public.ecr.aws/ubuntu/ubuntu:20.04_stable
 
 SHELL ["/bin/bash", "-c"]
 


### PR DESCRIPTION
This updates our Dockerfile to point to Amazon's equivalent of Docker Hub to source the Ubuntu 20.04 base image.

*Issue #, if available:*

*Description of changes:*
This updates our Dockerfile to point to Amazon's equivalent of Docker Hub to source the Ubuntu 20.04 base image.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
