### PR TITLE
Avoid overriding CipherSpi::engineDoFinal(ByteBuffer, ByteBuffer)

### DIFF
--- a/src/com/amazon/corretto/crypto/provider/AesGcmSpi.java
+++ b/src/com/amazon/corretto/crypto/provider/AesGcmSpi.java
@@ -926,22 +926,6 @@ final class AesGcmSpi extends CipherSpi {
     }
   }
 
-  @Override
-  protected int engineDoFinal(final ByteBuffer input, final ByteBuffer output)
-      throws ShortBufferException, IllegalBlockSizeException, BadPaddingException {
-    int initialPosition = output.position();
-
-    engineUpdate(input, output);
-
-    ShimArray shim = new ShimArray(output, engineGetOutputSize(0));
-    int finalBytes = engineDoFinal(EMPTY_ARRAY, 0, 0, shim.array, shim.offset);
-
-    shim.writeback();
-    output.position(output.position() + finalBytes);
-
-    return output.position() - initialPosition;
-  }
-
   private void checkOutputBuffer(
       final int inputLength, final byte[] output, final int outputOffset, final boolean doFinal)
       throws ShortBufferException {


### PR DESCRIPTION
*Description of changes:*

CipherSpi, the parent class of AesGcmSpi provides an implementation for engineDoFinal(ByteBuffer, ByteBuffer) that has a smaller memory footprint.

For benchmarking, I used [ckozak/accp branch of java-crypto-allocation-performance](https://github.com/carterkozak/java-crypto-allocation-performance/tree/ckozak/accp). Here is section of the report:

Baseline:
```
Benchmark                                                                               (cipher)   (length)  (provider)  Mode  Cnt          Score           Error   Units
DirectBufferTransportLayerSecurityBenchmark.download                      TLS_AES_256_GCM_SHA384  104857600       ACCP2  avgt    4        161.150 ±        10.875   ms/op
DirectBufferTransportLayerSecurityBenchmark.download:·gc.alloc.rate       TLS_AES_256_GCM_SHA384  104857600       ACCP2  avgt    4       1048.520 ±      4310.095  MB/sec
DirectBufferTransportLayerSecurityBenchmark.download:·gc.alloc.rate.norm  TLS_AES_256_GCM_SHA384  104857600       ACCP2  avgt    4  177981662.606 ± 732218228.614    B/op
DirectBufferTransportLayerSecurityBenchmark.download:·gc.count            TLS_AES_256_GCM_SHA384  104857600       ACCP2  avgt    4         90.000                  counts
DirectBufferTransportLayerSecurityBenchmark.download:·gc.time             TLS_AES_256_GCM_SHA384  104857600       ACCP2  avgt    4         80.000                      ms
```

With this PR:
```
Benchmark                                                                               (cipher)   (length)  (provider)  Mode  Cnt          Score           Error   Units
DirectBufferTransportLayerSecurityBenchmark.download                      TLS_AES_256_GCM_SHA384  104857600       ACCP2  avgt    4        135.932 ±        14.041   ms/op
DirectBufferTransportLayerSecurityBenchmark.download:·gc.alloc.rate       TLS_AES_256_GCM_SHA384  104857600       ACCP2  avgt    4        772.883 ±      3156.272  MB/sec
DirectBufferTransportLayerSecurityBenchmark.download:·gc.alloc.rate.norm  TLS_AES_256_GCM_SHA384  104857600       ACCP2  avgt    4  110326939.149 ± 450469639.448    B/op
DirectBufferTransportLayerSecurityBenchmark.download:·gc.count            TLS_AES_256_GCM_SHA384  104857600       ACCP2  avgt    4         66.000                  counts
DirectBufferTransportLayerSecurityBenchmark.download:·gc.time             TLS_AES_256_GCM_SHA384  104857600       ACCP2  avgt    4         55.000                      ms
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
