### PR TITLE
Allow users to control the release of EVP context for AES-GCM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -666,6 +666,24 @@ add_custom_target(check-junit-SecurityManager
 
     DEPENDS accp-jar tests-jar)
 
+add_custom_target(check-junit-AesGcmLazy
+    COMMAND ${TEST_JAVA_EXECUTABLE}
+        -Dcom.amazon.corretto.crypto.provider.nativeContextReleaseStrategy=LAZY
+        ${TEST_RUNNER_ARGUMENTS}
+        --select-class=com.amazon.corretto.crypto.provider.test.AesTest
+        --select-class=com.amazon.corretto.crypto.provider.test.AesGcmKatTest
+
+    DEPENDS accp-jar tests-jar)
+
+add_custom_target(check-junit-AesGcmEager
+    COMMAND ${TEST_JAVA_EXECUTABLE}
+        -Dcom.amazon.corretto.crypto.provider.nativeContextReleaseStrategy=EAGER
+        ${TEST_RUNNER_ARGUMENTS}
+        --select-class=com.amazon.corretto.crypto.provider.test.AesTest
+        --select-class=com.amazon.corretto.crypto.provider.test.AesGcmKatTest
+
+    DEPENDS accp-jar tests-jar)
+
 add_custom_target(check-junit-extra-checks
     COMMAND ${TEST_JAVA_EXECUTABLE}
         -Dcom.amazon.corretto.crypto.provider.extrachecks=ALL
@@ -758,7 +776,15 @@ add_custom_target(check-install-via-properties-with-debug
     DEPENDS accp-jar tests-jar)
 
 add_custom_target(check
-    DEPENDS check-recursive-init check-install-via-properties check-install-via-properties-with-debug check-junit check-junit-SecurityManager check-external-lib check-libaccp-rpath)
+    DEPENDS check-recursive-init
+    check-install-via-properties
+    check-install-via-properties-with-debug
+    check-junit
+    check-junit-SecurityManager
+    check-external-lib
+    check-libaccp-rpath
+    check-junit-AesGcmLazy
+    check-junit-AesGcmEager)
 
 if(ENABLE_NATIVE_TEST_HOOKS)
     add_custom_target(check-keyutils

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -6,6 +6,9 @@ The benchmarks can use locally built ACCP or published ACCP.
 The `lib:jmh` Gradle task runs the benchmarks and generates reports in JSON and HTML.
 The reports are saved under `lib/build/results/jmh`.
 
+* `-PincludeBenchmark="INCLUDE_BENCHMARK"` would only run the specified matching benchmarks.
+  * `INCLUDE_BENCHMARK` is a regular expression. For example, `CipherReuse|AesKwp` runs these two sets of benchmarks only.
+
 ### Benchmarking published ACCP to Maven
 
 ```bash

--- a/benchmarks/lib/build.gradle.kts
+++ b/benchmarks/lib/build.gradle.kts
@@ -1,6 +1,8 @@
 val accpVersion: String? by project
 val accpLocalJar: String by project
 val fips: Boolean by project
+val includeBenchmark: String by project
+val nativeContextReleaseStrategy: String by project
 
 plugins {
     `java-library`
@@ -46,7 +48,9 @@ java {
 }
 
 jmh {
-    // includes.add("AesXts") // can be used to run a subset of benchmarks
+    if (project.hasProperty("includeBenchmark")) {
+        includes.add(includeBenchmark)
+    }
     fork.set(1)
     benchmarkMode.add("thrpt")
     threads.set(1)
@@ -59,6 +63,9 @@ jmh {
     duplicateClassesStrategy.set(DuplicatesStrategy.WARN)
     jvmArgs.add("-DversionStr=${accpVersion}")
     jvmArgs.add("-Dcom.amazon.corretto.crypto.provider.registerSecureRandom=true")
+    if (project.hasProperty("nativeContextReleaseStrategy")) {
+        jvmArgs.add("-Dcom.amazon.corretto.crypto.provider.nativeContextReleaseStrategy=${nativeContextReleaseStrategy}")
+    }
 }
 
 jmhReport {

--- a/benchmarks/lib/src/jmh/java/com/amazon/corretto/crypto/provider/benchmarks/CipherReuse.java
+++ b/benchmarks/lib/src/jmh/java/com/amazon/corretto/crypto/provider/benchmarks/CipherReuse.java
@@ -1,0 +1,75 @@
+package com.amazon.corretto.crypto.provider.benchmarks;
+
+import com.amazon.corretto.crypto.provider.AmazonCorrettoCryptoProvider;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
+
+import javax.crypto.Cipher;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.util.Random;
+
+@State(Scope.Thread)
+public class CipherReuse {
+    private final static String AES = "AES";
+    private final static String AES_GCM = "AES/GCM/NoPadding";
+    Cipher shared;
+    SecretKeySpec key;
+    Random random = new Random();
+    byte[] iv = new byte[12];
+    byte[] input = new byte[1000];
+    byte[] keyb = new byte[32];
+    byte[] aad = new byte[100];
+
+    @Param({"true", "false"})
+    private boolean newKey;
+
+    @Setup
+    public void setup() throws Exception {
+        shared = getAesGcmCipherFromAccp();
+        random.nextBytes(keyb);
+        key = new SecretKeySpec(keyb, AES);
+        random.nextBytes(input);
+        random.nextBytes(aad);
+    }
+
+    @Benchmark
+    public void newInstance(Blackhole blackhole) throws Exception {
+        blackhole.consume(encryptDecrypt(getAesGcmCipherFromAccp()));
+    }
+
+    @Benchmark
+    public void reuse(Blackhole blackhole) throws Exception {
+        blackhole.consume(encryptDecrypt(shared));
+    }
+
+    byte[] encryptDecrypt(final Cipher cipher) throws Exception {
+        iv[0]++;
+        final SecretKey sk;
+        if (newKey) {
+            keyb[0]++;
+            sk = new SecretKeySpec(keyb, AES);
+        } else {
+            sk = key;
+        }
+        cipher.init(Cipher.ENCRYPT_MODE, sk, new GCMParameterSpec(128, iv));
+        cipher.updateAAD(aad);
+        final byte[] cipherText = cipher.doFinal(input);
+        cipher.init(Cipher.DECRYPT_MODE, sk, new GCMParameterSpec(128, iv));
+        cipher.updateAAD(aad);
+        return cipher.doFinal(cipherText);
+    }
+
+    private Cipher getAesGcmCipherFromAccp() {
+        try {
+            return Cipher.getInstance(AES_GCM, AmazonCorrettoCryptoProvider.INSTANCE);
+        } catch (final Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/csrc/aes_gcm.cpp
+++ b/csrc/aes_gcm.cpp
@@ -28,7 +28,7 @@
 
 using namespace AmazonCorrettoCryptoProvider;
 
-static void initContext(raii_env& env, raii_cipher_ctx& ctx, jint opMode, java_buffer key, java_buffer iv)
+static void initContext(raii_env& env, raii_cipher_ctx& ctx, jint opMode, java_buffer& key, java_buffer& iv)
 {
     const EVP_CIPHER* cipher;
 
@@ -63,6 +63,43 @@ static void initContext(raii_env& env, raii_cipher_ctx& ctx, jint opMode, java_b
 
     if (unlikely(!EVP_CipherInit_ex(ctx, NULL, NULL, keybuf, ivBorrow.data(), opMode))) {
         throw java_ex::from_openssl(EX_RUNTIME_CRYPTO, "Final cipher init failed");
+    }
+}
+
+static void initializeContext(raii_env& env,
+    jlong ctxPtr,
+    raii_cipher_ctx& ctx,
+    jboolean sameKey,
+    jbyteArray keyArray,
+    jbyteArray ivArray,
+    int enc)
+{
+    // There are three possible cases:
+    // 1) there is no context: in this case, we need to create a context and initialize both key and iv
+    // 2) there is a context, and the key is the same: in this case, we borrow the context and only initialize iv
+    // 3) there is a context, but the key is not the same: in this case, we borrow the context and intialize it with
+    // both key and iv
+    if (ctxPtr == 0) {
+        // Case 1
+        ctx.init();
+        EVP_CIPHER_CTX_init(ctx);
+    } else {
+        // Case 2 or 3
+        ctx.borrow(reinterpret_cast<EVP_CIPHER_CTX*>(ctxPtr));
+    }
+
+    java_buffer iv = java_buffer::from_array(env, ivArray);
+
+    if (ctxPtr != 0 && sameKey == JNI_TRUE) {
+        // Case 2
+        jni_borrow ivBorrow(env, iv, "iv");
+        if (unlikely(!EVP_CipherInit_ex(ctx, NULL, NULL, NULL, ivBorrow.data(), enc))) {
+            throw java_ex::from_openssl(EX_RUNTIME_CRYPTO, "Failed to set IV");
+        }
+    } else {
+        // Case 1 or 3
+        java_buffer key = java_buffer::from_array(env, keyArray);
+        initContext(env, ctx, enc, key, iv);
     }
 }
 
@@ -145,6 +182,7 @@ static int cryptFinish(raii_env& env, int opMode, java_buffer resultBuf, unsigne
 JNIEXPORT int JNICALL Java_com_amazon_corretto_crypto_provider_AesGcmSpi_oneShotEncrypt(JNIEnv* pEnv,
     jclass,
     jlong ctxPtr,
+    jboolean sameKey,
     jlongArray ctxOut,
     jbyteArray inputArray,
     jint inoffset,
@@ -157,25 +195,12 @@ JNIEXPORT int JNICALL Java_com_amazon_corretto_crypto_provider_AesGcmSpi_oneShot
 {
     try {
         raii_env env(pEnv);
+        raii_cipher_ctx ctx;
+
+        initializeContext(env, ctxPtr, ctx, sameKey, keyArray, ivArray, NATIVE_MODE_ENCRYPT);
 
         java_buffer input = java_buffer::from_array(env, inputArray, inoffset, inlen);
         java_buffer result = java_buffer::from_array(env, resultArray, resultOffset);
-        java_buffer iv = java_buffer::from_array(env, ivArray);
-
-        raii_cipher_ctx ctx;
-        if (ctxPtr) {
-            ctx.borrow(reinterpret_cast<EVP_CIPHER_CTX*>(ctxPtr));
-
-            jni_borrow ivBorrow(env, iv, "iv");
-            if (unlikely(!EVP_CipherInit_ex(ctx, NULL, NULL, NULL, ivBorrow.data(), NATIVE_MODE_ENCRYPT))) {
-                throw java_ex::from_openssl(EX_RUNTIME_CRYPTO, "Failed to set IV");
-            }
-        } else {
-            ctx.init();
-            EVP_CIPHER_CTX_init(ctx);
-            java_buffer key = java_buffer::from_array(env, keyArray);
-            initContext(env, ctx, NATIVE_MODE_ENCRYPT, key, iv);
-        }
 
         int outoffset = updateLoop(env, result, input, ctx);
         if (outoffset < 0)
@@ -197,41 +222,16 @@ JNIEXPORT int JNICALL Java_com_amazon_corretto_crypto_provider_AesGcmSpi_oneShot
     }
 }
 
-JNIEXPORT void JNICALL Java_com_amazon_corretto_crypto_provider_AesGcmSpi_encryptInit__J_3B(
-    JNIEnv* pEnv, jclass, jlong ctxPtr, jbyteArray ivArray)
-{
-    try {
-        raii_env env(pEnv);
-
-        if (!ctxPtr)
-            throw java_ex(EX_NPE, "Null context");
-
-        EVP_CIPHER_CTX* ctx = reinterpret_cast<EVP_CIPHER_CTX*>(ctxPtr);
-        java_buffer iv = java_buffer::from_array(env, ivArray);
-
-        jni_borrow ivBorrow(env, iv, "iv");
-        if (unlikely(!EVP_CipherInit_ex(ctx, NULL, NULL, NULL, ivBorrow.data(), NATIVE_MODE_ENCRYPT))) {
-            throw java_ex::from_openssl(EX_RUNTIME_CRYPTO, "Failed to set IV");
-        }
-    } catch (java_ex& ex) {
-        ex.throw_to_java(pEnv);
-    }
-}
-
-JNIEXPORT jlong JNICALL Java_com_amazon_corretto_crypto_provider_AesGcmSpi_encryptInit___3B_3B(
-    JNIEnv* pEnv, jclass, jbyteArray keyArray, jbyteArray ivArray)
+JNIEXPORT jlong JNICALL Java_com_amazon_corretto_crypto_provider_AesGcmSpi_encryptInit(
+    JNIEnv* pEnv, jclass, jlong ctxPtr, jboolean sameKey, jbyteArray keyArray, jbyteArray ivArray)
 {
     raii_cipher_ctx ctx;
-    ctx.init();
-    EVP_CIPHER_CTX_init(ctx);
 
     try {
         raii_env env(pEnv);
+        raii_cipher_ctx ctx;
 
-        java_buffer key = java_buffer::from_array(env, keyArray);
-        java_buffer iv = java_buffer::from_array(env, ivArray);
-
-        initContext(env, ctx, NATIVE_MODE_ENCRYPT, key, iv);
+        initializeContext(env, ctxPtr, ctx, sameKey, keyArray, ivArray, NATIVE_MODE_ENCRYPT);
 
         return (jlong)ctx.take();
     } catch (java_ex& ex) {
@@ -348,6 +348,7 @@ JNIEXPORT jint JNICALL Java_com_amazon_corretto_crypto_provider_AesGcmSpi_encryp
 JNIEXPORT jint JNICALL Java_com_amazon_corretto_crypto_provider_AesGcmSpi_oneShotDecrypt(JNIEnv* pEnv,
     jclass,
     jlong ctxPtr,
+    jboolean sameKey,
     jlongArray ctxOut,
     jbyteArray inputArray,
     jint inoffset,
@@ -362,25 +363,12 @@ JNIEXPORT jint JNICALL Java_com_amazon_corretto_crypto_provider_AesGcmSpi_oneSho
 {
     try {
         raii_env env(pEnv);
+        raii_cipher_ctx ctx;
+
+        initializeContext(env, ctxPtr, ctx, sameKey, keyArray, ivArray, NATIVE_MODE_DECRYPT);
 
         java_buffer input = java_buffer::from_array(env, inputArray, inoffset, inlen);
         java_buffer result = java_buffer::from_array(env, resultArray, resultOffset);
-        java_buffer iv = java_buffer::from_array(env, ivArray);
-
-        raii_cipher_ctx ctx;
-        if (ctxPtr) {
-            ctx.borrow(reinterpret_cast<EVP_CIPHER_CTX*>(ctxPtr));
-
-            jni_borrow ivBorrow(env, iv, "iv");
-            if (unlikely(!EVP_CipherInit_ex(ctx, NULL, NULL, NULL, ivBorrow.data(), NATIVE_MODE_DECRYPT))) {
-                throw java_ex::from_openssl(EX_RUNTIME_CRYPTO, "Failed to set IV");
-            }
-        } else {
-            ctx.init();
-            EVP_CIPHER_CTX_init(ctx);
-            java_buffer key = java_buffer::from_array(env, keyArray);
-            initContext(env, ctx, NATIVE_MODE_DECRYPT, key, iv);
-        }
 
         // Decrypt mode: Set the tag before we decrypt
         if (unlikely(tagLen > 16 || tagLen < 0)) {

--- a/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
+++ b/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
@@ -38,6 +38,7 @@ public final class AmazonCorrettoCryptoProvider extends java.security.Provider {
   private static final String PROPERTY_CACHE_SELF_TEST_RESULTS = "cacheselftestresults";
   private static final String PROPERTY_REGISTER_EC_PARAMS = "registerEcParams";
   private static final String PROPERTY_REGISTER_SECURE_RANDOM = "registerSecureRandom";
+
   private static final long serialVersionUID = 1L;
 
   public static final AmazonCorrettoCryptoProvider INSTANCE;
@@ -48,6 +49,7 @@ public final class AmazonCorrettoCryptoProvider extends java.security.Provider {
   private final boolean relyOnCachedSelfTestResults;
   private final boolean shouldRegisterEcParams;
   private final boolean shouldRegisterSecureRandom;
+  private final Utils.NativeContextReleaseStrategy nativeContextReleaseStrategy;
 
   private transient SelfTestSuite selfTestSuite = new SelfTestSuite();
 
@@ -391,6 +393,8 @@ public final class AmazonCorrettoCryptoProvider extends java.security.Provider {
     this.shouldRegisterSecureRandom =
         Utils.getBooleanProperty(PROPERTY_REGISTER_SECURE_RANDOM, !isFips());
 
+    this.nativeContextReleaseStrategy = Utils.getNativeContextReleaseStrategyProperty();
+
     Utils.optionsFromProperty(ExtraCheck.class, extraChecks, "extrachecks");
 
     if (!Loader.IS_AVAILABLE) {
@@ -405,6 +409,10 @@ public final class AmazonCorrettoCryptoProvider extends java.security.Provider {
 
     buildServiceMap();
     initializeSelfTests();
+  }
+
+  Utils.NativeContextReleaseStrategy getNativeContextReleaseStrategy() {
+    return nativeContextReleaseStrategy;
   }
 
   private synchronized void initializeSelfTests() {

--- a/src/com/amazon/corretto/crypto/provider/Utils.java
+++ b/src/com/amazon/corretto/crypto/provider/Utils.java
@@ -28,6 +28,9 @@ import javax.crypto.spec.SecretKeySpec;
 
 /** Miscellaneous utility methods. */
 final class Utils {
+  private static final String PROPERTY_NATIVE_CONTEXT_RELEASE_STRATEGY =
+      "nativeContextReleaseStrategy";
+
   private Utils() {
     // Prevent instantiation
   }
@@ -571,5 +574,32 @@ final class Utils {
 
   static String requireNonNullString(final String s, final String message) {
     return requireNonNull(s, message);
+  }
+
+  enum NativeContextReleaseStrategy {
+    HYBRID,
+    LAZY,
+    EAGER
+  }
+
+  private static NativeContextReleaseStrategy getNativeContextReleaseStrategyProperty(
+      final String propertyName) {
+    final String propertyStr = Loader.getProperty(propertyName, "HYBRID").toUpperCase();
+    if (propertyStr.equals("LAZY")) {
+      return NativeContextReleaseStrategy.LAZY;
+    }
+    if (propertyStr.equals("EAGER")) {
+      return NativeContextReleaseStrategy.EAGER;
+    }
+    if (!propertyStr.equals("HYBRID")) {
+      LOG.warning(
+          String.format(
+              "Valid values for %s are HYBRID, LAZY, EAGER, with HYBRID as default", propertyName));
+    }
+    return NativeContextReleaseStrategy.HYBRID;
+  }
+
+  static NativeContextReleaseStrategy getNativeContextReleaseStrategyProperty() {
+    return getNativeContextReleaseStrategyProperty(PROPERTY_NATIVE_CONTEXT_RELEASE_STRATEGY);
   }
 }

--- a/tst/com/amazon/corretto/crypto/provider/test/UtilsTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/UtilsTest.java
@@ -209,6 +209,24 @@ public class UtilsTest {
   }
 
   @Test
+  public void getNativeContextReleaseStrategyPropertyTests() throws Throwable {
+    getNativeContextReleaseStrategyPropertyTest("accp.native.property1", "HYBRID", "HYBRID");
+    getNativeContextReleaseStrategyPropertyTest("accp.native.property2", "dummy", "HYBRID");
+    getNativeContextReleaseStrategyPropertyTest("accp.native.property3", "LAZY", "LAZY");
+    getNativeContextReleaseStrategyPropertyTest("accp.native.property4", "EAGER", "EAGER");
+  }
+
+  private static void getNativeContextReleaseStrategyPropertyTest(
+      final String propertyName, final String value, final String expectedValue) throws Throwable {
+    final String fullPropertyName = TestUtil.NATIVE_PROVIDER_PACKAGE + "." + propertyName;
+    System.setProperty(fullPropertyName, value);
+    assertEquals(
+        expectedValue,
+        (sneakyInvoke(UTILS_CLASS, "getNativeContextReleaseStrategyProperty", propertyName)
+            .toString()));
+  }
+
+  @Test
   public void givenNull_whenCheckArrayLimits_expectException() {
     assertThrows(
         IllegalArgumentException.class,


### PR DESCRIPTION
*Description of changes:*

This change introduces a system property that allows one to control when an EVP_CIPHER_CTX (native context for encryption) is released. For use cases when the same Cipher object is used for multiple encryption/decryption operations, this can result in improved performance since it avoids allocation and release of the native context while the Cipher object is not garbage collected.

There are three strategies for releasing the context: 1) `Hybrid`, 2) `Eager`, 3) `Lazy`.

* `Hybrid`: this is the existing strategy and it's introduced so that existing customers would not be affected. In this strategy, the context is released eagerly, unless it is used with the same key. Benchmark `CipherReuse.reuse` when `newKey` is `false` shows that the existing optimizations are preserved for customers that use the default setting.
* `Eager`: in this strategy, the context is released as soon as possible. Based on `CipherReuse.newInstance` benchmarks, customers that use a fresh instance of `Cipher` class for their operations, could experience 30% performance improvement when `Eager` strategy is used.
* `Lazy`: the context object is preserved while the `Cipher` object is not garbage collected. Customers caching Cipher objects. Compared to default `Hybrid` strategy, could experience 16% performance improvement even if they use different keys for with the same `Cipher` class; however, using the same key, this strategy and `Hybrid` perform the same.

Here is benchmark results:

ACCP 2.3.2 (the latest release of ACCP on Maven)

```
#../gradlew -PaccpVersion="2.3.2" -PincludeBenchmark="CipherReuse" lib:jmh

Benchmark                (newKey)   Mode  Cnt       Score       Error  Units
CipherReuse.newInstance      true  thrpt    5  195961.858 ± 26482.726  ops/s
CipherReuse.newInstance     false  thrpt    5  194516.879 ± 31070.067  ops/s
CipherReuse.reuse            true  thrpt    5  305481.372 ± 13363.712  ops/s
CipherReuse.reuse           false  thrpt    5  440410.914 ± 18570.172  ops/s
```

HYBRID

```
#./gradlew -PaccpLocalJar="../../build/cmake/AmazonCorrettoCryptoProvider.jar" -PnativeContextReleaseStrategy="HYBRID" -PincludeBenchmark="CipherReuse" lib:jmh

Benchmark                (newKey)   Mode  Cnt       Score       Error  Units
CipherReuse.newInstance      true  thrpt    5  191908.943 ± 26892.090  ops/s
CipherReuse.newInstance     false  thrpt    5  197180.321 ± 29013.380  ops/s
CipherReuse.reuse            true  thrpt    5  323944.919 ± 11095.834  ops/s
CipherReuse.reuse           false  thrpt    5  444121.750 ±  9679.539  ops/s
```

EAGER

```
#./gradlew -PaccpLocalJar="../../build/cmake/AmazonCorrettoCryptoProvider.jar" -PnativeContextReleaseStrategy="EAGER" -PincludeBenchmark="CipherReuse" lib:jmh

Benchmark                (newKey)   Mode  Cnt       Score       Error  Units
CipherReuse.newInstance      true  thrpt    5  275440.808 ±  9990.183  ops/s
CipherReuse.newInstance     false  thrpt    5  275176.586 ± 10058.817  ops/s
CipherReuse.reuse            true  thrpt    5  327901.459 ± 12479.909  ops/s
CipherReuse.reuse           false  thrpt    5  324376.765 ± 18051.911  ops/s
```

LAZY

```
#./gradlew -PaccpLocalJar="../../build/cmake/AmazonCorrettoCryptoProvider.jar" -PnativeContextReleaseStrategy="LAZY" -PincludeBenchmark="CipherReuse" lib:jmh

Benchmark                (newKey)   Mode  Cnt       Score       Error  Units
CipherReuse.newInstance      true  thrpt    5  223333.903 ± 44229.461  ops/s
CipherReuse.newInstance     false  thrpt    5  221117.187 ± 34093.029  ops/s
CipherReuse.reuse            true  thrpt    5  382687.274 ± 18950.889  ops/s
CipherReuse.reuse           false  thrpt    5  440212.922 ± 11446.041  ops/s
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
