### PR TITLE
Fix configuring release task when staging

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -656,8 +656,6 @@ if (project.hasProperty('mavenUser') && project.hasProperty('jcecertAlias')) {
             }
             println "Loaded staging id is " + stagingProperties['staging.id']
             stagingRepositoryId = stagingProperties['staging.id']
-        } else {
-            ant.fail('Insufficient configuration for releasing')
         }
     }
 } else {


### PR DESCRIPTION
*Description of changes:*
During Gradle configuration phase when we want to stage,`releaseSonatypeStagingRepository`  would fail.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
