### PR TITLE
SecretKeyGenerator's DefaultSecureRandomSupplier always uses LibCryptoRng

### DIFF
--- a/src/com/amazon/corretto/crypto/provider/SecretKeyGenerator.java
+++ b/src/com/amazon/corretto/crypto/provider/SecretKeyGenerator.java
@@ -73,13 +73,7 @@ class SecretKeyGenerator extends KeyGeneratorSpi {
 
     @Override
     public SecureRandom get() {
-      try {
-        return SecureRandom.getInstance(
-            LibCryptoRng.ALGORITHM_NAME, AmazonCorrettoCryptoProvider.INSTANCE);
-      } catch (final NoSuchAlgorithmException e) {
-        throw new AssertionError(
-            LibCryptoRng.ALGORITHM_NAME + " is not a provided by AmazonCorrettoCryptoProvider", e);
-      }
+      return new LibCryptoRng();
     }
   }
 

--- a/tst/com/amazon/corretto/crypto/provider/test/SecurityPropertyTester.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/SecurityPropertyTester.java
@@ -13,6 +13,7 @@ import java.security.SecureRandom;
 import java.security.Security;
 import java.util.HashSet;
 import java.util.Set;
+import javax.crypto.KeyGenerator;
 import javax.net.ssl.SSLContext;
 
 /**
@@ -53,6 +54,12 @@ public final class SecurityPropertyTester {
       assertEquals(NATIVE_PROVIDER.getName(), new SecureRandom().getProvider().getName());
       assertEquals(NATIVE_PROVIDER.getName(), strongRng.getProvider().getName());
     }
+
+    // Ensure that we can successfully generate an AES key, regardless of FIPS
+    // mode or whether ACCP registers a SecureRandom implementation.
+    KeyGenerator aesKeyGen = KeyGenerator.getInstance("AES");
+    assertEquals(NATIVE_PROVIDER.getName(), aesKeyGen.getProvider().getName());
+    aesKeyGen.generateKey();
 
     // Also ensure that nothing shows up twice
     Set<String> names = new HashSet<>();


### PR DESCRIPTION
# Notes

We recently made [a change][1] to ACCP making the JCA registry of a SecureRandom implementation opt-in in FIPS mode. This had the unintended effect of breaking SecretKey generation in FIPS mode, as our SecretKeyGenerator internally sourced its LibCryptoRng instance from the JCA. Because we didn't register LibCryptoRng with the JCA by default in FIPS mode, exceptions got thrown.

The fix here is to just instantiate LibCryptoRng directy instead of obtaining it through the JCA. This has the added benefit of making sure we're _always_ using AWS-LC's DRBG for SecretKey generation by default, eliminating the possiblity of throw/fallback flows.

[1]: https://github.com/corretto/amazon-corretto-crypto-provider/pull/286

# Testing

```
$ git diff
diff --git a/src/com/amazon/corretto/crypto/provider/SecretKeyGenerator.java b/src/com/amazon/corretto/crypto/provider/SecretKeyGenerator.java
index 01ab338..52775ae 100644
--- a/src/com/amazon/corretto/crypto/provider/SecretKeyGenerator.java
+++ b/src/com/amazon/corretto/crypto/provider/SecretKeyGenerator.java
@@ -73,7 +73,13 @@ class SecretKeyGenerator extends KeyGeneratorSpi {

     @Override
     public SecureRandom get() {
-      return new LibCryptoRng();
+      try {
+        return SecureRandom.getInstance(
+            LibCryptoRng.ALGORITHM_NAME, AmazonCorrettoCryptoProvider.INSTANCE);
+      } catch (final NoSuchAlgorithmException e) {
+        throw new AssertionError(
+            LibCryptoRng.ALGORITHM_NAME + " is not a provided by AmazonCorrettoCryptoProvider", e);
+      }
     }
   }


$ ./gradlew -DFIPS=true cmake_clean test
...
Exception in thread "main" java.lang.AssertionError: LibCryptoRng is not a provided by AmazonCorrettoCryptoProvider
        at com.amazon.corretto.crypto.provider.SecretKeyGenerator$DefaultSecureRandomSupplier.get(SecretKeyGenerator.java:80)
        at com.amazon.corretto.crypto.provider.SecretKeyGenerator$DefaultSecureRandomSupplier.get(SecretKeyGenerator.java:66)
        at java.base/java.util.Optional.orElseGet(Optional.java:369)
        at com.amazon.corretto.crypto.provider.SecretKeyGenerator.engineGenerateKey(SecretKeyGenerator.java:59)
        at java.base/javax.crypto.KeyGenerator.generateKey(KeyGenerator.java:563)
        at com.amazon.corretto.crypto.provider.test.SecurityPropertyTester.main(SecurityPropertyTester.java:62)
Caused by: java.security.NoSuchAlgorithmException: no such algorithm: LibCryptoRng for provider AmazonCorrettoCryptoProvider
        at java.base/sun.security.jca.GetInstance.getService(GetInstance.java:101)
        at java.base/sun.security.jca.GetInstance.getInstance(GetInstance.java:218)
        at java.base/java.security.SecureRandom.getInstance(SecureRandom.java:469)
        at com.amazon.corretto.crypto.provider.SecretKeyGenerator$DefaultSecureRandomSupplier.get(SecretKeyGenerator.java:77)
        ... 5 more
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
