### PR TITLE
Only register LibCryptoRng by default in non-FIPS mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -601,6 +601,9 @@ set(COVERAGE_ARGUMENTS
 
 if(FIPS)
     set(TEST_FIPS_PROPERTY "-DFIPS=true")
+    # ACCP's default behavior in FIPS mode is to not register a SecureRandom implementation.
+    # However, we explicitly register it here to ensure its coverage under test.
+    set(REGISTER_RNG_PROPERTY "-Dcom.amazon.corretto.crypto.provider.registerSecureRandom=true")
 else()
     set(TEST_FIPS_PROPERTY "-DFIPS=false")
 endif()
@@ -614,6 +617,7 @@ set(TEST_RUNNER_ARGUMENTS
     ${TEST_ADD_OPENS}
     ${TEST_FIPS_PROPERTY}
     ${EXTERNAL_LIB_PROPERTY}
+    ${REGISTER_RNG_PROPERTY}
     -Dcom.amazon.corretto.crypto.provider.inTestSuite=hunter2
     -Dtest.data.dir=${TEST_DATA_DIR}
     -Djunit.jupiter.execution.parallel.enabled=true
@@ -811,6 +815,7 @@ if (CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
 add_custom_target(run-dieharder-libcrypto-rng
     COMMAND ${TEST_JAVA_EXECUTABLE} -cp $<TARGET_PROPERTY:accp-jar,JAR_FILE>:$<TARGET_PROPERTY:tests-jar,JAR_FILE>:${TEST_CLASSPATH}
         ${EXTERNAL_LIB_PROPERTY}
+        ${REGISTER_RNG_PROPERTY}
         com.amazon.corretto.crypto.provider.test.SecureRandomGenerator 'LibCryptoRng' 8192 1 |
         ${DIEHARDER_EXECUTABLE} -a -g 200 -Y 1 -k 2 |
         tee dieharder-results-libcrypto-rng.txt
@@ -820,6 +825,7 @@ add_custom_target(run-dieharder-libcrypto-rng
 add_custom_target(run-dieharder-libcrypto-rng-tail
     COMMAND ${TEST_JAVA_EXECUTABLE} -cp $<TARGET_PROPERTY:accp-jar,JAR_FILE>:$<TARGET_PROPERTY:tests-jar,JAR_FILE>:${TEST_CLASSPATH}
         ${EXTERNAL_LIB_PROPERTY}
+        ${REGISTER_RNG_PROPERTY}
         com.amazon.corretto.crypto.provider.test.SecureRandomGenerator 'LibCryptoRng' 31 1 |
         ${DIEHARDER_EXECUTABLE} -d 15 -g 200 -Y 1 -k 2 |
         tee dieharder-results-libcrypto-rng-tail.txt
@@ -829,6 +835,7 @@ add_custom_target(run-dieharder-libcrypto-rng-tail
 add_custom_target(run-dieharder-libcrypto-rng-threads
     COMMAND ${TEST_JAVA_EXECUTABLE} -cp $<TARGET_PROPERTY:accp-jar,JAR_FILE>:$<TARGET_PROPERTY:tests-jar,JAR_FILE>:${TEST_CLASSPATH}
         ${EXTERNAL_LIB_PROPERTY}
+        ${REGISTER_RNG_PROPERTY}
         com.amazon.corretto.crypto.provider.test.SecureRandomGenerator 'LibCryptoRng' 128 4 |
         ${DIEHARDER_EXECUTABLE} -a -g 200 -Y 1 -k 2 |
         tee dieharder-results-libcrypto-rng-threads.txt
@@ -838,6 +845,7 @@ add_custom_target(run-dieharder-libcrypto-rng-threads
 add_custom_target(run-dieharder-libcrypto-rng-threads-tail
     COMMAND ${TEST_JAVA_EXECUTABLE} -cp $<TARGET_PROPERTY:accp-jar,JAR_FILE>:$<TARGET_PROPERTY:tests-jar,JAR_FILE>:${TEST_CLASSPATH}
         ${EXTERNAL_LIB_PROPERTY}
+        ${REGISTER_RNG_PROPERTY}
         com.amazon.corretto.crypto.provider.test.SecureRandomGenerator 'LibCryptoRng' 31 4 |
         ${DIEHARDER_EXECUTABLE} -d 15 -g 200 -Y 1 -k 2 |
         tee dieharder-results-libcrypto-rng-threads-tail.txt

--- a/README.md
+++ b/README.md
@@ -174,6 +174,10 @@ Building this provider requires a 64 bit Linux or MacOS build system with the fo
 By providing `-DFIPS=true` to `gradlew` you will cause the entire build to be for a "FIPS mode" build.
 The only significant difference is that AWS-LC is built with `FIPS=1`.
 
+For performance reasons, ACCP does not register a SecureRandom implementation in FIPS mode.
+Relevant operations within the FIPS module boundary (e.g. key generation, non-deterministic signing, etc.) will still use AWS-LC's internal DRBG.
+Users who require ACCP to provide FIPS-validated pseudo-randomness _outside_ the module boundary via SecureRandom should set `registerSecureRandom=true`.
+
 When changing between FIPS and non-FIPS builds, be sure to do a full `clean` of your build environment.
 
 ##### All targets
@@ -268,6 +272,14 @@ Thus, these should all be set on the JVM command line using `-D`.
   Else, the JCA will get the implementation from another registered provider (usually stock JCE).
   Using JCE's impelmentation is generally recommended unless using ACCP as a standalone provider
   Callers can choose to register ACCP's implementation at runtime with a call to `AmazonCorrettoCryptoProvider.registerEcParams()`
+* `com.amazon.corretto.crypto.provider.registerSecureRandom`
+  Takes in `true` or `false` (defaults to `false` in FIPS mode, defaults to `true` in non-FIPS).
+  If `true`, then ACCP will register a SecureRandom implementation (`LibCryptoRng`) backed by AWS-LC
+  Else, ACCP will not register a SecureRandom implementation, meaning that the JCA will source SecureRandom instances from another registered provider. AWS-LC will still use its internal DRBG for key generation and other operations requiring secure pseudo-randomness.
+  LibCryptoRng is very fast during steady state operation in all cases. In FIPS mode, however, AWS-LC-FIPS's CPU jitter-based entropy source incurs a ~10ms initialization cost for every new thread.
+  This means that there is a slight "pause" before ACCP FIPS's SecureRandom can produce pseudo-random bytes in highly threaded environments.
+  Because, in extreme cases this could present an availability risk, we do not register LibCryptoRng by default in configurations where this initialization cost is incurred (i.e. FIPS mode).
+  Non-FIPS AWS-LC does not use CPU jitter for its DRBG seed's entropy, and therefore does not incur this initialization cost, therefore we register LibCryptoRng by default when not in FIPS mode.
 
 
 # License

--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ jmh {
     jvmArgs = [
         "-Djava.library.path=${rootDir}/build/cmake:" + System.getProperty("java.library.path"),
         "-DversionStr=${version}",
+        "-Dcom.amazon.corretto.crypto.provider.registerSecureRandom=true",
     ]
 
     sourceSets {

--- a/src/jmh/java/com/amazon/corretto/crypto/provider/Drbg.java
+++ b/src/jmh/java/com/amazon/corretto/crypto/provider/Drbg.java
@@ -57,5 +57,17 @@ public class Drbg {
         random.nextBytes(data);
         return data;
     }
-}
 
+    @Benchmark
+    @Threads(1)
+    public byte[] newThreadPerRequest() throws InterruptedException {
+        Thread t = new Thread() {
+            public void run() {
+                random.nextBytes(data);
+            }
+        };
+        t.start();
+        t.join();
+        return data;
+    }
+}

--- a/tst/com/amazon/corretto/crypto/provider/test/SecurityPropertyTester.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/SecurityPropertyTester.java
@@ -19,7 +19,8 @@ import javax.net.ssl.SSLContext;
 
 /**
  * This is a special stand-alone test case which asserts that AmazonCorrettoCryptoProvider is installed
- * as the highest priority provider and is functional.
+ * as the highest priority provider, has expected default behavior (the unit test suite is not
+ * necessarily configured with ACCP's defaults), and is functional.
  */
 public final class SecurityPropertyTester {
   public static void main(String[] args) throws Exception {
@@ -42,10 +43,16 @@ public final class SecurityPropertyTester {
     @SuppressWarnings("unused")
     KeyPairGenerator kpg = KeyPairGenerator.getInstance("EC", "SunEC");
 
-    // Ensure we properly configured ourselves as "strong" instance of SecureRandom
+    // Ensure that FIPS mode determines default behavior for registering SecureRandom and "strong" random
     // Applications should never use getInstanceStrong as it is an anti-pattern.
     final SecureRandom strongRng = SecureRandom.getInstanceStrong();
-    assertEquals(NATIVE_PROVIDER.getName(), strongRng.getProvider().getName());
+    if (NATIVE_PROVIDER.isFips()) {
+        assertNotEquals(NATIVE_PROVIDER.getName(), new SecureRandom().getProvider().getName());
+        assertNotEquals(NATIVE_PROVIDER.getName(), strongRng.getProvider().getName());
+    } else {
+        assertEquals(NATIVE_PROVIDER.getName(), new SecureRandom().getProvider().getName());
+        assertEquals(NATIVE_PROVIDER.getName(), strongRng.getProvider().getName());
+    }
 
     // Also ensure that nothing shows up twice
     Set<String> names = new HashSet<>();


### PR DESCRIPTION
*Issue #, if available:* t/P82298726

*Description of changes:*

# Notes

See the updated README for this option's motivation.

Unlike `registerEcParams`, we only provide this option as a JVM property
and not as a runtime method call. The reason for this is that the JCA
treats SecureRandomly differently from other algorithms, maintining
provider registry state across both [SecureRandom][1] and [Provider][2]
classes. This significantly complicates registering SecureRandom
implementations post-initialization for a given provider (e.g. ACCP)
after instances of SecureRandom have already been generated from a
different provider (e.g. SUN). So, for now, we only expose this option
as a JVM property set at process start.

[1]: https://github.com/corretto/corretto-11/blob/1fee80d48d98e91a6a7ad1ca24220ccc7c148ef3/src/java.base/share/classes/java/security/SecureRandom.java#L274
[2]: https://github.com/corretto/corretto-11/blob/1fee80d48d98e91a6a7ad1ca24220ccc7c148ef3/src/java.base/share/classes/java/security/Provider.java#L1411

# Benchmarking

The new benchmark (`newThreadPerRequest`) clearly demonstrates that
the performance cost of per-thread jitter initialization.

```diff
$ git diff
diff --git a/build.gradle b/build.gradle
index 1ba8ea9..e88f633 100644
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ ext.isFips = Boolean.getBoolean('FIPS')
 ext.isLegacyBuild = Boolean.getBoolean('LEGACY_BUILD')

 jmh {
+    includes = ['Drbg']
     fork = 1
     benchmarkMode = ['thrpt']
     threads = 1
@@ -385,7 +386,6 @@ task unit_tests(type: Copy) {
     from "${buildDir}/cmake/unit-tests/"
     into "${buildDir}/reports/unit-tests"
 }
-test.dependsOn unit_tests

 task checkstyle(type: Exec) {
     dependsOn executeCmake

$ ./gradlew -DFIPS=true clean jmh jmhReport
...
Benchmark                                   (provider)  (size)   Mode  Cnt       Score        Error  Units
Drbg.multiThreaded        AmazonCorrettoCryptoProvider    1024  thrpt    5  746237.847 _ 115563.930  ops/s
Drbg.multiThreaded                                  BC    1024  thrpt    5   35516.850 _    283.508  ops/s
Drbg.multiThreaded                                 SUN    1024  thrpt    5  100245.322 _   3642.675  ops/s
Drbg.newThreadPerRequest  AmazonCorrettoCryptoProvider    1024  thrpt    5      30.888 _      0.779  ops/s
Drbg.newThreadPerRequest                            BC    1024  thrpt    5    9296.259 _   1265.277  ops/s
Drbg.newThreadPerRequest                           SUN    1024  thrpt    5   11473.685 _   1121.174  ops/s
Drbg.singleThreaded       AmazonCorrettoCryptoProvider    1024  thrpt    5  761595.931 _   4866.979  ops/s
Drbg.singleThreaded                                 BC    1024  thrpt    5   35317.928 _    996.175  ops/s
Drbg.singleThreaded                                SUN    1024  thrpt    5   99673.483 _   1124.420  ops/s
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
