### PR TITLE
Provide isFipsStatusOk API to check if FIPS tests have passed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -264,6 +264,7 @@ add_library(
         csrc/util.cpp
         csrc/util_class.cpp
         csrc/fips_kat_self_test.cpp
+        csrc/fips_status.cpp
         ${JNI_HEADER_DIR}/generated-headers.h
 )
 
@@ -462,7 +463,7 @@ if(NOT ENABLE_NATIVE_TEST_HOOKS)
     CHECK_LINKER_FLAG_SUPPORT(USE_VERSION_SCRIPT "-Wl,--version-script -Wl,${CMAKE_CURRENT_SOURCE_DIR}/final-link.version")
 
 # This does the same thing as the version script, but works on Darwin platforms
-    CHECK_LINKER_FLAG_SUPPORT(USE_EXPORTED_SYMBOL "-Wl,-exported_symbol '-Wl,_Java_*' -Wl,-exported_symbol '-Wl,_JNI_*'")
+    CHECK_LINKER_FLAG_SUPPORT(USE_EXPORTED_SYMBOL "-Wl,-exported_symbol '-Wl,_Java_*' '-Wl,_AWS_LC_fips_failure_callback' -Wl,-exported_symbol '-Wl,_JNI_*'")
 endif()
 
 # Attempt to drop unused sections; the idea here is to exclude unreferenced
@@ -640,6 +641,7 @@ add_custom_target(check-junit
         --select-package=com.amazon.corretto.crypto.provider.test
         --exclude-package=com.amazon.corretto.crypto.provider.test.integration
         --exclude-classname=com.amazon.corretto.crypto.provider.test.SecurityManagerTest
+        --exclude-classname=com.amazon.corretto.crypto.provider.test.FipsStatusTest
 
     DEPENDS accp-jar tests-jar)
 
@@ -661,6 +663,15 @@ add_custom_target(check-junit-SecurityManager
 
     DEPENDS accp-jar tests-jar)
 
+add_custom_target(check-junit-FipsStatus
+    COMMAND ${TEST_JAVA_EXECUTABLE}
+        ${TEST_RUNNER_ARGUMENTS}
+        --select-class=com.amazon.corretto.crypto.provider.test.AesTest # Force loading ciphers
+        --select-class=com.amazon.corretto.crypto.provider.test.SHA1Test # Force loading digests
+        --select-class=com.amazon.corretto.crypto.provider.test.FipsStatusTest
+
+    DEPENDS accp-jar tests-jar)
+
 add_custom_target(check-junit-extra-checks
     COMMAND ${TEST_JAVA_EXECUTABLE}
         -Dcom.amazon.corretto.crypto.provider.extrachecks=ALL
@@ -668,6 +679,7 @@ add_custom_target(check-junit-extra-checks
         ${TEST_RUNNER_ARGUMENTS}
         --select-package=com.amazon.corretto.crypto.provider.test
         --exclude-package=com.amazon.corretto.crypto.provider.test.integration
+        --exclude-classname=com.amazon.corretto.crypto.provider.test.FipsStatusTest
         --exclude-classname=com.amazon.corretto.crypto.provider.test.SecurityManagerTest
 
     DEPENDS accp-jar tests-jar)
@@ -753,7 +765,7 @@ add_custom_target(check-install-via-properties-with-debug
     DEPENDS accp-jar tests-jar)
 
 add_custom_target(check
-    DEPENDS check-recursive-init check-install-via-properties check-install-via-properties-with-debug check-junit check-junit-SecurityManager check-external-lib check-libaccp-rpath)
+    DEPENDS check-recursive-init check-install-via-properties check-install-via-properties-with-debug check-junit check-junit-SecurityManager check-external-lib check-libaccp-rpath check-junit-FipsStatus)
 
 add_custom_target(checkstyle
     WORKING_DIRECTORY ${ORIG_SRCROOT}

--- a/csrc/atomic_bool.h
+++ b/csrc/atomic_bool.h
@@ -1,0 +1,90 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef ATOMIC_BOOL_H
+#define ATOMIC_BOOL_H
+
+#include "compiler.h"
+
+#ifdef HAVE_CPP11
+#include <atomic>
+#else
+// For pre-C++11, we use pthread_mutex to sync access to the AtomicBool
+#include <cstdlib>
+#include <cstdio>
+#include <pthread.h>
+#endif
+
+
+namespace AmazonCorrettoCryptoProvider {
+
+#ifdef HAVE_CPP11
+
+using AtomicBool = std::atomic<bool>;
+
+#else
+
+// If lock/unlock failes, we still proceed
+// Since we are using the default value when initializing the mutex, these failures should not happen.
+class UniquePthreadMutexLock {
+public:
+
+    UniquePthreadMutexLock(pthread_mutex_t* mutex): mutex_(mutex) {
+        int status = pthread_mutex_lock(mutex_);
+        if (status != 0) {
+            fprintf(stderr, "pthread_mutex_lock failed with error %d", status);
+        }
+    }
+
+    ~UniquePthreadMutexLock() {
+        int status = pthread_mutex_unlock(mutex_);
+        if (status != 0) {
+            fprintf(stderr, "pthread_mutex_unlock failed with error %d", status);
+        }
+    }
+
+private:
+    pthread_mutex_t* mutex_;
+};
+
+class AtomicBool {
+public:
+
+    AtomicBool(bool initial_value): value_(initial_value) {
+        int status = pthread_mutex_init(&value_mutex_, nullptr);
+        if (status != 0) {
+            // let's exit if we can't even initalize a mutex :(
+            fprintf(stderr, "failed to initialize the mutex; pthread_mutex_init failed with error code %d", status);
+            exit(EXIT_FAILURE);
+        }
+    }
+
+    ~AtomicBool() {
+        pthread_mutex_destroy(&value_mutex_);
+    }
+
+    bool load() {
+        UniquePthreadMutexLock lock(&value_mutex_);
+        return value_;
+    }
+
+    void store(bool value) {
+        UniquePthreadMutexLock lock(&value_mutex_);
+        value_ = value;
+    }
+
+private:
+    bool            value_;
+    pthread_mutex_t value_mutex_; // used to sync access to value_
+
+    // Disabling default constructors
+    AtomicBool();
+    AtomicBool(AtomicBool const&);
+    AtomicBool& operator=(AtomicBool const&);
+};
+
+#endif
+
+} // namespace AmazonCorrettoCryptoProvider
+
+#endif // ATOMIC_BOOL_H

--- a/csrc/fips_kat_self_test.cpp
+++ b/csrc/fips_kat_self_test.cpp
@@ -1,6 +1,8 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 #include <jni.h>
 #include <openssl/crypto.h>
-
 
 extern "C" JNIEXPORT jboolean JNICALL Java_com_amazon_corretto_crypto_provider_SelfTestSuite_awsLcSelfTestsPassed(JNIEnv*, jclass)
 {

--- a/csrc/fips_status.cpp
+++ b/csrc/fips_status.cpp
@@ -1,0 +1,30 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "atomic_bool.h"
+
+#include <jni.h>
+#include <cstdio>
+
+// To have this symbol exported, one needs to modify the final-link.version and the CMakeLists.txt
+extern "C" void AWS_LC_fips_failure_callback(char const* message);
+
+AmazonCorrettoCryptoProvider::AtomicBool g_is_fips_status_ok(true);
+
+void AWS_LC_fips_failure_callback(char const* message) {
+    fprintf(stderr, "AWS_LC_fips_failure_callback invoked with message: '%s'\n", message);
+    g_is_fips_status_ok.store(false);
+}
+
+extern "C" JNIEXPORT jboolean JNICALL Java_com_amazon_corretto_crypto_provider_AmazonCorrettoCryptoProvider_isFipsStatusOk(JNIEnv*, jobject) {
+    return g_is_fips_status_ok.load() ? JNI_TRUE : JNI_FALSE;
+}
+
+// The following methods are for testing purposes
+extern "C" JNIEXPORT void JNICALL Java_com_amazon_corretto_crypto_provider_test_NativeTestHooks_flipFipsStatus(JNIEnv*, jclass) {
+    g_is_fips_status_ok.store(!g_is_fips_status_ok.load());
+}
+
+extern "C" JNIEXPORT void JNICALL Java_com_amazon_corretto_crypto_provider_test_NativeTestHooks_callAwsLcFipsFailureCallback(JNIEnv*, jclass) {
+    AWS_LC_fips_failure_callback("called by a test");
+}

--- a/csrc/testhooks.cpp
+++ b/csrc/testhooks.cpp
@@ -5,7 +5,6 @@
 #include "env.h"
 #include "buffer.h"
 
-
 using namespace AmazonCorrettoCryptoProvider;
 
 JNIEXPORT void JNICALL Java_com_amazon_corretto_crypto_provider_test_NativeTestHooks_throwException

--- a/examples/break-tests/app/src/main/java/com/amazon/accp/breaktests/App.java
+++ b/examples/break-tests/app/src/main/java/com/amazon/accp/breaktests/App.java
@@ -2,6 +2,7 @@ package com.amazon.accp.breaktests;
 
 import com.amazon.corretto.crypto.provider.AmazonCorrettoCryptoProvider;
 
+import javax.crypto.KeyGenerator;
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.security.KeyPairGenerator;
@@ -28,11 +29,12 @@ public class App {
             System.out.println("BORINGSSL_FIPS_BREAK_TEST is set to " + boringsslFipsBreakTestEnvVar);
         } else {
             System.out.println("BORINGSSL_FIPS_BREAK_TEST is not defined");
+            return;
         }
 
         System.out.println("Checking if ACCP is installed properly. If not, we'll get an exception ...");
         p.assertHealthy();
-        System.out.println("Checking if ACCP FIPS is good ... " + p.isFips());
+        System.out.println("Checking if ACCP FIPS is good ... " + p.isFipsStatusOk());
 
         final KeyPairGenerator ecKpg = KeyPairGenerator.getInstance("EC", p);
         ecKpg.initialize(new ECGenParameterSpec("secp256r1"));
@@ -47,7 +49,7 @@ public class App {
         System.out.println("Using GDB to break tests ...");
         System.out.println("Checking if ACCP is installed properly. If not, we'll get an exception ...");
         p.assertHealthy();
-        System.out.println("Checking if ACCP FIPS is good ... " + p.isFips());
+        System.out.println("Checking if ACCP FIPS is good ... " + p.isFipsStatusOk());
         System.out.println("Now, use GDB and attach to this process...");
         System.out.println("The process id is " + ProcessHandle.current().pid());
         System.out.println("Use \'gdb -p " + ProcessHandle.current().pid() + "\' to attach to the process");
@@ -64,6 +66,12 @@ public class App {
         System.out.println("Once your done, press any key to continue ...");
         final BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
         br.readLine();
-        System.out.println("Checking if ACCP FIPS is still good ... " + p.isFips());
+        System.out.println("Checking if ACCP FIPS is still good ... " + p.isFipsStatusOk());
+        System.out.println("If we ask for anything, we should get an exception now ...");
+        try {
+            KeyGenerator.getInstance("AES", p);
+        } catch (final Exception ex) {
+            System.out.println("Got exception: " + ex.getMessage());
+        }
     }
 }

--- a/final-link.version
+++ b/final-link.version
@@ -1,6 +1,7 @@
 {
     global:
         Java_*;
+        AWS_LC_fips_failure_callback;
         JNI_*;
         hook_*;
     local:

--- a/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
+++ b/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
@@ -202,6 +202,10 @@ public final class AmazonCorrettoCryptoProvider extends java.security.Provider {
 
         @Override
         public Object newInstance(final Object constructorParameter) throws NoSuchAlgorithmException {
+            if (isFips() && !isFipsStatusOk()) {
+                throw new FipsStatusException("The provider is built in FIPS mode and its status is not Ok.");
+            }
+
             if (constructorParameter != null) {
                 // We do not currently support any algorithms that take ctor parameters.
                 throw new NoSuchAlgorithmException("Constructor parameters not used with "
@@ -434,11 +438,16 @@ public final class AmazonCorrettoCryptoProvider extends java.security.Provider {
     }
 
     /**
-     * Returns {@code true} if and only if the underlying libcrypto library is a FIPS build and passes FIPS KAT self tests
+     * Returns {@code true} if and only if the underlying libcrypto library is a FIPS build
      */
     public boolean isFips() {
-        return Loader.FIPS_BUILD && SelfTestSuite.awsLcSelfTestsPassed();
+        return Loader.FIPS_BUILD;
     }
+
+    /**
+     * @return true if and only if the underlying libcrypto library's FIPS related checks pass
+     */
+    public native boolean isFipsStatusOk();
 
     /**
      * Register ACCP's EC-flavored AlgorithmParameters implementation

--- a/src/com/amazon/corretto/crypto/provider/FipsStatusException.java
+++ b/src/com/amazon/corretto/crypto/provider/FipsStatusException.java
@@ -1,0 +1,11 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.amazon.corretto.crypto.provider;
+
+@SuppressWarnings("serial")
+public class FipsStatusException extends RuntimeCryptoException {
+    public FipsStatusException(final String message) {
+        super(message);
+    }
+}

--- a/tst/com/amazon/corretto/crypto/provider/test/FipsStatusTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/FipsStatusTest.java
@@ -1,0 +1,41 @@
+package com.amazon.corretto.crypto.provider.test;
+
+import com.amazon.corretto.crypto.provider.AmazonCorrettoCryptoProvider;
+import com.amazon.corretto.crypto.provider.FipsStatusException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
+
+import javax.crypto.KeyGenerator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@ExtendWith(TestResultLogger.class)
+@Execution(ExecutionMode.CONCURRENT)
+@ResourceLock(value = TestUtil.RESOURCE_GLOBAL, mode = ResourceAccessMode.READ)
+public class FipsStatusTest {
+
+    private final AmazonCorrettoCryptoProvider provider = AmazonCorrettoCryptoProvider.INSTANCE;
+
+    @Test
+    public void givenAccpBuiltWithFips_whenAWS_LC_fips_failure_callback_expectException() throws Exception {
+        if (provider.isFips()) {
+            assertTrue(provider.isFipsStatusOk());
+            assertNotNull(KeyGenerator.getInstance("AES", provider));
+            // call the failure callback
+            NativeTestHooks.callAwsLcFipsFailureCallback();
+            assertFalse(provider.isFipsStatusOk());
+            // we should not be able to get any service object
+            assertThrows(FipsStatusException.class, () -> KeyGenerator.getInstance("AES", provider));
+            // we need to flip the status back to OK so the rest of tests would work. In practice, once the flag is set to false, it remains false.
+            NativeTestHooks.flipFipsStatus();
+        }
+    }
+}

--- a/tst/com/amazon/corretto/crypto/provider/test/NativeTestHooks.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/NativeTestHooks.java
@@ -16,6 +16,8 @@ public class NativeTestHooks {
     // generally safe to call.
 
     public static native void throwException();
+    public static native void callAwsLcFipsFailureCallback();
+    public static native void flipFipsStatus();
     public static native void getBytes(byte[] array, int offset, int length, int off2, int len2);
     public static native void putBytes(byte[] array, int offset, int length, int off2, int len2);
     public static native void getBytesLocked(byte[] array, int offset, int length, int off2, int len2);


### PR DESCRIPTION
*Description of changes:*

* `AWS_LC_fips_failure_callback` is a method invoked by AWS-LC in case a FIPS related check fails
* ACCP updates a global flag to false in case this callback is invoked
* The value of the global flag is returned as the result of `isFipsStatusOk`
* ACCP built in FIPS mode checks `isFipsStatusOk` whenever a crypto service is requested

*Testing*

*  Used break-tests from examples, and did the following:
  * `./gradlew clean -DALLOW_FIPS_TEST_BREAK=true -DFIPS=true build`
  * `cd examples/break-tests`
  *  ` BORINGSSL_FIPS_BREAK_TEST=CRNG ./gradlew run`
  * The output shows that AWS-LC invokes the provided callback in case a FIPS related check fails.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
