### PR TITLE
Register ACCP's SecureRandom in FIPS mode for the example code

### DIFF
--- a/examples/gradle-kt-dsl/lib/build.gradle.kts
+++ b/examples/gradle-kt-dsl/lib/build.gradle.kts
@@ -45,6 +45,7 @@ dependencies {
 }
 
 tasks.withType<Test> {
+    systemProperties(System.getProperties().toMap() as Map<String, Object>)
     this.testLogging {
         this.showStandardStreams = true
     }

--- a/examples/gradle-kt-dsl/run-tests.sh
+++ b/examples/gradle-kt-dsl/run-tests.sh
@@ -7,7 +7,7 @@ DELAY_BETWEEN_RETRIES=10
 for i in $(seq 1 ${NUMBER_OF_RETRIES})
 do
     echo "Iteration ${i}"
-    ./gradlew lib:test && ./gradlew -Pfips lib:test
+    ./gradlew lib:test && ./gradlew -Pfips -Dcom.amazon.corretto.crypto.provider.registerSecureRandom=true lib:test
     result=$?
     if [[ $result -eq 0 ]]
     then


### PR DESCRIPTION
*Description of changes:*

Register ACCP's SecureRandom in FIPS mode for the example code. In FIPS mode, by default, the SecureRandom is not registered and a system property needs to be set to have it registered.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
