### PR TITLE
Update Mac CI workflows to use latest Mac runner

### DIFF
--- a/.github/workflows/macos_ci.yml
+++ b/.github/workflows/macos_ci.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   # Job to run regular ACCP tests on MacOS.
   macOS:
-    runs-on: macos-11 # latest
+    runs-on: macos-latest
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/macos_ci_fips.yml
+++ b/.github/workflows/macos_ci_fips.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   # Job to run FIPS version of ACCP tests on MacOS.
   macOS:
-    runs-on: macos-11 # latest
+    runs-on: macos-latest
     steps:
     - uses: actions/checkout@v3
       with:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
There's nothing particularly special about Big Sur that we need to pin
our testing to it. Development machines, which are presumably our only
Mac use case, are expected to be kept up to date.

n.b. This actually resolves to Monterey right now, rather than Ventura.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
