### PR TITLE
Serializable Keys

### DIFF
--- a/src/com/amazon/corretto/crypto/provider/EvpKey.java
+++ b/src/com/amazon/corretto/crypto/provider/EvpKey.java
@@ -278,7 +278,7 @@ abstract class EvpKey implements Key, Destroyable {
     private final boolean isPublicKey;
     private final byte[] encoded;
 
-    public SerializedKey(EvpKeyType type, boolean isPublicKey, byte[] encoded) {
+    public SerializedKey(final EvpKeyType type, final boolean isPublicKey, final byte[] encoded) {
       this.type = type;
       this.isPublicKey = isPublicKey;
       this.encoded = encoded;
@@ -287,13 +287,11 @@ abstract class EvpKey implements Key, Destroyable {
     private Object readResolve() throws ObjectStreamException {
       try {
         final KeyFactory kf = AmazonCorrettoCryptoProvider.INSTANCE.getKeyFactory(type);
-        final EvpKey result;
         if (isPublicKey) {
-          result = (EvpKey) kf.generatePublic(new X509EncodedKeySpec(encoded));
+          return kf.generatePublic(new X509EncodedKeySpec(encoded));
         } else {
-          result = (EvpKey) kf.generatePrivate(new PKCS8EncodedKeySpec(encoded));
+          return kf.generatePrivate(new PKCS8EncodedKeySpec(encoded));
         }
-        return result;
       } catch (final InvalidKeySpecException ex) {
         throw new InvalidObjectException(ex.getMessage());
       }

--- a/src/com/amazon/corretto/crypto/provider/EvpKey.java
+++ b/src/com/amazon/corretto/crypto/provider/EvpKey.java
@@ -3,17 +3,23 @@
 package com.amazon.corretto.crypto.provider;
 
 import java.io.IOException;
+import java.io.InvalidObjectException;
 import java.io.NotSerializableException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.ObjectStreamException;
+import java.io.Serializable;
 import java.math.BigInteger;
 import java.security.AlgorithmParameters;
 import java.security.GeneralSecurityException;
 import java.security.Key;
+import java.security.KeyFactory;
 import java.security.MessageDigest;
 import java.security.PublicKey;
 import java.security.spec.AlgorithmParameterSpec;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.security.spec.X509EncodedKeySpec;
 import java.util.Arrays;
 import java.util.Base64;
 import javax.security.auth.Destroyable;
@@ -216,24 +222,81 @@ abstract class EvpKey implements Key, Destroyable {
     T getPublicKey();
   }
 
-  // The Key interface requires us to be serializable.
-  // However, we are not easily serializable because we have native state which won't be captured.
-  // So, we prevent any attempt to serialize ourselves by throwing an exception.
-  // If we discover that we actually need to support this functionality, we can manage it through
-  // serializing an
-  // encoded copy of the key and decoding that upon deserialization.
-  // Doing that will require changing out InternalKey from being a final field to a transient one
-  // and this feels
-  // like a bad tradeoff if we can avoid it.
+  /*
+   * Java Keys are Serializable but we cannot use the trivial serialization of an EvpKey.
+   * - They contain a pointer to native memory (and associated native memory).
+   *   This obviously cannot remain valid after being serialized/deserialized.
+   * - The pointer to native memory is final to ensure there is no risk of it being invalid.
+   *   This means that we cannot just fix it up when deserializing.
+   *
+   * The trivial solution would be to make the pointer non-final, but that introduces a greater risk of serious bugs.
+   *
+   * Instead, we use writeReplace() and readResolve() to store our information in a dedicated format for serialization.
+   * - writeReplace() on the object to be serialized (an EvpKey) returns the *real* object to be serialized.
+   *   In our case, we return an instance of SerializedKey which contains the minimal information to properly save and retrieve a key.
+   * - readResolve() is called on the object which is *actually* serialized (and thus being deserialized) and returns the object that users care about.
+   *   In our case, SeralizedKey.readResolve() returns an appropriate instance of EvpKey.
+   *
+   * So, the entire (hidden from the user) flow goes like this.
+   * 1.  User tries to serialize an EvpKey
+   * 2.  Java detects that EvpKey.writeReplace() exists and calls it
+   * 3.  EvpKey.writeReplace() returns an instance of SerializedKey
+   * 4.  Java actually serializes SerializedKey
+   * 5.  (Some time passes)
+   * 6.  User tries to deserialize the bytes
+   * 7.  Java detects that the bytes contain a serialized SerializedKey and so deserializes it.
+   * 8.  Java detects that SerializedKey.readResolve() exists and calls it
+   * 9.  SerializedKey.readResolve() creates and returns an instance of EvpKey
+   * 10. User gets an instance of EvpKey and never realizes that the above complexity exists
+   */
+  Object writeReplace() throws ObjectStreamException {
+    return new SerializedKey(type, isPublicKey, internalGetEncoded());
+  }
+
+  // This object must never be serialized directly
   private void writeObject(final ObjectOutputStream out) throws IOException {
     throw new NotSerializableException("EvpKey");
   }
 
+  // This object must never be deserialized directly
   private void readObject(final ObjectInputStream in) throws IOException, ClassNotFoundException {
     throw new NotSerializableException("EvpKey");
   }
 
+  // This object must never be deserialized directly
   private void readObjectNoData() throws ObjectStreamException {
     throw new NotSerializableException("EvpKey");
+  }
+
+  /**
+   * Minimal information needed to serialize/deserialize any instance of EvpKey. Contains the key
+   * type, whether it is a public key, and the appropriate encoding of it.
+   */
+  private static class SerializedKey implements Serializable {
+    private static final long serialVersionUID = 1;
+    private final EvpKeyType type;
+    private final boolean isPublicKey;
+    private final byte[] encoded;
+
+    public SerializedKey(EvpKeyType type, boolean isPublicKey, byte[] encoded) {
+      this.type = type;
+      this.isPublicKey = isPublicKey;
+      this.encoded = encoded;
+    }
+
+    private Object readResolve() throws ObjectStreamException {
+      try {
+        final KeyFactory kf = AmazonCorrettoCryptoProvider.INSTANCE.getKeyFactory(type);
+        final EvpKey result;
+        if (isPublicKey) {
+          result = (EvpKey) kf.generatePublic(new X509EncodedKeySpec(encoded));
+        } else {
+          result = (EvpKey) kf.generatePrivate(new PKCS8EncodedKeySpec(encoded));
+        }
+        return result;
+      } catch (final InvalidKeySpecException ex) {
+        throw new InvalidObjectException(ex.getMessage());
+      }
+    }
   }
 }


### PR DESCRIPTION
*Description of changes:*

Java specifies that implementations of [Key are Serializable](https://docs.oracle.com/en/java/javase/18/docs/api/java.base/java/security/Key.html). Currently ACCP does not allow its keys to be serialized due to the difficulties in handling pointers into native memory and fixing them up while still letting them be `final`. This change safely serializes and deserializes instances of `EvpKey` by using a secondary helper class. A code comment explaining how this works is duplicated below.


> Java Keys are Serializable but we cannot use the trivial serialization of an EvpKey.
> - They contain a pointer to native memory (and associated native memory).
>   This obviously cannot remain valid after being serialized/deserialized.
> - The pointer to native memory is final to ensure there is no risk of it being invalid.
>   This means that we cannot just fix it up when deserializing.
> 
> The trivial solution would be to make the pointer non-final, but that introduces a greater risk of serious bugs.
> 
> Instead, we use writeReplace() and readResolve() to store our information in a dedicated format for serialization.
> - writeReplace() on the object to be serialized (an EvpKey) returns the *real* object to be serialized.
>    In our case, we return an instance of SerializedKey which contains the minimal information to properly save and retrieve a key.
> - readResolve() is called on the object which is *actually* serialized (and thus being deserialized) and returns the object that users care about.
>   In our case, SeralizedKey.readResolve() returns an appropriate instance of EvpKey.
> 
> So, the entire (hidden from the user) flow goes like this.
> 1.  User tries to serialize an EvpKey
> 2.  Java detects that EvpKey.writeReplace() exists and calls it
> 3.  EvpKey.writeReplace() returns an instance of SerializedKey
> 4.  Java actually serializes SerializedKey
> 5.  (Some time passes)
> 6.  User tries to deserialize the bytes
> 7.  Java detects that the bytes contain a serialized SerializedKey and so deserializes it.
> 8.  Java detects that SerializedKey.readResolve() exists and calls it
> 9.  SerializedKey.readResolve() creates and returns an instance of EvpKey
> 10. User gets an instance of EvpKey and never realizes that the above complexity exists

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
