### PR TITLE
Build OpenSSL w/ 64-bit ECC optimizations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -104,7 +104,7 @@ task buildOpenSsl {
             args 'no-autoload-config', 'no-capieng', 'no-cms', 'no-comp', 'no-ct', 'no-dgram', 'no-devcryptoeng'
             args 'no-gost', 'no-hw-padlock', 'no-nextprotoneg', 'no-ocsp', 'no-psk', 'no-rfc3779', 'no-shared'
             args 'no-sock', 'no-srp', 'no-srtp', 'threads', 'no-ts',  "no-bf", "no-cast", "no-md2", "no-rc2"
-            args "no-rc4", "no-rc5", "no-srp", 'no-comp', 'no-hw', 'no-mdc2'
+            args "no-rc4", "no-rc5", "no-srp", 'no-comp', 'no-hw', 'no-mdc2', 'enable-ec_nistp_64_gcc_128'
         }
         exec {
             workingDir opensslSrcPath


### PR DESCRIPTION
# Notes

**THIS PR IS FOR ACCP 1.x ONLY **

From OpenSSL's [news page for 1.1.1][1]:

>  *) Add optional 64-bit optimized implementations of elliptic curves NIST-P224,
>     NIST-P256, NIST-P521, with constant-time single point multiplication on
>     typical inputs. Compiler support for the nonstandard type __uint128_t is
>     required to use this (present in gcc 4.4 and later, for 64-bit builds).
>     Code made available under Apache License version 2.0.

[1]: https://www.openssl.org/news/cl111.txt

These optimizations provide substantial improvement in secp512r1 performance across the board. In the benchmarks below (all run on a Graviton 3 c7g.large), ACCP 1.6 w/o the `enable-ec_nistp_64_gcc_128` build flag are on the left, while benchmarks on the right have the flag set.

![Screenshot 2023-04-25 at 1 10 22 PM](https://user-images.githubusercontent.com/3589880/234389696-43debc26-1c05-407a-98f0-cd3f7d8ac9cf.png)
![Screenshot 2023-04-25 at 1 10 07 PM](https://user-images.githubusercontent.com/3589880/234389660-a36b5d91-a51d-4b17-8358-4d7211d58b75.png)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
