### PR TITLE
Optimize handling of overlapping input/output buffers for AES-GCM

### DIFF
--- a/tst/com/amazon/corretto/crypto/provider/test/UtilsTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/UtilsTest.java
@@ -33,36 +33,37 @@ public class UtilsTest {
     }
   }
 
-  boolean maybeOverlaps(ByteBuffer a, ByteBuffer b) throws Throwable {
-    return (Boolean) sneakyInvoke(UTILS_CLASS, "buffersMaybeOverlap", a, b);
+  boolean outputClobbers(ByteBuffer input, ByteBuffer output) throws Throwable {
+    return (Boolean) sneakyInvoke(UTILS_CLASS, "outputClobbersInput", input, output);
   }
 
-  private void assertMaybeOverlaps0(ByteBuffer a, ByteBuffer b) throws Throwable {
-    assertTrue(maybeOverlaps(a, b));
-    assertTrue(maybeOverlaps(b, a));
+  private void assertOutputClobbers0(ByteBuffer input, ByteBuffer output) throws Throwable {
+    assertTrue(outputClobbers(input, output));
   }
 
-  private void assertMaybeOverlaps(ByteBuffer a, ByteBuffer b) throws Throwable {
-    assertMaybeOverlaps0(a, b);
-    assertMaybeOverlaps0(a.slice(), b);
-    assertMaybeOverlaps0(a, b.slice());
-    assertMaybeOverlaps0(a.slice(), b.slice());
+  private void assertOutputClobbers(ByteBuffer input, ByteBuffer output) throws Throwable {
+    assertOutputClobbers0(input, output);
+    assertOutputClobbers0(input.slice(), output);
+    assertOutputClobbers0(input, output.slice());
+    assertOutputClobbers0(input.slice(), output.slice());
   }
 
-  private void assertNoOverlap0(ByteBuffer a, ByteBuffer b) throws Throwable {
-    assertFalse(maybeOverlaps(a, b));
-    assertFalse(maybeOverlaps(b, a));
+  private void assertNoClobber0(ByteBuffer input, ByteBuffer output) throws Throwable {
+    assertFalse(outputClobbers(input, output));
   }
 
-  private void assertNoOverlap(ByteBuffer a, ByteBuffer b) throws Throwable {
-    assertNoOverlap0(a, b);
-    assertNoOverlap0(a.slice(), b);
-    assertNoOverlap0(a, b.slice());
-    assertNoOverlap0(a.slice(), b.slice());
+  private void assertNoClobber(ByteBuffer input, ByteBuffer output) throws Throwable {
+    assertNoClobber0(input, output);
+    assertNoClobber0(input.slice(), output);
+    assertNoClobber0(input, output.slice());
+    assertNoClobber0(input.slice(), output.slice());
   }
 
-  boolean arraysOverlap(byte[] a1, int o1, byte[] a2, int o2, int length) throws Throwable {
-    return (Boolean) sneakyInvoke(UTILS_CLASS, "arraysOverlap", a1, o1, a2, o2, length);
+  boolean arraysClobber(byte[] input, int inputOffset, int length, byte[] output, int outputOffset)
+      throws Throwable {
+    return (Boolean)
+        sneakyInvoke(
+            UTILS_CLASS, "outputClobbersInput", input, inputOffset, length, output, outputOffset);
   }
 
   @BeforeAll
@@ -72,69 +73,71 @@ public class UtilsTest {
   }
 
   @Test
-  public void whenArrayBuffersAreDifferentArrays_noOverlap() throws Throwable {
+  public void whenArrayBuffersAreDifferentArrays_noClobber() throws Throwable {
     ByteBuffer a = ByteBuffer.allocate(100);
     ByteBuffer b = ByteBuffer.allocate(100);
 
-    assertNoOverlap(a, b);
+    assertNoClobber(a, b);
 
     b.position(10);
     a.limit(11);
 
-    assertNoOverlap(a, b);
+    assertNoClobber(a, b);
   }
 
   @Test
-  public void whenArrayBuffersAreDifferentArrays_correctOverlap() throws Throwable {
+  public void whenArrayBuffersAreDifferentArrays_correctClobber() throws Throwable {
     ByteBuffer a = ByteBuffer.allocate(100);
     ByteBuffer b = a.duplicate();
 
-    assertMaybeOverlaps(a, b);
+    // Exact overlap
+    assertNoClobber(a, b);
+    b.limit(20);
+    assertNoClobber(a, b);
 
-    b.limit(10);
-
-    assertMaybeOverlaps(a, b);
-
+    // Output clobbers
     b.position(10);
-
-    assertMaybeOverlaps(a, b);
-
+    assertOutputClobbers(a, b);
     a.limit(11);
+    assertOutputClobbers(a, b);
 
-    assertMaybeOverlaps(a, b);
-
+    // Output leads, but is beyond the input limit
     a.limit(10);
+    assertNoClobber(a, b);
 
-    assertNoOverlap(a, b);
+    // Output lags
+    b.position(1);
+    a.position(2);
+    assertNoClobber(a, b);
   }
 
   @Test
-  public void whenOneBufferIsReadOnly_assumesOverlap() throws Throwable {
+  public void whenOneBufferIsReadOnly_assumesClobber() throws Throwable {
     ByteBuffer a = ByteBuffer.allocate(100);
     ByteBuffer b = ByteBuffer.allocate(100).asReadOnlyBuffer();
 
-    assertMaybeOverlaps(a, b);
+    assertOutputClobbers(a, b);
   }
 
   @Test
-  public void whenOneBufferIsDirect_noOverlap() throws Throwable {
+  public void whenOneBufferIsDirect_noClobber() throws Throwable {
     ByteBuffer a = ByteBuffer.allocate(100);
     ByteBuffer b = ByteBuffer.allocateDirect(100);
 
-    assertNoOverlap(a, b);
-    assertNoOverlap(a.asReadOnlyBuffer(), b);
+    assertNoClobber(a, b);
+    assertNoClobber(a.asReadOnlyBuffer(), b);
   }
 
   @Test
-  public void whenBothBuffersAreDirect_fromDifferentAllocations_noOverlap() throws Throwable {
+  public void whenBothBuffersAreDirect_fromDifferentAllocations_noClobber() throws Throwable {
     ByteBuffer a = ByteBuffer.allocateDirect(100);
     ByteBuffer b = ByteBuffer.allocateDirect(100);
 
-    assertNoOverlap(a, b);
+    assertNoClobber(a, b);
   }
 
   @Test
-  public void whenMaximumSizeNativeBuffersAreUsed_correctOverlapDetermination() throws Throwable {
+  public void whenMaximumSizeNativeBuffersAreUsed_correctClobberDetermination() throws Throwable {
     ByteBuffer buf;
     try {
       buf = ByteBuffer.allocateDirect(Integer.MAX_VALUE);
@@ -146,32 +149,37 @@ public class UtilsTest {
     ByteBuffer b = buf.duplicate();
 
     b.position(b.limit() - 1);
-    assertMaybeOverlaps(a, b);
+    assertOutputClobbers(a, b);
 
     a.limit(1);
-    assertNoOverlap(a, b);
+    assertNoClobber(a, b);
 
     a.limit(a.capacity());
     a.position(b.position());
-    assertMaybeOverlaps(a, b);
+    assertOutputClobbers(a, b);
   }
 
   @Test
-  public void arraysOverlapTests() throws Throwable {
+  public void arraysClobberTests() throws Throwable {
     byte[] arr1 = new byte[10];
     byte[] arr2 = new byte[10];
 
-    assertTrue(arraysOverlap(arr1, 0, arr1, 0, 10));
-    assertFalse(arraysOverlap(arr1, 0, arr2, 0, 10));
-
-    assertTrue(arraysOverlap(arr1, 0, arr1, 5, 10));
-    assertTrue(arraysOverlap(arr1, 0, arr1, 5, 6));
-    assertFalse(arraysOverlap(arr1, 0, arr1, 5, 5));
-    assertTrue(arraysOverlap(arr1, 1, arr1, 5, 5));
-    assertTrue(arraysOverlap(arr1, 5, arr1, 0, 10));
-    assertTrue(arraysOverlap(arr1, 5, arr1, 0, 6));
-    assertFalse(arraysOverlap(arr1, 5, arr1, 0, 5));
-    assertTrue(arraysOverlap(arr1, 5, arr1, 1, 5));
+    // Exact overlap
+    assertFalse(arraysClobber(arr1, 0, 10, arr1, 0));
+    // Different arrays
+    assertFalse(arraysClobber(arr1, 0, 10, arr2, 0));
+    // Same array, but clobbering
+    assertTrue(arraysClobber(arr1, 0, 10, arr1, 5));
+    assertTrue(arraysClobber(arr1, 0, 6, arr1, 5));
+    assertTrue(arraysClobber(arr1, 1, 5, arr1, 5));
+    // Same array, but outputs beyond input
+    assertFalse(arraysClobber(arr1, 0, 5, arr1, 5));
+    assertFalse(arraysClobber(arr1, 0, 5, arr1, 6));
+    // Same array, but output lags
+    assertFalse(arraysClobber(arr1, 5, 10, arr1, 0));
+    assertFalse(arraysClobber(arr1, 5, 6, arr1, 0));
+    assertFalse(arraysClobber(arr1, 5, 5, arr1, 0));
+    assertFalse(arraysClobber(arr1, 5, 5, arr1, 1));
   }
 
   @Test


### PR DESCRIPTION
*Issue #, if available:*
#271

*Description of changes:*
Currently, ACCP does not tolerate any overlap between input/output buffers. If it detects any overlap, it will buffer a copy of the entire input prior to proceeding (consuming O(n) more memory). This is to prevent any risk of the output of the operation from overwriting the input prior to processing that input. However, it is a common case for our clients (e.g. Sun JSSE's TLS implementation) to preserve memory by reusing the input/output buffers since they have little use for the input once it has been successfully encrypted/decrypted.

AES, as a block cipher, operates on blocks. It reads one block of input into intermediate memory for processing and then writes one block of output. Implementations of AES can tolerate writing the output to the exact same block of memory where it read the input. Where we run into trouble is whenever the output block overwrites data from any input block beyond the block that was just processed.

This changeset relaxes the boundary checking in the input/output arrays so that it allows the case where we overlap exactly or any case where the output lags behind the input. We still safely handle cases where the output overwrites the input by detecting and cloning the input buffer as necessary. We also check for cases where the output leads the input, but beyond the limit of the input buffer and allow this configuration without cloning memory. The end result is that we unlock another 30% improvement in memory consumption under the benchmarks in issue #271.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
