### PR TITLE
Avoid overriding CipherSpi::engineDoFinal(ByteBuffer, ByteBuffer)

### DIFF
--- a/src/com/amazon/corretto/crypto/provider/AesGcmSpi.java
+++ b/src/com/amazon/corretto/crypto/provider/AesGcmSpi.java
@@ -993,20 +993,4 @@ final class AesGcmSpi extends CipherSpi {
     hasConsumedData = false;
     contextInitialized = false;
   }
-
-  @Override
-  protected int engineDoFinal(final ByteBuffer input, final ByteBuffer output)
-      throws ShortBufferException, IllegalBlockSizeException, BadPaddingException {
-    int initialPosition = output.position();
-
-    engineUpdate(input, output);
-
-    ShimArray shim = new ShimArray(output, engineGetOutputSize(0));
-    int finalBytes = engineDoFinal(EMPTY_ARRAY, 0, 0, shim.array, shim.offset);
-
-    shim.writeback();
-    output.position(output.position() + finalBytes);
-
-    return output.position() - initialPosition;
-  }
 }

--- a/tst/com/amazon/corretto/crypto/provider/test/AESGenerativeTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/AESGenerativeTest.java
@@ -3,7 +3,9 @@
 package com.amazon.corretto.crypto.provider.test;
 
 import static com.amazon.corretto.crypto.provider.test.TestUtil.NATIVE_PROVIDER;
+import static com.amazon.corretto.crypto.provider.test.TestUtil.getJavaVersion;
 import static com.amazon.corretto.crypto.provider.test.TestUtil.versionCompare;
+import static org.junit.Assume.assumeTrue;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -64,8 +66,34 @@ public class AESGenerativeTest {
   }
 
   @Test
+  public void testEncrypt91() throws Exception {
+    // The implementation of javax.crypto.CipherSpi::bufferCrypt in JDK 10
+    // has an issue that has been resolved in the following PR:
+    // https://github.com/openjdk/jdk/commit/c3a97b27e244f97c80a14388aea4fc425006a87e
+    // We disable this test for JDK 10.
+
+    // To replicate the error for other JDKs, copy-paste the buggy implementation into
+    // AesGcmSpi.java
+    // and run `./gradlew cmake_clean single_test
+    // -DSINGLE_TEST=com.amazon.corretto.crypto.provider.test.AESGenerativeTest`
+    // The buggy implementation is available here:
+    // https://github.com/openjdk/jdk/blob/f98aad58dea1d0b818706215166bcbbc349d1c6d/src/java.base/share/classes/javax/crypto/CipherSpi.java#L736-L857
+    assumeTrue(getJavaVersion() != 10);
+    try {
+      testEncrypt(91, 10);
+    } catch (Throwable t) {
+      throw new AssertionError("Seed: 91", t);
+    }
+  }
+
+  @Test
   public void testEncryptRandomly() throws Exception {
     for (int i = 0; i < 100; i++) {
+      // when i == 91, the test case fails for JDK 10. This case is tested in another method:
+      // testEncrypt91
+      if (i == 91) {
+        continue;
+      }
       try {
         testEncrypt(i, 10);
       } catch (Throwable t) {


### PR DESCRIPTION
*Description of changes:*

+ Avoid overriding CipherSpi::engineDoFinal(ByteBuffer, ByteBuffer).
+ The implementation of engineDoFinal has bug in JDK 10.
+ We disable the failing test for JDK 10.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
