### PR TITLE
Revert "Only register LibCryptoRng by default in non-FIPS mode"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -602,9 +602,6 @@ set(COVERAGE_ARGUMENTS
 
 if(FIPS)
     set(TEST_FIPS_PROPERTY "-DFIPS=true")
-    # ACCP's default behavior in FIPS mode is to not register a SecureRandom implementation.
-    # However, we explicitly register it here to ensure its coverage under test.
-    set(REGISTER_RNG_PROPERTY "-Dcom.amazon.corretto.crypto.provider.registerSecureRandom=true")
 else()
     set(TEST_FIPS_PROPERTY "-DFIPS=false")
 endif()
@@ -618,7 +615,6 @@ set(TEST_RUNNER_ARGUMENTS
     ${TEST_ADD_OPENS}
     ${TEST_FIPS_PROPERTY}
     ${EXTERNAL_LIB_PROPERTY}
-    ${REGISTER_RNG_PROPERTY}
     -Dcom.amazon.corretto.crypto.provider.inTestSuite=hunter2
     -Dtest.data.dir=${TEST_DATA_DIR}
     -Djunit.jupiter.execution.parallel.enabled=true
@@ -818,7 +814,6 @@ if (CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
 add_custom_target(run-dieharder-libcrypto-rng
     COMMAND ${TEST_JAVA_EXECUTABLE} -cp $<TARGET_PROPERTY:accp-jar,JAR_FILE>:$<TARGET_PROPERTY:tests-jar,JAR_FILE>:${TEST_CLASSPATH}
         ${EXTERNAL_LIB_PROPERTY}
-        ${REGISTER_RNG_PROPERTY}
         com.amazon.corretto.crypto.provider.test.SecureRandomGenerator 'LibCryptoRng' 8192 1 |
         ${DIEHARDER_EXECUTABLE} -a -g 200 -Y 1 -k 2 |
         tee dieharder-results-libcrypto-rng.txt
@@ -828,7 +823,6 @@ add_custom_target(run-dieharder-libcrypto-rng
 add_custom_target(run-dieharder-libcrypto-rng-tail
     COMMAND ${TEST_JAVA_EXECUTABLE} -cp $<TARGET_PROPERTY:accp-jar,JAR_FILE>:$<TARGET_PROPERTY:tests-jar,JAR_FILE>:${TEST_CLASSPATH}
         ${EXTERNAL_LIB_PROPERTY}
-        ${REGISTER_RNG_PROPERTY}
         com.amazon.corretto.crypto.provider.test.SecureRandomGenerator 'LibCryptoRng' 31 1 |
         ${DIEHARDER_EXECUTABLE} -d 15 -g 200 -Y 1 -k 2 |
         tee dieharder-results-libcrypto-rng-tail.txt
@@ -838,7 +832,6 @@ add_custom_target(run-dieharder-libcrypto-rng-tail
 add_custom_target(run-dieharder-libcrypto-rng-threads
     COMMAND ${TEST_JAVA_EXECUTABLE} -cp $<TARGET_PROPERTY:accp-jar,JAR_FILE>:$<TARGET_PROPERTY:tests-jar,JAR_FILE>:${TEST_CLASSPATH}
         ${EXTERNAL_LIB_PROPERTY}
-        ${REGISTER_RNG_PROPERTY}
         com.amazon.corretto.crypto.provider.test.SecureRandomGenerator 'LibCryptoRng' 128 4 |
         ${DIEHARDER_EXECUTABLE} -a -g 200 -Y 1 -k 2 |
         tee dieharder-results-libcrypto-rng-threads.txt
@@ -848,7 +841,6 @@ add_custom_target(run-dieharder-libcrypto-rng-threads
 add_custom_target(run-dieharder-libcrypto-rng-threads-tail
     COMMAND ${TEST_JAVA_EXECUTABLE} -cp $<TARGET_PROPERTY:accp-jar,JAR_FILE>:$<TARGET_PROPERTY:tests-jar,JAR_FILE>:${TEST_CLASSPATH}
         ${EXTERNAL_LIB_PROPERTY}
-        ${REGISTER_RNG_PROPERTY}
         com.amazon.corretto.crypto.provider.test.SecureRandomGenerator 'LibCryptoRng' 31 4 |
         ${DIEHARDER_EXECUTABLE} -d 15 -g 200 -Y 1 -k 2 |
         tee dieharder-results-libcrypto-rng-threads-tail.txt

--- a/README.md
+++ b/README.md
@@ -174,10 +174,6 @@ Building this provider requires a 64 bit Linux or MacOS build system with the fo
 By providing `-DFIPS=true` to `gradlew` you will cause the entire build to be for a "FIPS mode" build.
 The only significant difference is that AWS-LC is built with `FIPS=1`.
 
-For performance reasons, ACCP does not register a SecureRandom implementation in FIPS mode.
-Relevant operations within the FIPS module boundary (e.g. key generation, non-deterministic signing, etc.) will still use AWS-LC's internal DRBG.
-Users who require ACCP to provide FIPS-validated pseudo-randomness _outside_ the module boundary via SecureRandom should set `registerSecureRandom=true`.
-
 When changing between FIPS and non-FIPS builds, be sure to do a full `clean` of your build environment.
 
 ##### All targets
@@ -272,14 +268,6 @@ Thus, these should all be set on the JVM command line using `-D`.
   Else, the JCA will get the implementation from another registered provider (usually stock JCE).
   Using JCE's impelmentation is generally recommended unless using ACCP as a standalone provider
   Callers can choose to register ACCP's implementation at runtime with a call to `AmazonCorrettoCryptoProvider.registerEcParams()`
-* `com.amazon.corretto.crypto.provider.registerSecureRandom`
-  Takes in `true` or `false` (defaults to `false` in FIPS mode, defaults to `true` in non-FIPS).
-  If `true`, then ACCP will register a SecureRandom implementation (`LibCryptoRng`) backed by AWS-LC
-  Else, ACCP will not register a SecureRandom implementation, meaning that the JCA will source SecureRandom instances from another registered provider. AWS-LC will still use its internal DRBG for key generation and other operations requiring secure pseudo-randomness.
-  LibCryptoRng is very fast during steady state operation in all cases. In FIPS mode, however, AWS-LC-FIPS's CPU jitter-based entropy source incurs a ~10ms initialization cost for every new thread.
-  This means that there is a slight "pause" before ACCP FIPS's SecureRandom can produce pseudo-random bytes in highly threaded environments.
-  Because, in extreme cases this could present an availability risk, we do not register LibCryptoRng by default in configurations where this initialization cost is incurred (i.e. FIPS mode).
-  Non-FIPS AWS-LC does not use CPU jitter for its DRBG seed's entropy, and therefore does not incur this initialization cost, therefore we register LibCryptoRng by default when not in FIPS mode.
 
 
 # License

--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,6 @@ jmh {
     jvmArgs = [
         "-Djava.library.path=${rootDir}/build/cmake:" + System.getProperty("java.library.path"),
         "-DversionStr=${version}",
-        "-Dcom.amazon.corretto.crypto.provider.registerSecureRandom=true",
     ]
 
     sourceSets {

--- a/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
+++ b/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
@@ -33,7 +33,6 @@ public final class AmazonCorrettoCryptoProvider extends java.security.Provider {
   private static final String PACKAGE_PREFIX = "com.amazon.corretto.crypto.provider.";
   private static final String PROPERTY_CACHE_SELF_TEST_RESULTS = "cacheselftestresults";
   private static final String PROPERTY_REGISTER_EC_PARAMS = "registerEcParams";
-  private static final String PROPERTY_REGISTER_SECURE_RANDOM = "registerSecureRandom";
   private static final long serialVersionUID = 1L;
 
   public static final AmazonCorrettoCryptoProvider INSTANCE;
@@ -43,7 +42,6 @@ public final class AmazonCorrettoCryptoProvider extends java.security.Provider {
 
   private final boolean relyOnCachedSelfTestResults;
   private final boolean shouldRegisterEcParams;
-  private final boolean shouldRegisterSecureRandom;
 
   private transient SelfTestSuite selfTestSuite = new SelfTestSuite();
 
@@ -98,15 +96,13 @@ public final class AmazonCorrettoCryptoProvider extends java.security.Provider {
       registerEcParams();
     }
 
-    if (shouldRegisterSecureRandom) {
-      addService(
-              "SecureRandom",
-              "LibCryptoRng",
-              "LibCryptoRng$SPI",
-              singletonMap("ThreadSafe", "true"),
-              "DEFAULT")
-          .setSelfTest(LibCryptoRng.SPI.SELF_TEST);
-    }
+    addService(
+            "SecureRandom",
+            "LibCryptoRng",
+            "LibCryptoRng$SPI",
+            singletonMap("ThreadSafe", "true"),
+            "DEFAULT")
+        .setSelfTest(LibCryptoRng.SPI.SELF_TEST);
 
     addSignatures();
   }
@@ -362,14 +358,6 @@ public final class AmazonCorrettoCryptoProvider extends java.security.Provider {
     this.relyOnCachedSelfTestResults =
         Utils.getBooleanProperty(PROPERTY_CACHE_SELF_TEST_RESULTS, true);
     this.shouldRegisterEcParams = Utils.getBooleanProperty(PROPERTY_REGISTER_EC_PARAMS, false);
-
-    // AWS-LC-FIPS's DRBG has per-thread initialization latency that can degrade performance in
-    // highly threaded
-    // applications. Until this is resolved, we only register an AWS-LC-backed SecureRandom
-    // implementation
-    // when we're not operating in FIPS mode.
-    this.shouldRegisterSecureRandom =
-        Utils.getBooleanProperty(PROPERTY_REGISTER_SECURE_RANDOM, !isFips());
 
     Utils.optionsFromProperty(ExtraCheck.class, extraChecks, "extrachecks");
 

--- a/src/jmh/java/com/amazon/corretto/crypto/provider/Drbg.java
+++ b/src/jmh/java/com/amazon/corretto/crypto/provider/Drbg.java
@@ -53,18 +53,4 @@ public class Drbg {
     random.nextBytes(data);
     return data;
   }
-
-  @Benchmark
-  @Threads(1)
-  public byte[] newThreadPerRequest() throws InterruptedException {
-    Thread t =
-        new Thread() {
-          public void run() {
-            random.nextBytes(data);
-          }
-        };
-    t.start();
-    t.join();
-    return data;
-  }
 }

--- a/tst/com/amazon/corretto/crypto/provider/test/SecurityPropertyTester.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/SecurityPropertyTester.java
@@ -18,8 +18,7 @@ import javax.net.ssl.SSLContext;
 
 /**
  * This is a special stand-alone test case which asserts that AmazonCorrettoCryptoProvider is
- * installed as the highest priority provider, has expected default behavior (the unit test suite is
- * not necessarily configured with ACCP's defaults), and is functional.
+ * installed as the highest priority provider and is functional.
  */
 public final class SecurityPropertyTester {
   public static void main(String[] args) throws Exception {
@@ -43,17 +42,10 @@ public final class SecurityPropertyTester {
     @SuppressWarnings("unused")
     KeyPairGenerator kpg = KeyPairGenerator.getInstance("EC", "SunEC");
 
-    // Ensure that FIPS mode determines default behavior for registering SecureRandom and "strong"
-    // random
+    // Ensure we properly configured ourselves as "strong" instance of SecureRandom
     // Applications should never use getInstanceStrong as it is an anti-pattern.
     final SecureRandom strongRng = SecureRandom.getInstanceStrong();
-    if (NATIVE_PROVIDER.isFips()) {
-      assertNotEquals(NATIVE_PROVIDER.getName(), new SecureRandom().getProvider().getName());
-      assertNotEquals(NATIVE_PROVIDER.getName(), strongRng.getProvider().getName());
-    } else {
-      assertEquals(NATIVE_PROVIDER.getName(), new SecureRandom().getProvider().getName());
-      assertEquals(NATIVE_PROVIDER.getName(), strongRng.getProvider().getName());
-    }
+    assertEquals(NATIVE_PROVIDER.getName(), strongRng.getProvider().getName());
 
     // Ensure that we can successfully generate an AES key, regardless of FIPS
     // mode or whether ACCP registers a SecureRandom implementation.


### PR DESCRIPTION



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
