### PR TITLE
Use FIPS approved APIs to generate RSA key pairs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 2.1.0 (not released yet)
+
+### Minor changes
+* Support AlgorithmParameters for EC [PR 274]
+* Support KeyGenerator for AES [PR 279]
+* Register LibCryptoRng by default in non-FIPS mode [PR 286]
+* Use FIPS approved API of AWS-LC for RSA key generation in FIPS mode [PR 301]
+* Include AWS-LC's self tests as part of ACCP's self tests [PR 283]
+
+### Patches
+* Fixed bug in output buffer size check [PR 297]
+* Improved the performance of AES-GCM [PRs 296, 298, 300, 302]
+* Added code formatting and style checking to the build scripts [PRs 287, 292]
+* Renamed branches on GitHub
+
 ## 2.0.0
 
 ### Overview

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ plugins {
 }
 
 group = 'software.amazon.cryptools'
-version = '2.0.0'
+version = '2.1.0'
 ext.isFips = Boolean.getBoolean('FIPS')
 ext.isLegacyBuild = Boolean.getBoolean('LEGACY_BUILD')
 

--- a/examples/gradle-kt-dsl/lib/build.gradle.kts
+++ b/examples/gradle-kt-dsl/lib/build.gradle.kts
@@ -1,4 +1,4 @@
-val accpVersion = "2.0.0"
+val accpVersion = "2.1.0"
 
 plugins {
     // Apply the org.jetbrains.kotlin.jvm Plugin to add support for Kotlin.

--- a/src/com/amazon/corretto/crypto/provider/RsaGen.java
+++ b/src/com/amazon/corretto/crypto/provider/RsaGen.java
@@ -70,10 +70,10 @@ class RsaGen extends KeyPairGeneratorSpi {
   private static RSAKeyGenParameterSpec validateParameter(final RSAKeyGenParameterSpec spec)
       throws InvalidAlgorithmParameterException {
 
-    // Similar to BC-FIPS, ACCP only disallows public exponents less than F4.
-    if (Loader.FIPS_BUILD && spec.getPublicExponent().compareTo(RSAKeyGenParameterSpec.F4) <= -1) {
+    // In FIPS mode, ACCP only allows public exponents F4.
+    if (Loader.FIPS_BUILD && !RSAKeyGenParameterSpec.F4.equals(spec.getPublicExponent())) {
       throw new InvalidAlgorithmParameterException(
-          "For FIPS builds, public exponent cannot be less that F4");
+          "For FIPS builds, public exponent must be equal to F4");
     }
 
     if (spec.getKeysize() < MIN_KEY_SIZE) {


### PR DESCRIPTION
*Description of changes:*

* Use FIPS approved APIs to generate RSA key pairs
* Update CHANGELOG.md
* Update version numbers to 2.1.0


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
