### PR TITLE
Update scripts for 1.6.2 release

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,9 +9,9 @@ plugins {
 }
 
 group = 'software.amazon.cryptools'
-version = '1.6.1'
+version = '1.6.2'
 
-def openssl_version = '1.1.1j'
+def openssl_version = '1.1.1t'
 def opensslSrcPath = "${buildDir}/openssl/openssl-${openssl_version}"
 
 configurations {
@@ -55,8 +55,8 @@ dependencies {
 
     testDep 'org.junit.jupiter:junit-jupiter:5.6.2'
     testDep 'org.junit.vintage:junit-vintage-engine:5.6.2'
-    testDep 'org.bouncycastle:bcprov-debug-jdk15on:1.65'
-    testDep 'org.bouncycastle:bcpkix-jdk15on:1.65'
+    testDep 'org.bouncycastle:bcprov-debug-jdk15on:1.69'
+    testDep 'org.bouncycastle:bcpkix-jdk15on:1.69'
     testDep 'commons-codec:commons-codec:1.12'
     testDep 'org.hamcrest:hamcrest:2.1'
     testDep 'org.jacoco:org.jacoco.core:0.8.3'
@@ -148,8 +148,8 @@ task executeCmake(type: Exec) {
         prebuiltJar = "${projectDir}/" + System.properties['prebuiltJar']
     }
 
-    executable 'cmake'
-    args 'cmake', "-DTEST_CLASSPATH=${configurations.testDep.asPath}", "-DJACOCO_AGENT_JAR=${configurations.jacocoAgent.singleFile}"
+    executable 'cmake3'
+    args "-DTEST_CLASSPATH=${configurations.testDep.asPath}", "-DJACOCO_AGENT_JAR=${configurations.jacocoAgent.singleFile}"
     args "-DOPENSSL_ROOT_DIR=${buildDir}/openssl/bin", '-DCMAKE_BUILD_TYPE=Release', '-DPROVIDER_VERSION_STRING=' + version
     args "-DTEST_RUNNER_JAR=${configurations.testRunner.singleFile}"
 
@@ -303,7 +303,7 @@ task coverage_cmake(type: Exec) {
         mkdir "${buildDir}/cmake-coverage"
     }
     workingDir "${buildDir}/cmake-coverage"
-    executable 'cmake'
+    executable 'cmake3'
     args "-DTEST_CLASSPATH=${configurations.testDep.asPath}"
     args "-DJACOCO_AGENT_JAR=${configurations.jacocoAgent.singleFile}"
     args "-DOPENSSL_ROOT_DIR=${buildDir}/openssl/bin"

--- a/openssl.sha256
+++ b/openssl.sha256
@@ -1,1 +1,1 @@
-aaf2fcb575cdf6491b98ab4829abf78a3dec8402b8b81efc8f23c00d443981bf  openssl-1.1.1j.tar.gz
+8dee9b24bdb1dcbf0c3d1e9b02fb8f6bf22165e807f45adeb7c9677536859d3b  openssl-1.1.1t.tar.gz


### PR DESCRIPTION
*Description of changes:*
* Update OpenSSL to 1.1.1t
* Fix some integration tests
* Use cmake3 to build

*Testing:*
* `./gradlew -Dorg.gradle.internal.http.socketTimeout=300000  build src_jar javadoc test test_integration`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
