### PR TITLE
Implement AlgorithmParameters for EC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 /.classpath
 tests/ci/cdk/.idea
 tests/ci/cdk/venv
+coverage/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -589,6 +589,7 @@ if (TEST_JAVA_MAJOR_VERSION VERSION_GREATER_EQUAL 17)
     --add-opens java.base/javax.crypto=ALL-UNNAMED
     --add-opens java.base/java.lang.invoke=ALL-UNNAMED
     --add-opens java.base/java.security=ALL-UNNAMED
+    --add-opens=java.base/sun.security.util=ALL-UNNAMED
     --add-exports jdk.crypto.ec/sun.security.ec=java.base
     )
 endif()
@@ -693,6 +694,7 @@ add_custom_target(check-install-via-properties
     COMMAND ${TEST_JAVA_EXECUTABLE}
         ${COVERAGE_ARGUMENTS}
         ${TEST_FIPS_PROPERTY}
+        ${TEST_ADD_OPENS}
         -cp $<TARGET_PROPERTY:accp-jar,JAR_FILE>:$<TARGET_PROPERTY:tests-jar,JAR_FILE>:${TEST_CLASSPATH}
         ${EXTERNAL_LIB_PROPERTY}
         -Dcom.amazon.corretto.crypto.provider.inTestSuite=hunter2
@@ -709,6 +711,7 @@ add_custom_target(check-external-lib
     COMMAND ${TEST_JAVA_EXECUTABLE}
         ${COVERAGE_ARGUMENTS}
         ${TEST_FIPS_PROPERTY}
+        ${TEST_ADD_OPENS}
         -cp $<TARGET_PROPERTY:accp-jar,JAR_FILE>:$<TARGET_PROPERTY:tests-jar,JAR_FILE>:${TEST_CLASSPATH}
         # Since this tests external loading we always provide this property
         -Djava.library.path=$<TARGET_FILE_DIR:amazonCorrettoCryptoProvider>
@@ -725,6 +728,7 @@ add_custom_target(check-install-via-properties-recursive
     COMMAND ${TEST_JAVA_EXECUTABLE}
         ${COVERAGE_ARGUMENTS}
         ${TEST_FIPS_PROPERTY}
+        ${TEST_ADD_OPENS}
         -cp $<TARGET_PROPERTY:accp-jar,JAR_FILE>:$<TARGET_PROPERTY:tests-jar,JAR_FILE>:${TEST_CLASSPATH}
         ${EXTERNAL_LIB_PROPERTY}
         -Dcom.amazon.corretto.crypto.provider.inTestSuite=hunter2
@@ -739,6 +743,7 @@ add_custom_target(check-install-via-properties-with-debug
     COMMAND ${TEST_JAVA_EXECUTABLE}
         ${COVERAGE_ARGUMENTS}
         ${TEST_FIPS_PROPERTY}
+        ${TEST_ADD_OPENS}
         -cp $<TARGET_PROPERTY:accp-jar,JAR_FILE>:$<TARGET_PROPERTY:tests-jar,JAR_FILE>:${TEST_CLASSPATH}
         ${EXTERNAL_LIB_PROPERTY}
         -Dcom.amazon.corretto.crypto.provider.inTestSuite=hunter2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -589,7 +589,7 @@ if (TEST_JAVA_MAJOR_VERSION VERSION_GREATER_EQUAL 17)
     --add-opens java.base/javax.crypto=ALL-UNNAMED
     --add-opens java.base/java.lang.invoke=ALL-UNNAMED
     --add-opens java.base/java.security=ALL-UNNAMED
-    --add-opens=java.base/sun.security.util=ALL-UNNAMED
+    --add-opens java.base/sun.security.util=ALL-UNNAMED
     --add-exports jdk.crypto.ec/sun.security.ec=java.base
     )
 endif()
@@ -694,7 +694,6 @@ add_custom_target(check-install-via-properties
     COMMAND ${TEST_JAVA_EXECUTABLE}
         ${COVERAGE_ARGUMENTS}
         ${TEST_FIPS_PROPERTY}
-        ${TEST_ADD_OPENS}
         -cp $<TARGET_PROPERTY:accp-jar,JAR_FILE>:$<TARGET_PROPERTY:tests-jar,JAR_FILE>:${TEST_CLASSPATH}
         ${EXTERNAL_LIB_PROPERTY}
         -Dcom.amazon.corretto.crypto.provider.inTestSuite=hunter2
@@ -711,7 +710,6 @@ add_custom_target(check-external-lib
     COMMAND ${TEST_JAVA_EXECUTABLE}
         ${COVERAGE_ARGUMENTS}
         ${TEST_FIPS_PROPERTY}
-        ${TEST_ADD_OPENS}
         -cp $<TARGET_PROPERTY:accp-jar,JAR_FILE>:$<TARGET_PROPERTY:tests-jar,JAR_FILE>:${TEST_CLASSPATH}
         # Since this tests external loading we always provide this property
         -Djava.library.path=$<TARGET_FILE_DIR:amazonCorrettoCryptoProvider>
@@ -728,7 +726,6 @@ add_custom_target(check-install-via-properties-recursive
     COMMAND ${TEST_JAVA_EXECUTABLE}
         ${COVERAGE_ARGUMENTS}
         ${TEST_FIPS_PROPERTY}
-        ${TEST_ADD_OPENS}
         -cp $<TARGET_PROPERTY:accp-jar,JAR_FILE>:$<TARGET_PROPERTY:tests-jar,JAR_FILE>:${TEST_CLASSPATH}
         ${EXTERNAL_LIB_PROPERTY}
         -Dcom.amazon.corretto.crypto.provider.inTestSuite=hunter2
@@ -743,7 +740,6 @@ add_custom_target(check-install-via-properties-with-debug
     COMMAND ${TEST_JAVA_EXECUTABLE}
         ${COVERAGE_ARGUMENTS}
         ${TEST_FIPS_PROPERTY}
-        ${TEST_ADD_OPENS}
         -cp $<TARGET_PROPERTY:accp-jar,JAR_FILE>:$<TARGET_PROPERTY:tests-jar,JAR_FILE>:${TEST_CLASSPATH}
         ${EXTERNAL_LIB_PROPERTY}
         -Dcom.amazon.corretto.crypto.provider.inTestSuite=hunter2
@@ -790,6 +786,8 @@ add_custom_target(coverage
 add_custom_target(check-integration-extra-checks
     COMMAND ${TEST_JAVA_EXECUTABLE}
         -Dcom.amazon.corretto.crypto.provider.extrachecks=ALL
+        # perform standard integration tests with JCE EC parameters, and extra-checks integration tests with ACCP's
+        -Dcom.amazon.corretto.crypto.provider.registerEcParams=true
         ${TEST_RUNNER_ARGUMENTS}
         --select-package=com.amazon.corretto.crypto.provider.test.integration
 

--- a/README.md
+++ b/README.md
@@ -262,6 +262,12 @@ Thus, these should all be set on the JVM command line using `-D`.
   and the subsequent calls to `AmazonCorrettoCryptoProvider::runSelfTests`
   would avoid re-running tests; otherwise, each call to `AmazonCorrettoCryptoProvider::runSelfTests`
   re-run the tests.
+* `com.amazon.corretto.crypto.provider.registerEcParams`
+  Takes in `true` or `false` (defaults to `false`).
+  If `true`, then ACCP will register its EC-flavoered AlgorithmParameters implementation on startup.
+  Else, the JCA will get the implementation from another registered provider (usually stock JCE).
+  Using JCE's impelmentation is generally recommended unless using ACCP as a standalone provider
+  Callers can choose to register ACCP's implementation at runtime with a call to `AmazonCorrettoCryptoProvider.registerEcParams()`
 
 
 # License

--- a/csrc/ec_utils.cpp
+++ b/csrc/ec_utils.cpp
@@ -5,6 +5,7 @@
 #include <openssl/ec.h>
 #include <openssl/err.h>
 #include <openssl/objects.h>
+#include <vector>
 #include "generated-headers.h"
 #include "util.h"
 #include "env.h"
@@ -63,7 +64,9 @@ JNIEXPORT jint JNICALL Java_com_amazon_corretto_crypto_provider_EcUtils_curveNam
   jbyteArray cofactorArr,
   jbyteArray gxArr,
   jbyteArray gyArr,
-  jbyteArray orderArr)
+  jbyteArray orderArr,
+  jbyteArray oid,
+  jbyteArray encoded)
 {
     try {
         raii_env env(pEnv);
@@ -155,9 +158,101 @@ JNIEXPORT jint JNICALL Java_com_amazon_corretto_crypto_provider_EcUtils_curveNam
         }
         orderBN.toJavaArray(env, orderArr);
 
+        // Get the decoded (string) curve OID
+        jni_borrow oidBorrow = jni_borrow(env, java_buffer::from_array(env, oid), "curveNameToInfo");
+        if (!OBJ_obj2txt((char*) oidBorrow.data(), (int) oidBorrow.len(), OBJ_nid2obj(nid), /*always_return_oid*/1)) {
+            throw_openssl("Unable to get decoded curve OID");
+        }
+        oidBorrow.release();
+
+        // Get the DER-encoded curve OID
+        jni_borrow encodedBorrow = jni_borrow(env, java_buffer::from_array(env, encoded), "curveNameToInfo");
+        CBB cbb;
+        CBB_init_fixed(&cbb, encodedBorrow.data(), encodedBorrow.len());
+        if (!EC_KEY_marshal_curve_name(&cbb, group)) {
+            throw_openssl("Unable to get encoded curve OID");
+        }
+        encodedBorrow.release();
+
         return nid;
     } catch (java_ex &ex) {
         ex.throw_to_java(pEnv);
         return 0;
+    }
+}
+
+/*
+ * Class:     com_amazon_corretto_crypto_provider_EcUtils
+ * Method:    getCurveNames
+ */
+JNIEXPORT jobjectArray JNICALL Java_com_amazon_corretto_crypto_provider_EcUtils_getCurveNames(
+  JNIEnv *pEnv,
+  jclass)
+{
+    try {
+        raii_env env(pEnv);
+
+        std::vector<EC_builtin_curve> curves;
+        // Specify 0 as the max return count so no data is written, but we get the curve count
+        size_t numCurves = EC_get_builtin_curves(curves.data(), 0);
+        // Now that we know the number of curves to expect, resize and get the curve info from LC
+        curves.resize(numCurves);
+        numCurves = EC_get_builtin_curves(curves.data(), curves.size());
+        if (numCurves > curves.size()) {
+            // We get curve count from LC and resize accordingly, so we should never hit this.
+            throw_openssl("Too many curves");
+        }
+
+        jobjectArray names = env->NewObjectArray(numCurves, env->FindClass("java/lang/String"), nullptr);
+        for (size_t i = 0; i < numCurves; i++) {
+            // NOTE: we return the "short name" (e.g. secp384r1) rather than the NIST name (e.g. "NIST P-384")
+            env->SetObjectArrayElement(names, i, env->NewStringUTF(OBJ_nid2sn(curves[i].nid)));
+        }
+
+        return names;
+    } catch (java_ex &ex) {
+        ex.throw_to_java(pEnv);
+        return nullptr;
+    }
+}
+
+/*
+ * Class:     com_amazon_corretto_crypto_provider_EcUtils
+ * Method:    getCurveNameFromEncoded
+ * Signature: ([B)Ljava/lang/String
+ */
+JNIEXPORT jstring JNICALL Java_com_amazon_corretto_crypto_provider_EcUtils_getCurveNameFromEncoded(
+  JNIEnv *pEnv,
+  jclass,
+  jbyteArray encoded
+  )
+{
+    try {
+        raii_env env(pEnv);
+
+        jni_borrow borrow = jni_borrow(env, java_buffer::from_array(env, encoded), "getCurveNameFromEncoded");
+        CBS cbs;
+        CBS_init(&cbs, borrow.data(), borrow.len());
+        EC_GROUP *group = EC_KEY_parse_curve_name(&cbs);
+        if (group == nullptr) {
+            throw_openssl("Unable to parse curve OID ASN.1");
+        }
+
+        int nid = EC_GROUP_get_curve_name(group);
+        if (nid == NID_undef) {
+            throw_openssl("Unable to get curve nid from group");
+        }
+        // NOTE: we return the "short name" (e.g. secp384r1) rather than the NIST name (e.g. "NIST P-384")
+        const char* shortName = OBJ_nid2sn(nid);
+        if (shortName == nullptr) {
+            throw_openssl("Unable to get short name from nid");
+        }
+        // NOTE: need to use the JNIEnv |pEnv| here instead of raii_env |env|
+        // because we're returning the JString value and |env|'s dtor checks
+        // for locks once it goes out of scope.
+        return pEnv->NewStringUTF(shortName);
+    } catch (java_ex &ex) {
+        ex.throw_to_java(pEnv);
+        return nullptr;
     }
 }

--- a/csrc/env.cpp
+++ b/csrc/env.cpp
@@ -191,7 +191,7 @@ void raii_env::buffer_lock_trace() {
     int n = 0;
     for (jni_borrow *p = m_last_buffer_lock; p; p = p->m_prior_borrow) {
         n++;
-        std::cerr << "\t" << p << ": \"" << p->m_trace << "\"" << std::endl;
+        std::cerr << "\t" << p << ": \"" << (p->m_trace ? p->m_trace : "NO TRACE") << "\"" << std::endl;
     }
     std::cerr << "End trace (" << n << " locks)" << std::endl;
 

--- a/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
+++ b/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
@@ -72,6 +72,8 @@ public final class AmazonCorrettoCryptoProvider extends java.security.Provider {
 
         addService("KeyGenerator", "AES", "keygeneratorspi.SecretKeyGenerator", false);
 
+        addService("AlgorithmParameters", "EC", "EcParameters");
+
         addService("Cipher", "RSA/ECB/NoPadding", "RsaCipher$NoPadding");
         addService("Cipher", "RSA/ECB/Pkcs1Padding", "RsaCipher$Pkcs1");
         addService("Cipher", "RSA/ECB/OAEPPadding", "RsaCipher$OAEP");

--- a/src/com/amazon/corretto/crypto/provider/EcGen.java
+++ b/src/com/amazon/corretto/crypto/provider/EcGen.java
@@ -119,9 +119,9 @@ class EcGen extends KeyPairGeneratorSpi {
 
     private static byte[] encodeSpec(final AlgorithmParameterSpec spec) {
         try {
-            final AlgorithmParameters toEncode = AlgorithmParameters.getInstance("EC");
-            toEncode.init(spec);
-            return toEncode.getEncoded();
+            AlgorithmParameters parameters = AlgorithmParameters.getInstance("EC");
+            parameters.init(spec);
+            return parameters.getEncoded();
         } catch (final GeneralSecurityException | IOException ex) {
             throw new RuntimeCryptoException(ex);
         }

--- a/src/com/amazon/corretto/crypto/provider/EcParameters.java
+++ b/src/com/amazon/corretto/crypto/provider/EcParameters.java
@@ -1,0 +1,115 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.amazon.corretto.crypto.provider;
+
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.security.*;
+import java.security.spec.*;
+
+
+public final class EcParameters extends AlgorithmParametersSpi {
+    private EcUtils.ECInfo ecInfo;
+
+    // A public constructor is required by AlgorithmParameters class.
+    public EcParameters() {}
+
+    protected void engineInit(AlgorithmParameterSpec paramSpec) throws InvalidParameterSpecException {
+        if (paramSpec == null) {
+            throw new InvalidParameterSpecException("paramSpec must not be null");
+        }
+
+        String name = null;
+        if (paramSpec instanceof ECParameterSpec) {
+            name = EcUtils.getNameBySpec((ECParameterSpec) paramSpec);
+            // Earlier Java TLS implementations cache curve params by OID instead of human-readable "shortname".
+            // Specifying the shortname where OID is expected results in TLS handshake failures due to the server
+            // not being able to "find" the intended curve, tricking the server into believing it doesn't support any
+            // of the curves stipulated by the client.
+            //
+            // https://github.com/corretto/corretto-8/blob/235873fd43e5b7aa556d011f436e65a99c10c20a/jdk/src/share/classes/sun/security/ssl/SupportedGroupsExtension.java#L585-L607
+            // https://github.com/openjdk/jdk10u/blob/ef9178d7d8a4489640a31a1d0c88958724af5304/src/java.base/share/classes/sun/security/ssl/SupportedGroupsExtension.java#L188-L210
+            if (Utils.getJavaVersion() < 11) {
+                name = EcUtils.getOidFromName(name);
+            }
+        } else if (paramSpec instanceof ECGenParameterSpec) {
+            name = ((ECGenParameterSpec) paramSpec).getName();
+        } else if ("sun.security.util.ECKeySizeParameterSpec".equals(paramSpec.getClass().getName())) {
+            // OpenJDK's JCE sometimes passes ECKeySizeParameterSpec when initializing EC AlgorithmParameters. We can
+            // reference this class directly using instanceof up until Java 8, but in Java 9 it was moved to the
+            // java.base module and only exported to other JDK-internal modules. To work around this, we use reflection
+            // to get the key size and get the corresponding curve name from our own database. Future versions of java
+            // may restrict reflective access to private modules, so this functionality may break.
+            //
+            // https://github.com/corretto/corretto-11/blob/14c02261590b4dc01284888a7a51d39ff581ac8d/src/java.base/share/classes/sun/security/util/ECParameters.java#L121
+            // https://github.com/corretto/corretto-11/blob/14c02261590b4dc01284888a7a51d39ff581ac8d/src/java.base/share/classes/module-info.java#L301-L314
+            try {
+                Method getKeySize = paramSpec.getClass().getMethod("getKeySize");
+                Integer keySize = Integer.class.cast(getKeySize.invoke(paramSpec));
+                name = EcUtils.getNameByKeySize(keySize);
+            } catch (ReflectiveOperationException e) {
+                // pass, perhaps due to reflective access control restrictions. rely null check below to throw.
+            }
+        }
+
+        if (name == null) {
+            throw new InvalidParameterSpecException("Only ECParameterSpec and ECGenParameterSpec supported");
+        }
+
+        ecInfo = EcUtils.getSpecByName(name);
+        if (ecInfo == null) {
+            throw new InvalidParameterSpecException("Unknown curve: " + paramSpec);
+        }
+    }
+
+    protected void engineInit(byte[] params) throws IOException {
+        String name = null;
+        try {
+            name = EcUtils.getNameByEncoded(params);
+        } catch (RuntimeCryptoException e) {
+            // pass, handle via null check below
+        }
+        if (name == null) {
+            throw new IOException("Only named EcParameters supported");
+        }
+        ecInfo = EcUtils.getSpecByName(name);
+        if (ecInfo == null) {
+            throw new IOException("Unknown named curve: " + name);
+        }
+    }
+
+    protected void engineInit(byte[] params, String unused) throws IOException {
+        engineInit(params);
+    }
+
+    protected <T extends AlgorithmParameterSpec> T engineGetParameterSpec(Class<T> spec)
+            throws InvalidParameterSpecException {
+
+        if (spec.isAssignableFrom(ECParameterSpec.class)) {
+            return spec.cast(ecInfo.spec);
+        }
+
+        if (spec.isAssignableFrom(ECGenParameterSpec.class)) {
+            return spec.cast(new ECGenParameterSpec(ecInfo.name));
+        }
+
+        throw new InvalidParameterSpecException("Only ECParameterSpec and ECGenParameterSpec supported");
+    }
+
+    protected byte[] engineGetEncoded() throws IOException {
+        return ecInfo.encoded.clone();  // clone to avoid exposing static reference
+    }
+
+    protected byte[] engineGetEncoded(String encodingMethod) throws IOException {
+        return engineGetEncoded();
+    }
+
+    protected String engineToString() {
+        if (ecInfo == null) {
+            return "Not initialized";
+        }
+
+        return ecInfo.name;
+    }
+}

--- a/src/com/amazon/corretto/crypto/provider/Utils.java
+++ b/src/com/amazon/corretto/crypto/provider/Utils.java
@@ -32,7 +32,6 @@ import javax.crypto.spec.SecretKeySpec;
  * Miscellaneous utility methods.
  */
 final class Utils {
-    private static final String CACHE_SELF_TEST_RESULTS = "cacheselftestresults";
     private Utils() {
         // Prevent instantiation
     }
@@ -526,13 +525,14 @@ final class Utils {
         return JAVA_VERSION;
     }
 
-    static boolean getCacheSelfTestResultsProperty() {
-        final String relyOnCacheSelfTestResultsStr = Loader.getProperty(CACHE_SELF_TEST_RESULTS, "true").toLowerCase();
-        if (!relyOnCacheSelfTestResultsStr.equals("true") && !relyOnCacheSelfTestResultsStr.equals("false")) {
-            LOG.warning(String.format("Valid values for %s are false and true, with true as default", CACHE_SELF_TEST_RESULTS));
-            return true;
+    static boolean getBooleanProperty(String propertyName, boolean defaultValue) {
+        final String defaultStr = defaultValue ? "true" : "false";
+        final String propertyStr = Loader.getProperty(propertyName, defaultStr).toLowerCase();
+        if (!propertyStr.equals("true") && !propertyStr.equals("false")) {
+            LOG.warning(String.format("Valid values for %s are false and true, with %s as default", propertyName, defaultStr));
+            return defaultValue;
         }
-        return Boolean.parseBoolean(relyOnCacheSelfTestResultsStr);
+        return Boolean.parseBoolean(propertyStr);
     }
 }
 

--- a/tst/com/amazon/corretto/crypto/provider/test/EcGenTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/EcGenTest.java
@@ -56,8 +56,7 @@ public class EcGenTest {
     public static final String[][] LEGACY_CURVES = new String[][] {
             // Prime Curves
             new String[]{"secp224r1", "NIST P-224", "1.3.132.0.33"},
-            // TODO uncomment below pending https://sim.amazon.com/issues/CryptoAlg-1024
-            // new String[]{"secp256k1", "1.3.132.0.10"},
+            new String[]{"secp256k1", "1.3.132.0.10"},
             };
 
     public static final ECParameterSpec EXPLICIT_CURVE;

--- a/tst/com/amazon/corretto/crypto/provider/test/EcGenTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/EcGenTest.java
@@ -75,7 +75,6 @@ public class EcGenTest {
     public void setup() throws GeneralSecurityException {
         nativeGen = KeyPairGenerator.getInstance("EC", NATIVE_PROVIDER);
         jceGen = KeyPairGenerator.getInstance("EC", "SunEC");
-
     }
 
     @AfterEach

--- a/tst/com/amazon/corretto/crypto/provider/test/EcGenTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/EcGenTest.java
@@ -46,19 +46,6 @@ import org.junit.jupiter.params.provider.ValueSource;
 @Execution(ExecutionMode.CONCURRENT)
 @ResourceLock(value = TestUtil.RESOURCE_GLOBAL, mode = ResourceAccessMode.READ)
 public class EcGenTest {
-    public static final String[][] KNOWN_CURVES = new String[][] {
-            new String[]{"secp256r1", "NIST P-256", "X9.62 prime256v1", /* "prime256v1", */ "1.2.840.10045.3.1.7"},
-            new String[]{"secp384r1", "NIST P-384", "1.3.132.0.34"},
-            new String[]{"secp521r1", "NIST P-521", "1.3.132.0.35"},
-            };
-
-    // Not supported in JDK17
-    public static final String[][] LEGACY_CURVES = new String[][] {
-            // Prime Curves
-            new String[]{"secp224r1", "NIST P-224", "1.3.132.0.33"},
-            new String[]{"secp256k1", "1.3.132.0.10"},
-            };
-
     public static final ECParameterSpec EXPLICIT_CURVE;
     private static final KeyFactory KEY_FACTORY;
 
@@ -100,7 +87,7 @@ public class EcGenTest {
     }
 
     private static String[][] legacyCurveParams() {
-        return LEGACY_CURVES;
+        return TestUtil.LEGACY_CURVES;
     }
 
     @ParameterizedTest
@@ -113,7 +100,7 @@ public class EcGenTest {
     }
 
     private static String[][] knownCurveParams() {
-        return KNOWN_CURVES;
+        return TestUtil.KNOWN_CURVES;
     }
 
     @ParameterizedTest
@@ -235,7 +222,7 @@ public class EcGenTest {
         final byte[] message = new byte[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
         // We're purposefully using Java's ECDSA logic, since we trust it to be correct
         final Signature ecdsa = Signature.getInstance("NONEwithECDSA", "SunEC");
-            for (final String[] names : KNOWN_CURVES) {
+            for (final String[] names : TestUtil.KNOWN_CURVES) {
                 for (final String name : names) {
                 nativeGen.initialize(new ECGenParameterSpec(name));
                 final KeyPair keyPair = nativeGen.generateKeyPair();
@@ -257,7 +244,7 @@ public class EcGenTest {
         final byte[] message = new byte[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
         // We're purposefully using Java's ECDSA logic, since we trust it to be correct
         final Signature ecdsa = Signature.getInstance("NONEwithECDSA", "SunEC");
-            for (final String[] names : LEGACY_CURVES) {
+            for (final String[] names : TestUtil.LEGACY_CURVES) {
                 for (final String name : names) {
                 nativeGen.initialize(new ECGenParameterSpec(name));
                 final KeyPair keyPair = nativeGen.generateKeyPair();
@@ -291,8 +278,8 @@ public class EcGenTest {
         final KeyPairGenerator[] generators = new KeyPairGenerator[generatorCount];
         for (int x = 0; x < generatorCount; x++) {
             generators[x] = KeyPairGenerator.getInstance("EC", NATIVE_PROVIDER);
-            final int curveIdx = rng.nextInt(KNOWN_CURVES.length);
-            generators[x].initialize(new ECGenParameterSpec(KNOWN_CURVES[curveIdx][0]));
+            final int curveIdx = rng.nextInt(TestUtil.KNOWN_CURVES.length);
+            generators[x].initialize(new ECGenParameterSpec(TestUtil.KNOWN_CURVES[curveIdx][0]));
         }
 
         final List<TestThread> threads = new ArrayList<>();
@@ -349,6 +336,11 @@ public class EcGenTest {
         assertEquals(expected.getOrder(), actual.getOrder(), message);
         assertEquals(expected.getGenerator(), actual.getGenerator(), message);
         assertEquals(expected.getCurve(), actual.getCurve(), message);
+    }
+
+    public static void assertECEquals(final String message, final ECGenParameterSpec expected,
+            final ECGenParameterSpec actual) {
+        assertEquals(expected.getName(), actual.getName(), message);
     }
 
     private static class TestThread extends Thread {

--- a/tst/com/amazon/corretto/crypto/provider/test/EcParametersTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/EcParametersTest.java
@@ -1,0 +1,160 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.amazon.corretto.crypto.provider.test;
+
+import static com.amazon.corretto.crypto.provider.test.TestUtil.NATIVE_PROVIDER;
+import static com.amazon.corretto.crypto.provider.test.EcGenTest.assertECEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.io.IOException;
+import java.math.BigInteger;
+import java.security.*;
+import java.security.interfaces.ECPublicKey;
+import java.security.spec.AlgorithmParameterSpec;
+import java.security.spec.ECGenParameterSpec;
+import java.security.spec.ECParameterSpec;
+import java.security.spec.InvalidParameterSpecException;
+import java.security.spec.RSAKeyGenParameterSpec;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.aggregator.ArgumentsAccessor;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@ExtendWith(TestResultLogger.class)
+@Execution(ExecutionMode.CONCURRENT)
+@ResourceLock(value = TestUtil.RESOURCE_GLOBAL, mode = ResourceAccessMode.READ)
+public class EcParametersTest {
+
+    private static String[][] legacyCurveParams() {
+        return TestUtil.LEGACY_CURVES;
+    }
+
+    @ParameterizedTest
+    @EnabledForJreRange(min=JRE.JAVA_8, max=JRE.JAVA_14)
+    @MethodSource("legacyCurveParams")
+    public void legacyCurves(ArgumentsAccessor arguments) throws Exception {
+        for (final Object name : arguments.toArray()) {
+            testCurveParamsByName((String) name);
+        }
+    }
+
+    private static String[][] knownCurveParams() {
+        return TestUtil.KNOWN_CURVES;
+    }
+
+    @ParameterizedTest
+    @MethodSource("knownCurveParams")
+    public void knownCurves(ArgumentsAccessor arguments) throws Exception {
+        for (final Object name : arguments.toArray()) {
+            testCurveParamsByName((String) name);
+        }
+    }
+
+    private void testCurveParamsByName(String name) throws Exception {
+        ECGenParameterSpec genSpec = new ECGenParameterSpec(name);
+        final KeyPairGenerator jceGen = KeyPairGenerator.getInstance("EC", "SunEC");;
+        final KeyPairGenerator nativeGen = KeyPairGenerator.getInstance("EC", NATIVE_PROVIDER);;
+        jceGen.initialize(genSpec);
+        nativeGen.initialize(genSpec);
+        KeyPair jcePair = jceGen.generateKeyPair();
+        KeyPair nativePair = nativeGen.generateKeyPair();
+        final ECParameterSpec jceParams = ((ECPublicKey) jcePair.getPublic()).getParams();
+        final ECParameterSpec nativeParams = ((ECPublicKey) nativePair.getPublic()).getParams();
+        assertECEquals(name, jceParams, nativeParams);
+
+        // Ensure mutual compatibility between JCE and ACCP for conversion to/from ECParameterSpec
+        final AlgorithmParameters jceAlgParams = AlgorithmParameters.getInstance("EC", "SunEC");
+        final AlgorithmParameters nativeAlgParams = AlgorithmParameters.getInstance("EC", NATIVE_PROVIDER);
+        jceAlgParams.init(jceParams);
+        nativeAlgParams.init(nativeParams);
+        final ECParameterSpec jceAlgSpec = jceAlgParams.getParameterSpec(ECParameterSpec.class);
+        final ECParameterSpec nativeAlgSpec = nativeAlgParams.getParameterSpec(ECParameterSpec.class);
+        assertECEquals(name, jceParams, jceAlgSpec);
+        assertECEquals(name, nativeParams, nativeAlgSpec);
+        assertECEquals(name, jceAlgSpec, nativeAlgSpec);
+        assertNotNull(nativeAlgParams.toString());
+
+
+        // Ensure mutual compatibility between JCE and ACCP for conversion to/from AlgorithmParameterSpec
+        final AlgorithmParameters jceGenParams = AlgorithmParameters.getInstance("EC", "SunEC");
+        final AlgorithmParameters nativeGenParams = AlgorithmParameters.getInstance("EC", NATIVE_PROVIDER);
+        jceGenParams.init(genSpec);
+        nativeGenParams.init(genSpec);
+        final String jceCurveName = jceAlgParams.getParameterSpec(ECGenParameterSpec.class).getName();
+        // Some versions of JCE will return the curve OID instead of curve name, so account for that
+        // and convert ACCP's to corresponding OID before comparing.
+        if (TestUtil.isOid(jceCurveName)) {
+            final String nativeCurveOid = TestUtil.getCurveOid(
+                nativeAlgParams.getParameterSpec(ECGenParameterSpec.class).getName()
+            );
+            assertEquals(jceCurveName, nativeCurveOid);
+        } else {
+            assertECEquals(
+                name,
+                jceAlgParams.getParameterSpec(ECGenParameterSpec.class),
+                nativeAlgParams.getParameterSpec(ECGenParameterSpec.class)
+            );
+        }
+        assertECEquals(name, genSpec, nativeGenParams.getParameterSpec(ECGenParameterSpec.class));
+
+        // Ensure mutual compatibility between JCE and ACCP for encoding/decoding round trip
+        byte[] jceEncodedParams = jceAlgParams.getEncoded();
+        byte[] nativeEncodedParams = nativeAlgParams.getEncoded();
+        assertArrayEquals(jceEncodedParams, nativeEncodedParams);
+        AlgorithmParameters jceDecodedParams = AlgorithmParameters.getInstance("EC", "SunEC");
+        AlgorithmParameters nativeDecodedParams = AlgorithmParameters.getInstance("EC", NATIVE_PROVIDER);
+        jceDecodedParams.init(jceEncodedParams);
+        nativeDecodedParams.init(nativeEncodedParams);
+        ECParameterSpec jceDecodedSpec = jceDecodedParams.getParameterSpec(ECParameterSpec.class);
+        ECParameterSpec nativeDecodedSpec = nativeDecodedParams.getParameterSpec(ECParameterSpec.class);
+        assertECEquals(name, jceAlgSpec, jceDecodedSpec);
+        assertECEquals(name, nativeAlgSpec, nativeDecodedSpec);
+        assertECEquals(name, jceDecodedSpec, nativeDecodedSpec);
+
+        // Included for coverage of ancillary method overloads
+        nativeEncodedParams = nativeAlgParams.getEncoded("ignored encoding method");
+        assertArrayEquals(nativeAlgParams.getEncoded(), nativeEncodedParams);
+        nativeDecodedParams = AlgorithmParameters.getInstance("EC", NATIVE_PROVIDER);
+        nativeDecodedParams.init(nativeEncodedParams, "ignored encoding method");
+        nativeDecodedSpec = nativeDecodedParams.getParameterSpec(ECParameterSpec.class);
+        assertECEquals(name, nativeAlgSpec, nativeDecodedSpec);
+    }
+
+    @Test
+    public void testInitBadParams() throws Exception {
+        AlgorithmParameters params = AlgorithmParameters.getInstance("EC", NATIVE_PROVIDER);
+
+        // AlgorithmParameters.init(AlgorithmParameterSpec)
+        TestUtil.assertThrows(InvalidParameterSpecException.class, () -> params.init((ECParameterSpec) null));
+        TestUtil.assertThrows(
+            InvalidParameterSpecException.class,
+            () -> params.init(new RSAKeyGenParameterSpec(0, BigInteger.ZERO))
+        );
+        TestUtil.assertThrows(  // invalid name/OID
+            IllegalArgumentException.class,
+            () -> params.init(new ECGenParameterSpec("lolNotACurve"))
+        );
+        TestUtil.assertThrows(  // valid OID for brainpoolP160r1, not on NIST standardization path
+            IllegalArgumentException.class,
+            () -> params.init(new ECGenParameterSpec("1.3.36.3.3.2.8.1.1.1"))
+        );
+
+        // AlgorithmParameters.init(byte[])
+        TestUtil.assertThrows(IOException.class, () -> params.init((byte[]) null));
+        TestUtil.assertThrows(IOException.class, () -> params.init(new byte[] {}));
+
+        // AlgorithmParameters.init(byte[], String)
+        TestUtil.assertThrows(IOException.class, () -> params.init((byte[]) null, "unused"));
+    }
+}

--- a/tst/com/amazon/corretto/crypto/provider/test/SecurityPropertyTester.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/SecurityPropertyTester.java
@@ -5,7 +5,9 @@ package com.amazon.corretto.crypto.provider.test;
 
 import static com.amazon.corretto.crypto.provider.test.TestUtil.NATIVE_PROVIDER;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
+import java.security.AlgorithmParameters;
 import java.security.KeyPairGenerator;
 import java.security.Provider;
 import java.security.SecureRandom;
@@ -31,6 +33,9 @@ public final class SecurityPropertyTester {
 
     // Ensure that TLS works as expected
     SSLContext.getInstance("TLS"); // Throws exception on problem
+
+    // Ensure that ACCP isn't configured to provide EC parameters by defualt
+    assertNotEquals(NATIVE_PROVIDER.getName(), AlgorithmParameters.getInstance("EC").getProvider().getName());
 
     // We know that Java has the SunEC provider which can generate EC keys.
     // We try to grab it to show that the nothing interfered with proper provider loading.

--- a/tst/com/amazon/corretto/crypto/provider/test/TestUtil.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/TestUtil.java
@@ -41,6 +41,44 @@ public class TestUtil {
     public static final String NATIVE_PROVIDER_PACKAGE =
         NATIVE_PROVIDER.getClass().getName().substring(0, NATIVE_PROVIDER.getClass().getName().lastIndexOf("."));
 
+    public static final String[][] KNOWN_CURVES = new String[][] {
+            new String[]{"secp256r1", "NIST P-256", "X9.62 prime256v1", /* "prime256v1", */ "1.2.840.10045.3.1.7"},
+            new String[]{"secp384r1", "NIST P-384", "1.3.132.0.34"},
+            new String[]{"secp521r1", "NIST P-521", "1.3.132.0.35"},
+            };
+
+    // Not supported in JDK17
+    public static final String[][] LEGACY_CURVES = new String[][] {
+            // Prime Curves
+            new String[]{"secp224r1", "NIST P-224", "1.3.132.0.33"},
+            new String[]{"secp256k1", "1.3.132.0.10"},
+            };
+
+    public static String getCurveOid(String nameOrOid) {
+        if (nameOrOid == null) {
+            return null;
+        }
+        switch(nameOrOid) {
+            case "secp224r1":
+                return "1.3.132.0.33";
+            case "prime256v1":
+            case "secp256r1":
+                return "1.2.840.10045.3.1.7";
+            case "secp256k1":
+                return "1.3.132.0.10";
+            case "secp384r1":
+                return "1.3.132.0.34";
+            case "secp521r1":
+                return "1.3.132.0.35";
+            default:
+                return nameOrOid;    // if no known curve was specified, assume it's an OID
+        }
+    }
+
+    public static boolean isOid(String name) {
+        return name.matches("^[\\d\\.]+$");
+    }
+
     /**
      * Thread local instances of SecureRandom with no further guarantees about implementation or security.
      *

--- a/tst/com/amazon/corretto/crypto/provider/test/UtilsTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/UtilsTest.java
@@ -3,6 +3,7 @@
 
 package com.amazon.corretto.crypto.provider.test;
 
+import static com.amazon.corretto.crypto.provider.test.TestUtil.sneakyGetField;
 import static com.amazon.corretto.crypto.provider.test.TestUtil.sneakyInvoke;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -178,13 +179,18 @@ public class UtilsTest {
 
     @Test
     public void givenInvalidValueForCacheSelfTestResultsProperty_whenGetCacheSelfTestResultsProperty_expectTrue() throws Throwable {
-        System.setProperty("com.amazon.corretto.crypto.provider.cacheselftestresults", "dummy");
-        assertTrue((Boolean) sneakyInvoke(UTILS_CLASS, "getCacheSelfTestResultsProperty"));
+        final String propertyName = (String) sneakyGetField(AmazonCorrettoCryptoProvider.class, "PROPERTY_CACHE_SELF_TEST_RESULTS");
+        assertNotNull(propertyName);
+        System.setProperty("com.amazon.corretto.crypto.provider." + propertyName, "dummy");
+        assertTrue((Boolean) sneakyInvoke(UTILS_CLASS, "getBooleanProperty", propertyName, true));
     }
 
     @Test
     public void givenFalseForCacheSelfTestResultsProperty_whenGetCacheSelfTestResultsProperty_expectFalse() throws Throwable {
-        System.setProperty("com.amazon.corretto.crypto.provider.cacheselftestresults", "False");
-        assertFalse((Boolean) sneakyInvoke(UTILS_CLASS, "getCacheSelfTestResultsProperty"));
+        final String propertyName = (String) sneakyGetField(AmazonCorrettoCryptoProvider.class, "PROPERTY_CACHE_SELF_TEST_RESULTS");
+        assertNotNull(propertyName);
+        System.setProperty("com.amazon.corretto.crypto.provider." + propertyName, "False");
+        assertFalse((Boolean) sneakyInvoke(UTILS_CLASS, "getBooleanProperty",
+                    sneakyGetField(AmazonCorrettoCryptoProvider.class, "PROPERTY_CACHE_SELF_TEST_RESULTS"), true));
     }
 }

--- a/tst/com/amazon/corretto/crypto/provider/test/integration/LocalHTTPSIntegrationTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/integration/LocalHTTPSIntegrationTest.java
@@ -150,7 +150,7 @@ public class LocalHTTPSIntegrationTest {
             fail("Server died");
         }
 
-        Security.insertProviderAt(AmazonCorrettoCryptoProvider.INSTANCE, 1);
+        AmazonCorrettoCryptoProvider.install();
 
         Cipher c = Cipher.getInstance("AES/GCM/NoPadding");
         assertEquals(AmazonCorrettoCryptoProvider.INSTANCE, c.getProvider());

--- a/tst/com/amazon/corretto/crypto/provider/test/integration/TestHTTPSServer.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/integration/TestHTTPSServer.java
@@ -261,6 +261,12 @@ public class TestHTTPSServer {
         javaInvocation.add("-cp");
         javaInvocation.add(classpathString.toString());
         javaInvocation.add("-Djava.library.path=" + System.getProperty("java.library.path"));
+        // NOTE: the below debug parameter is useful when debugging server-side
+        //       issues that occur before the TLS handshake has completed (e.g.
+        //       certificate signature mismatches) and test log utilitiess at
+        //       the HTTPS level are available.
+        //
+        //       javaInvocation.add("-Djavax.net.debug=all");
         javaInvocation.addAll(Arrays.asList(args));
 
         return Runtime.getRuntime().exec(javaInvocation.toArray(new String[0]));


### PR DESCRIPTION
*Issue #, if available:* i/CryptoAlg-1413

*Description of changes:*

---

## Implement AlgorithmParameters for EC

This commit registers support for EC AlgorithmParameters with the JCA,
in an effort to get ACCP closer to functioning as a stand-alone
providers. At startup (i.e. `static` initialization time), we query
AWS-LC for which curves are avaialable at startup and cache the relevant
information in order to avoid redundant JNI calls fetching the same,
invariant information.

For some tests to function with correctly with the new
AlgorithmParameters on Java17+, we need to add the sun.security.util
package (internal to JDK, not exported outside of the java.base module)
to the list of specified "opens", allowing for deep reflection.  We
attempt reflection in some cases across java versions because JCE will
sometimes pass `ECKeySizeParameterSpec` instances to
`AlgorithmParameters.init`, but `ECKeySizeParameterSpec` is not a public
class in JDK8 or exported within a module in JDK11+. So, as a "best
effort", we try to handle this using reflection to extract the key size,
which must be explicitly allowed for JDK-internal classes/modules in
Java17+. It's not an ideal, but is an unfortunate reality of the JDK's
module configuration and interface limitations.

I confirmed that the new EcParameters class has full coverage, save for
a few exception-throwing cases that are difficult to trigger due to
current inability to mock our JNI/AWS-LC layer.

---

## Make ACCP-vended EC AlgorithmParameters opt-in

This commit makes ACCP-provided EC paramter not only optional, but
opt-in. The reason for this is somewhat complex, but is fundamentally
due to later JDK versions' addition of the module system and default
tightening of access to JDK-internal classes via reflection.

In testing with JDK17, I started to notice this odd exception:

```
Exception in thread "main" java.security.NoSuchAlgorithmException: Error constructing KeyPairGenerator for EC using SunEC
        at jdk.crypto.ec/sun.security.ec.SunEC$ProviderService.newInstance(SunEC.java:181)
        at java.base/sun.security.jca.GetInstance.getInstance(GetInstance.java:236)
        at java.base/sun.security.jca.GetInstance.getInstance(GetInstance.java:206)
        at java.base/java.security.KeyPairGenerator.getInstance(KeyPairGenerator.java:300)
        at com.amazon.corretto.crypto.provider.test.SecurityPropertyTester.main(SecurityPropertyTester.java:43)
Caused by: java.security.InvalidParameterException: No EC parameters available for key size 256 bits
        at jdk.crypto.ec/sun.security.ec.ECKeyPairGenerator.initialize(ECKeyPairGenerator.java:81)
        at jdk.crypto.ec/sun.security.ec.ECKeyPairGenerator.<init>(ECKeyPairGenerator.java:71)
        at jdk.crypto.ec/sun.security.ec.SunEC$ProviderService.newInstance(SunEC.java:155)
        ... 4 more
```

The issue, as alluded to in the prior commit message, is that SunEC will
pass a `ECKeySizeParameterSpec` instance into `AlgorithmParameters.init`
and thus our EC parameters implementation needs to handle that class.
Unfortunately, `ECKeySizeParameterSpec` is a JDK-internal class and is
not exported by its module configuration. We work around this for JDK11
by using reflection to access the key size parameter, but JDK17
restricts the relevant reflection permissions by default. See [these
docs][1].

The upshot for us is that in order for ACCP to play nicely with JDK17,
users would need to include this flag to their JDK invocations:

```
--add-opens java.base/sun.security.util=ALL-UNNAMED
```

This permissions expansion to application code may be either onerous or
impermissible for customers, so we're making the EC parameters feature
opt-in for now. It should only be used by customers wishing to use ACCP
as a standalone provider that doesn't need to interface with
JCE/Java-internal cryptography.

[1]: https://docs.oracle.com/en/java/javase/18/migrate/migrating-jdk-8-later-jdk-releases.html#GUID-12F945EB-71D6-46AF-8C3D-D354FD0B1781

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
