### PR TITLE
Improve SignatureException handling

### DIFF
--- a/DIFFERENCES.md
+++ b/DIFFERENCES.md
@@ -12,7 +12,7 @@ These differences are those most likely to be noticed by a consuming application
 The official documentation does not fully specify when the [Signature](https://docs.oracle.com/javase/8/docs/api/java/security/Signature.html) object is expected to throw a [SignatureException](https://docs.oracle.com/javase/8/docs/api/java/security/SignatureException.html).
 Having multiple different ways to reject a signature (such as `signature.verify() == false` and throwing a `SignatureException`) is an anti-pattern and we should try to avoid it.
 ACCP throws a `SignatureException` from `Signature.verify()` only when not throwing would introduce compatibility issues (such as with the [JCK](https://en.wikipedia.org/wiki/Technology_Compatibility_Kit#TCK_for_the_Java_platform).)
-Currently, ACCP will throw a `SignatureException` only when verifying an EDSA signature that is not properly encoded.
+Currently, ACCP will throw a `SignatureException` only when verifying an EDSA signature that is not properly encoded or an RSA signature which is an invalid length.
 In all other cases, ACCP will return `false` from `Signature.verify()` when given an invalid signature.
 This is different from the default OpenJDK implementation, which also inspects the inner structure of RSA signatures and rejects them with a `SignatureException` if they are improperly encoded.
 ACCP follows the guidance provided in [PKCS #1 section 8.2.2](https://tools.ietf.org/html/rfc8017#section-8.2.2) in that it does not parse the inner structure but, instead, does a binary comparison against the expected value.

--- a/src/com/amazon/corretto/crypto/provider/EvpSignature.java
+++ b/src/com/amazon/corretto/crypto/provider/EvpSignature.java
@@ -441,20 +441,21 @@ class EvpSignature extends EvpSignatureBase {
   protected synchronized boolean engineVerify(final byte[] sigBytes, final int off, final int len)
       throws SignatureException {
     ensureInitialized(false);
-    byte[] tempSig = maybeConvertSignatureToVerify(sigBytes, off, len);
-    final byte[] finalSigBytes;
-    final int finalOff;
-    final int finalLen;
-    if (tempSig != null) {
-      finalSigBytes = tempSig;
-      finalOff = 0;
-      finalLen = finalSigBytes.length;
-    } else {
-      finalSigBytes = sigBytes;
-      finalOff = off;
-      finalLen = len;
-    }
     try {
+      byte[] tempSig = maybeConvertSignatureToVerify(sigBytes, off, len);
+      final byte[] finalSigBytes;
+      final int finalOff;
+      final int finalLen;
+      if (tempSig != null) {
+        finalSigBytes = tempSig;
+        finalOff = 0;
+        finalLen = finalSigBytes.length;
+      } else {
+        finalSigBytes = sigBytes;
+        finalOff = off;
+        finalLen = len;
+      }
+      sniffTest(finalSigBytes, finalOff, finalLen);
       return verifyingBuffer
           .withDoFinal((ctx) -> verifyFinish(ctx.take(), finalSigBytes, finalOff, finalLen))
           .withSinglePass(

--- a/src/com/amazon/corretto/crypto/provider/EvpSignatureBase.java
+++ b/src/com/amazon/corretto/crypto/provider/EvpSignatureBase.java
@@ -423,8 +423,9 @@ abstract class EvpSignatureBase extends SignatureSpi {
     // Right now we only check RSA signatures to ensure they are the proper length
     if (key_ instanceof RSAKey) {
       final RSAKey rsaKey = (RSAKey) key_;
-      if (length != (rsaKey.getModulus().bitLength() + 7) / 8) {
-        throw new SignatureException("RSA Signature of invalid length.");
+      final int expectedLength = (rsaKey.getModulus().bitLength() + 7) / 8;
+      if (length != expectedLength) {
+        throw new SignatureException("RSA Signature of invalid length. Expected " + expectedLength);
       }
     }
   }

--- a/src/com/amazon/corretto/crypto/provider/EvpSignatureBase.java
+++ b/src/com/amazon/corretto/crypto/provider/EvpSignatureBase.java
@@ -413,4 +413,19 @@ abstract class EvpSignatureBase extends SignatureSpi {
     System.arraycopy(signature, sStart, result, numLen + numLen - sLen, sLen);
     return result;
   }
+
+  /**
+   * Does an initial check of the signature seeing if it is of the proper format and size. This lets
+   * us quickly reject invalid signatures in a way that the JDK expects.
+   */
+  protected void sniffTest(final byte[] signature, final int offset, final int length)
+      throws SignatureException {
+    // Right now we only check RSA signatures to ensure they are the proper length
+    if (key_ instanceof RSAKey) {
+      final RSAKey rsaKey = (RSAKey) key_;
+      if (length != (rsaKey.getModulus().bitLength() + 7) / 8) {
+        throw new SignatureException("RSA Signature of invalid length.");
+      }
+    }
+  }
 }

--- a/src/com/amazon/corretto/crypto/provider/EvpSignatureRaw.java
+++ b/src/com/amazon/corretto/crypto/provider/EvpSignatureRaw.java
@@ -40,6 +40,7 @@ class EvpSignatureRaw extends EvpSignatureBase {
   @Override
   protected byte[] engineSign() throws SignatureException {
     try {
+      ensureInitialized(true);
       return key_.use(
           ptr -> signRaw(ptr, paddingType_, 0, 0, buffer.getDataBuffer(), 0, buffer.size()));
     } finally {
@@ -56,6 +57,8 @@ class EvpSignatureRaw extends EvpSignatureBase {
   protected boolean engineVerify(final byte[] sigBytes, final int offset, final int length)
       throws SignatureException {
     try {
+      ensureInitialized(false);
+      sniffTest(sigBytes, offset, length);
       return key_.use(
           ptr ->
               verifyRaw(

--- a/tst/com/amazon/corretto/crypto/provider/test/EvpSignatureSpecificTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/EvpSignatureSpecificTest.java
@@ -639,36 +639,6 @@ public final class EvpSignatureSpecificTest {
   }
 
   /**
-   * For better compatibility with the JDK, we want to throw SignatureException if the length of the
-   * signature is wrong.
-   */
-  @Test
-  public void rsaSignatureWrongLength() throws Exception {
-    final Signature signer = Signature.getInstance("SHA256withRSA", NATIVE_PROVIDER);
-    signer.initSign(RSA_PAIR.getPrivate());
-    signer.update(MESSAGE);
-    final byte[] validSignature = signer.sign();
-
-    // Sanity check
-    signer.initVerify(RSA_PAIR.getPublic());
-    signer.update(MESSAGE);
-    assertTrue(signer.verify(validSignature));
-
-    // Too long throws an exception
-    final byte[] longSig = Arrays.copyOf(validSignature, validSignature.length + 1);
-    longSig[longSig.length - 1] = 1;
-    signer.initVerify(RSA_PAIR.getPublic());
-    signer.update(MESSAGE);
-    assertThrows(SignatureException.class, () -> signer.verify(longSig));
-
-    // Too short throws an exception
-    final byte[] shortSig = Arrays.copyOf(validSignature, validSignature.length - 1);
-    signer.initVerify(RSA_PAIR.getPublic());
-    signer.update(MESSAGE);
-    assertThrows(SignatureException.class, () -> signer.verify(shortSig));
-  }
-
-  /**
    * This test iterates over every implemented algorithm and ensures that it is compatible with the
    * equivalent BouncyCastle implementation. It doesn't check negative cases as the more detailed
    * tests cover that for algorithm families.

--- a/tst/com/amazon/corretto/crypto/provider/test/EvpSignatureTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/EvpSignatureTest.java
@@ -434,14 +434,18 @@ public class EvpSignatureTest {
   @MethodSource("params")
   public void verifyTruncatedSignature(TestParams params) throws GeneralSecurityException {
     params.verifier.update(params.message);
-    byte[] badSignature = Arrays.copyOf(params.goodSignature, params.goodSignature.length - 1);
-    // Truncated signatures will sometime return false and sometimes throw an exception. Both are
-    // acceptable
-    try {
-      assertFalse(params.verifier.verify(badSignature));
-    } catch (final SignatureException ex) {
-      // We allow truncated signatures to throw
-    }
+    final byte[] badSignature = Arrays.copyOf(params.goodSignature, params.goodSignature.length - 1);
+    // Truncated signatures always throw now.
+    assertThrows(SignatureException.class, () -> params.verifier.verify(badSignature));
+  }
+
+  @ParameterizedTest
+  @MethodSource("params")
+  public void verifyExtendedSignature(TestParams params) throws GeneralSecurityException {
+    params.verifier.update(params.message);
+    final byte[] badSignature = Arrays.copyOf(params.goodSignature, params.goodSignature.length + 1);
+    // Extended signatures always throw now.
+    assertThrows(SignatureException.class, () -> params.verifier.verify(badSignature));
   }
 
   // Modification of body of the message only works

--- a/tst/com/amazon/corretto/crypto/provider/test/EvpSignatureTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/EvpSignatureTest.java
@@ -434,7 +434,8 @@ public class EvpSignatureTest {
   @MethodSource("params")
   public void verifyTruncatedSignature(TestParams params) throws GeneralSecurityException {
     params.verifier.update(params.message);
-    final byte[] badSignature = Arrays.copyOf(params.goodSignature, params.goodSignature.length - 1);
+    final byte[] badSignature =
+        Arrays.copyOf(params.goodSignature, params.goodSignature.length - 1);
     // Truncated signatures always throw now.
     assertThrows(SignatureException.class, () -> params.verifier.verify(badSignature));
   }
@@ -443,7 +444,8 @@ public class EvpSignatureTest {
   @MethodSource("params")
   public void verifyExtendedSignature(TestParams params) throws GeneralSecurityException {
     params.verifier.update(params.message);
-    final byte[] badSignature = Arrays.copyOf(params.goodSignature, params.goodSignature.length + 1);
+    final byte[] badSignature =
+        Arrays.copyOf(params.goodSignature, params.goodSignature.length + 1);
     // Extended signatures always throw now.
     assertThrows(SignatureException.class, () -> params.verifier.verify(badSignature));
   }


### PR DESCRIPTION
*Description of changes:*

The JCA does not fully specify when SignatureException should be thrown but the ResetAfterException test from OpenJDK indicates that SignatureException should be thrown when [validating a too-short signature](https://github.com/openjdk/jdk/blob/101bf2290da5735fd9624ab647a8183c2c21f22d/test/jdk/java/security/Signature/ResetAfterException.java#L107-L109). This PR modifies ACCP to throw an exception in this case and to always properly reset when exceptions are thrown.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
