### PR TITLE
Use FIPS approved APIs to generate RSA key pairs

### DIFF
--- a/src/com/amazon/corretto/crypto/provider/RsaGen.java
+++ b/src/com/amazon/corretto/crypto/provider/RsaGen.java
@@ -70,10 +70,10 @@ class RsaGen extends KeyPairGeneratorSpi {
   private static RSAKeyGenParameterSpec validateParameter(final RSAKeyGenParameterSpec spec)
       throws InvalidAlgorithmParameterException {
 
-    // Similar to BC-FIPS, ACCP only disallows public exponents less than F4.
-    if (Loader.FIPS_BUILD && spec.getPublicExponent().compareTo(RSAKeyGenParameterSpec.F4) <= -1) {
+    // In FIPS mode, ACCP only allows public exponents F4.
+    if (Loader.FIPS_BUILD && !RSAKeyGenParameterSpec.F4.equals(spec.getPublicExponent())) {
       throw new InvalidAlgorithmParameterException(
-          "For FIPS builds, public exponent cannot be less that F4");
+          "For FIPS builds, public exponent must be equal to F4");
     }
 
     if (spec.getKeysize() < MIN_KEY_SIZE) {


### PR DESCRIPTION
*Description of changes:*

* AWS-LC's FIPS approved API only supports RSA keys of sizes 2048, 3072, and 4096; moreover, on F4 as public exponent is supported.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
