### PR TITLE
Update AWS-LC's commit ID

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -534,8 +534,14 @@ target_link_libraries(amazonCorrettoCryptoProvider ${PROBED_LINKED_FLAGS})
 # MacOS/Darwin because its gcc is actually an alias to clang, which does not
 # fully support them.
 if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
-   target_link_libraries(amazonCorrettoCryptoProvider -static-libstdc++)
-   target_link_libraries(amazonCorrettoCryptoProvider -static-libgcc)
+    message(STATUS "System name matches linux. Checking if -static-libstdc++ and -static-libgcc are supported by the compiler.")
+    CHECK_ENABLE_CXX_FLAG(CXX_SUPPORT_STATIC_LIBSTDCPP -static-libstdc++)
+    CHECK_ENABLE_CXX_FLAG(CXX_SUPPORT_STATIC_LIBGCC -static-libgcc)
+    if(CXX_SUPPORT_STATIC_LIBSTDCPP AND CXX_SUPPORT_STATIC_LIBGCC)
+        message(STATUS "Using -static-libstdc++ and -static-libgcc flags")
+        target_link_libraries(amazonCorrettoCryptoProvider -static-libstdc++)
+        target_link_libraries(amazonCorrettoCryptoProvider -static-libgcc)
+    endif()
 endif()
 
 # Add pthread support

--- a/README.md
+++ b/README.md
@@ -121,6 +121,14 @@ The below snippet will pull in all versions of ACCP prior to the 2.0.0 release. 
 </dependency>
 ```
 
+ACCP artifacts on Maven can be verified using the following PGP keys:
+
+| ACCP Version  | PGP Key ID       | Key Server |
+|---------------|------------------|------------|
+| 1.x | 6F189046CEE0B2C1 | keyserver.ubuntu.com |
+| 2.x | 5EFEEFE6BD0BD916 | keyserver.ubuntu.com |
+
+
 ### Gradle
 Add the following to your `build.gradle` file. If you already have a
 `dependencies` block in your `build.gradle`, you can add the ACCP line to your

--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@ plugins {
 group = 'software.amazon.cryptools'
 version = '2.0.0'
 ext.isFips = Boolean.getBoolean('FIPS')
+ext.isLegacyBuild = Boolean.getBoolean('LEGACY_BUILD')
 
 jmh {
     fork = 1
@@ -150,7 +151,7 @@ task buildAwsLc {
         // directory arguments is slightly different.
         // FIPS isn't tested for this dimension. The only thing we care about for the
         // legacy build is non C++11 and CMake 3.9 compatibility.
-        if (Boolean.getBoolean('LEGACY_BUILD')) {
+        if (isLegacyBuild) {
             exec {
                 workingDir cMakeBuildDir
                 executable cmakeBin
@@ -533,7 +534,11 @@ task coverage {
 }
 
 task release {
-    dependsOn build, test, coverage, javadoc, src_jar, checkstyle
+    if (isLegacyBuild) {
+        dependsOn build, test, javadoc, src_jar, checkstyle
+    } else {
+        dependsOn build, test, coverage, javadoc, src_jar, checkstyle
+    }
 }
 
 task overkill {


### PR DESCRIPTION
**Description of changes:**

* Updated AWS-LC's commit ID to the tip of main (1ccaebeb9a1c877d309337a93ff2c2c75d36f4e8)
* Disable coverage for legacy build: lcov introduces some global symbols that are not properly handled with the legacy build, which uses gcc4.1
* Avoid static linking of standard libraries if they are not supported by the compiler: gcc-4.1 sometimes silently fails when it does not recognize the flag
* Add IDs for PGP keys we use to sign artifacts that we release to Maven

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
