### PR TITLE
Round RSA key sizes up when generating

### DIFF
--- a/DIFFERENCES.md
+++ b/DIFFERENCES.md
@@ -40,6 +40,14 @@ ACCP cannot make any promises that its default key sizes match the defaults of *
 Because no providers have guarantees around the uninitialized behavior of `KeyPairGenerators` it is generally fragile for your application to use a `KeyPairGenerator` without initialization.
 For this reason, even if you don't use ACCP, we recommend that you always call the [KeyPairGenerator.initialize(AlgorithmParameterSpec params)](https://docs.oracle.com/javase/8/docs/api/java/security/KeyPairGenerator.html#initialize-java.security.spec.AlgorithmParameterSpec-) prior to generating a key pair.
 
+## Supported RSA key sizes for generation.
+Aws-lc (our underlying cryptographic implementation) does not support generating arbitrary RSA key sizes.
+Specifically, it requires that [bit-lengths are a multiple of 128](https://github.com/aws/aws-lc/blob/25260d785f6e2eaf3c5f5dce83cf92c272f0a8b1/crypto/fipsmodule/rsa/rsa_impl.c#L1168-L1171).
+For better compatibility with applications, when in *non-FIPS mode*, ACCP will round bit-lengths up to the nearest multiple of 128.
+This way we will not throw exceptions at runtime and will give our callers at least as much security as requested.
+This is different from the default JDK provider which will attempt to generate a key of the exact requested bit-length.
+In FIPS mode will will only return keys of the exact requested length.
+
 ## Elliptic Curve KeyPairGeneration by curve size
 Neither the JCE nor the default OpenJDK provider for Elliptic Curve Cryptography (SunEC) specify the effect of calling `KeyPairGenerator.initialize(int keysize)` with an arbitrary value.
 This behavior is fully specified only for values of 192, 224, 256, 384, and 521.

--- a/csrc/rsa_gen.cpp
+++ b/csrc/rsa_gen.cpp
@@ -35,7 +35,7 @@ JNIEXPORT jlong JNICALL Java_com_amazon_corretto_crypto_provider_RsaGen_generate
             // round up. We only do this in the non-FIPS branch because in FIPS mode we want to do
             // exactly what the application requests.
             if (bits % 128 != 0) {
-                bits += 128;
+                bits += 128 - (bits % 128);
             }
 
             BigNumObj bne;

--- a/csrc/rsa_gen.cpp
+++ b/csrc/rsa_gen.cpp
@@ -21,6 +21,14 @@ JNIEXPORT jlong JNICALL Java_com_amazon_corretto_crypto_provider_RsaGen_generate
     try {
         raii_env env(pEnv);
 
+        // AWS-LC requires that the bitlength be a multiple of 128 and will round down.
+        // We want to guarantee that we return a key of at least the requested strength and so must
+        // round up.
+        jint rounded_bits = bits & ~127;
+        if (rounded_bits < bits) {
+            bits += 128;
+        }
+
         if (FIPS_mode() == 1) {
             // RSA_generate_key_fips performs extra checks so there is no need
             // to run post generation checks. This API generates keys with

--- a/tst/com/amazon/corretto/crypto/provider/test/RsaGenTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/RsaGenTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 import com.amazon.corretto.crypto.provider.AmazonCorrettoCryptoProvider;
 import com.amazon.corretto.crypto.provider.RuntimeCryptoException;
@@ -129,6 +130,23 @@ public class RsaGenTest {
     final RSAPublicKey pubKey = (RSAPublicKey) keyPair.getPublic();
     final RSAPrivateCrtKey privKey = (RSAPrivateCrtKey) keyPair.getPrivate();
     assertEquals(3072, pubKey.getModulus().bitLength());
+    assertEquals(RSAKeyGenParameterSpec.F4, pubKey.getPublicExponent());
+    assertConsistency(pubKey, privKey);
+  }
+
+  // We want to ensure that when we ask for a strange keylength we get something of at least that
+  // strength.
+  @Test
+  public void test3073() throws GeneralSecurityException {
+    assumeFalse(
+        AmazonCorrettoCryptoProvider.INSTANCE.isFips(),
+        "Keysize of 3073 is not supported with FIPS");
+    final KeyPairGenerator generator = getGenerator();
+    generator.initialize(3073);
+    final KeyPair keyPair = generator.generateKeyPair();
+    final RSAPublicKey pubKey = (RSAPublicKey) keyPair.getPublic();
+    final RSAPrivateCrtKey privKey = (RSAPrivateCrtKey) keyPair.getPrivate();
+    assertTrue(3073 <= pubKey.getModulus().bitLength());
     assertEquals(RSAKeyGenParameterSpec.F4, pubKey.getPublicExponent());
     assertConsistency(pubKey, privKey);
   }


### PR DESCRIPTION
AWS-LC will only generate RSA keys with bit-lengths that are multiples of 128 and will round the requested bit-length down to meet that [requirement](https://github.com/aws/aws-lc/blob/25260d785f6e2eaf3c5f5dce83cf92c272f0a8b1/crypto/fipsmodule/rsa/rsa_impl.c#L1168-L1171). This means that when ACCP is used to generate an RSA key, requests such as KeyPairGenerator.initialize(2049) will result in smaller than requested keys. In general, we should try to always provide at least as much security as requested and so rounding down is unexpected.

For example,the above behavior causes tests such as the [DefaultSignatureAlgorithm test from the OpenJDK](https://github.com/openjdk/jdk/blob/dfacda488bfbe2e11e8d607a6d08527710286982/test/jdk/sun/security/tools/keytool/fakegen/DefaultSignatureAlgorithm.java#L51) to fail. It fails because it is checking for behavior differences for keys larger than a threshold (such as 3072) where the default signature algorithm changes from using SHA256 to SHA384. With the current version of ACCP, requesting a 3073 bit key gets a 3072 key (and thus will use SHA256) so the test fails. By changing the logic to rounding up, requesting a 3073 bit key gets a 3200 bit key (which will trigger use of SHA384) and the test passes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
