### PR TITLE
Include AWS-LC's self tests in ACCP's self tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -263,6 +263,7 @@ add_library(
         csrc/testhooks.cpp
         csrc/util.cpp
         csrc/util_class.cpp
+        csrc/fips_kat_self_test.cpp
         ${JNI_HEADER_DIR}/generated-headers.h
 )
 

--- a/csrc/fips_kat_self_test.cpp
+++ b/csrc/fips_kat_self_test.cpp
@@ -1,0 +1,8 @@
+#include <jni.h>
+#include <openssl/crypto.h>
+
+
+extern "C" JNIEXPORT jboolean JNICALL Java_com_amazon_corretto_crypto_provider_SelfTestSuite_awsLcSelfTestsPassed(JNIEnv*, jclass)
+{
+    return BORINGSSL_self_test() == 1 ? JNI_TRUE : JNI_FALSE;
+}

--- a/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
+++ b/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
@@ -336,12 +336,15 @@ public final class AmazonCorrettoCryptoProvider extends java.security.Provider {
             return;
         }
 
+        // The order of adding determines the order of failure reporting and test execution. We do not short circuit
+        // the execution of tests when a test fails.
+        selfTestSuite.addSelfTest(SelfTestSuite.AWS_LC_SELF_TESTS);
+        selfTestSuite.addSelfTest(LibCryptoRng.SPI.SELF_TEST);
         selfTestSuite.addSelfTest(EvpHmac.SHA512.SELF_TEST);
         selfTestSuite.addSelfTest(EvpHmac.SHA384.SELF_TEST);
         selfTestSuite.addSelfTest(EvpHmac.SHA256.SELF_TEST);
         selfTestSuite.addSelfTest(EvpHmac.SHA1.SELF_TEST);
         selfTestSuite.addSelfTest(EvpHmac.MD5.SELF_TEST);
-        selfTestSuite.addSelfTest(LibCryptoRng.SPI.SELF_TEST);
 
         // Kick off self-tests in the background. It's vitally important that we don't actually _wait_ for these to
         // complete, as if we do we'll end up recursing through some JCE internals back to attempts to use
@@ -422,19 +425,24 @@ public final class AmazonCorrettoCryptoProvider extends java.security.Provider {
         if (Loader.LOADING_ERROR != null) {
             throw new RuntimeCryptoException("Unable to load native library", Loader.LOADING_ERROR);
         }
+
+        if (!relyOnCachedSelfTestResults) {
+            resetAllSelfTests();
+        }
+
         selfTestSuite.assertAllTestsPassed();
     }
 
     /**
-     * Returns {@code true} if and only if the underlying libcrypto library is a FIPS build.
+     * Returns {@code true} if and only if the underlying libcrypto library is a FIPS build and passes FIPS KAT self tests
      */
     public boolean isFips() {
-        return Loader.FIPS_BUILD;
+        return Loader.FIPS_BUILD && SelfTestSuite.awsLcSelfTestsPassed();
     }
 
     /**
      * Register ACCP's EC-flavored AlgorithmParameters implementation
-     *
+     * <p>
      * Most use-cases can and should rely on JCE-provided EC AlgorithmParameters
      * implementation as it supports more curves, is more broadly compatible,
      * and does not affect FIPS compliance posture as the EC parameters wrapper

--- a/src/com/amazon/corretto/crypto/provider/LibCryptoRng.java
+++ b/src/com/amazon/corretto/crypto/provider/LibCryptoRng.java
@@ -37,10 +37,10 @@ class LibCryptoRng extends SecureRandom {
             final long initialLong = rnd.nextLong();
             for (int trial = 0; trial < 3; trial++) {
                 if (initialLong != rnd.nextLong()) {
-                    return new SelfTestResult(SelfTestStatus.PASSED);
+                    return SelfTestResult.PASS_RESULT;
                 }
             }
-            return new SelfTestResult(SelfTestStatus.FAILED);
+            return new SelfTestResult(new AssertionError("LibCryptoRng's self tests failed."));
         }
 
         SPI() {

--- a/src/com/amazon/corretto/crypto/provider/SelfTestResult.java
+++ b/src/com/amazon/corretto/crypto/provider/SelfTestResult.java
@@ -9,6 +9,8 @@ public class SelfTestResult {
     private final SelfTestStatus status;
     private final Throwable throwable;
 
+    public static SelfTestResult PASS_RESULT = new SelfTestResult(SelfTestStatus.PASSED);
+
     public SelfTestStatus getStatus() {
         return status;
     }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Include AWS-LC's self tests in ACCP's self tests.
* Modify `assertHealthy` to re-run tests in case it should not rely on cached results
* Perform AWS-LC's KAT FIPS tests as part of `isFips` API too.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
