### PR TITLE
Apply Java formatter to JML source

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,17 +44,7 @@ def getDescriptionForPom(isFips) {
 spotless {
   java {
     target 'src/**/*.java', 'tst/**/*.java'
-
-    // Exclude files which contain JML syntax since they conflict with Google Formatter rules
-    def jml_syntax_excludes = [
-        'src/com/amazon/corretto/crypto/provider/AccessibleByteArrayOutputStream.java',
-        'src/com/amazon/corretto/crypto/provider/InputBuffer.java',
-        'src/com/amazon/corretto/crypto/provider/Janitor.java'
-    ]
-    targetExclude(*jml_syntax_excludes)
-
     licenseHeaderFile 'build-tools/license-headers/LicenseHeader.java'
-
     googleJavaFormat().reflowLongStrings()
   }
 

--- a/src/com/amazon/corretto/crypto/provider/AccessibleByteArrayOutputStream.java
+++ b/src/com/amazon/corretto/crypto/provider/AccessibleByteArrayOutputStream.java
@@ -1,6 +1,5 @@
 // Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-
 package com.amazon.corretto.crypto.provider;
 
 import java.io.OutputStream;
@@ -8,93 +7,98 @@ import java.nio.ByteBuffer;
 import java.util.Arrays;
 
 class AccessibleByteArrayOutputStream extends OutputStream implements Cloneable {
-    private final int limit;
-    private byte[] buf;
-    private int count;
+  private final int limit;
+  private byte[] buf;
+  private int count;
 
-    AccessibleByteArrayOutputStream() {
-        this(32, Integer.MAX_VALUE);
+  // getter function for count
+  // Add 10 to it before returning
+
+  AccessibleByteArrayOutputStream() {
+    this(32, Integer.MAX_VALUE);
+  }
+
+  AccessibleByteArrayOutputStream(final int capacity, final int limit) {
+    if (limit < 0) {
+      throw new IllegalArgumentException("Limit must be non-negative");
     }
-
-    AccessibleByteArrayOutputStream(final int capacity, final int limit) {
-        if (limit < 0) {
-            throw new IllegalArgumentException("Limit must be non-negative");
-        }
-        if (capacity < 0 || capacity > limit) {
-            throw new IllegalArgumentException("Capacity must be non-negative and less than limit");
-        }
-        buf = capacity == 0 ? Utils.EMPTY_ARRAY : new byte[capacity];
-        this.limit = limit;
-        count = 0;
+    if (capacity < 0 || capacity > limit) {
+      throw new IllegalArgumentException("Capacity must be non-negative and less than limit");
     }
+    buf = capacity == 0 ? Utils.EMPTY_ARRAY : new byte[capacity];
+    this.limit = limit;
+    count = 0;
+  }
 
-    @Override
-    public AccessibleByteArrayOutputStream clone() {
-        try {
-            final AccessibleByteArrayOutputStream cloned = (AccessibleByteArrayOutputStream) super.clone();
-            cloned.buf = buf.clone();
-            return cloned;
-        } catch (final CloneNotSupportedException ex) {
-            throw new RuntimeCryptoException("Unexpected exception", ex);
-        }
+  @Override
+  public AccessibleByteArrayOutputStream clone() {
+    try {
+      final AccessibleByteArrayOutputStream cloned =
+          (AccessibleByteArrayOutputStream) super.clone();
+      cloned.buf = buf.clone();
+      return cloned;
+    } catch (final CloneNotSupportedException ex) {
+      throw new RuntimeCryptoException("Unexpected exception", ex);
     }
+  }
 
-    @Override
-    public void write(final byte[] b, final int off, final int len) {
-        growCapacity(count + len);
-        System.arraycopy(b, off, buf, count, len);
-        count += len;
+  @Override
+  public void write(final byte[] b, final int off, final int len) {
+    growCapacity(count + len);
+    System.arraycopy(b, off, buf, count, len);
+    count += len;
+  }
+
+  @Override
+  public void write(final int b) {
+    growCapacity(count + 1);
+    buf[count++] = (byte) b;
+  }
+
+  int size() {
+    return count;
+  }
+
+  /**
+   * Returns the actual internal field containing the data. Callers <em>MUST NOT</em> leak this
+   * value outside of ACCP without careful analysis as any further use of this object may cause the
+   * contents of the returned array to change.
+   */
+  byte[] getDataBuffer() {
+    return buf;
+  }
+
+  void reset() {
+    Arrays.fill(buf, 0, count, (byte) 0);
+    count = 0;
+    // TODO: Consider keeping track of length at reset.
+    // If it is consistently below the maximum value we may want to trim
+    // down to save on memory.
+  }
+
+  void write(final ByteBuffer bbuff) {
+    final int length = bbuff.remaining();
+    growCapacity(count + length);
+    bbuff.get(buf, count, length);
+    count += length;
+  }
+
+  private void growCapacity(final int newCapacity) {
+    if (newCapacity < 0) {
+      throw new OutOfMemoryError();
     }
-
-    @Override
-    public void write(final int b) {
-        growCapacity(count + 1);
-        buf[count++] = (byte) b;
+    if (newCapacity > limit) {
+      throw new IllegalArgumentException(
+          String.format("Exceeded capacity limit %d. Requested %d", limit, newCapacity));
     }
-
-    int size() {
-        return count;
+    if (newCapacity <= buf.length) {
+      return;
     }
+    final int predictedSize = Math.min(limit, buf.length << 1);
 
-    /** Returns the actual internal field containing the data.
-     * Callers <em>MUST NOT</em> leak this value outside of ACCP without careful analysis
-     * as any further use of this object may cause the contents of the returned array to change.
-     */
-    byte[] getDataBuffer() {
-        return buf;
-    }
-
-    void reset() {
-        Arrays.fill(buf, 0, count, (byte) 0);
-        count = 0;
-        // TODO: Consider keeping track of length at reset.
-        // If it is consistently below the maximum value we may want to trim
-        // down to save on memory.
-    }
-
-    void write(final ByteBuffer bbuff) {
-        final int length = bbuff.remaining();
-        growCapacity(count + length);
-        bbuff.get(buf, count, length);
-        count += length;
-    }
-
-    private void growCapacity(final int newCapacity) {
-        if (newCapacity < 0) {
-            throw new OutOfMemoryError();
-        }
-        if (newCapacity > limit) {
-            throw new IllegalArgumentException(String.format("Exceeded capacity limit %d. Requested %d", limit,
-                    newCapacity));
-        }
-        if (newCapacity <= buf.length) {
-            return;
-        }
-        final int predictedSize = Math.min(limit, buf.length << 1);
-
-        final byte[] tmp = Arrays.copyOf(buf, Math.max(predictedSize, newCapacity));
-        final byte[] toZeroize = buf;
-        buf = tmp;
-        Arrays.fill(toZeroize, 0, count, (byte) 0);
-    }
+    final byte[] tmp = Arrays.copyOf(buf, Math.max(predictedSize, newCapacity));
+    final byte[] toZeroize = buf;
+    buf = tmp;
+    Arrays.fill(toZeroize, 0, count, (byte) 0);
+  }
 }

--- a/src/com/amazon/corretto/crypto/provider/InputBuffer.java
+++ b/src/com/amazon/corretto/crypto/provider/InputBuffer.java
@@ -1,6 +1,5 @@
 // Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-
 package com.amazon.corretto.crypto.provider;
 
 import java.nio.ByteBuffer;
@@ -9,25 +8,23 @@ import java.util.function.BiConsumer;
 import java.util.function.Function;
 
 /**
- * <p>
  * Class to handle buffering data prior to passing it through to the native code. It buffers it up
- * into fewer (larger) chunks to avoid incurring marshalling overhead.  The first time a handler is
+ * into fewer (larger) chunks to avoid incurring marshalling overhead. The first time a handler is
  * called it will be an {@code InitialUpdate} handler (if present). All subsequent calls are
- * guaranteed to go to standard {@code Update} handlers.  If all of the data can be buffered prior
- * to calling {@link #doFinal()}, then this class will attempt to use the {@code SinglePass} handler
- * if available.
+ * guaranteed to go to standard {@code Update} handlers. If all of the data can be buffered prior to
+ * calling {@link #doFinal()}, then this class will attempt to use the {@code SinglePass} handler if
+ * available.
  *
- * <p>
- * The following handlers <em>must</em> be set.
+ * <p>The following handlers <em>must</em> be set.
+ *
  * <ul>
- * <li>{@link #withUpdater(ArrayStateConsumer)}
- * <li>{@link #withDoFinal(FinalHandlerFunction)}
+ *   <li>{@link #withUpdater(ArrayStateConsumer)}
+ *   <li>{@link #withDoFinal(FinalHandlerFunction)}
  * </ul>
  *
- * <p>
- * All {@link ByteBuffer} handlers default to calling their {@link ArrayStateConsumer} equivalents. All
- * InitialUpdate handlers default to calling their Update equivalents.
- * {@link #withSinglePass(ArrayFunction)} defaults to calling the update and doFinal steps.
+ * <p>All {@link ByteBuffer} handlers default to calling their {@link ArrayStateConsumer}
+ * equivalents. All InitialUpdate handlers default to calling their Update equivalents. {@link
+ * #withSinglePass(ArrayFunction)} defaults to calling the update and doFinal steps.
  *
  * @param <T> result type
  * @param <S> state type
@@ -35,314 +32,315 @@ import java.util.function.Function;
  */
 public class InputBuffer<T, S, X extends Throwable> implements Cloneable {
 
-    @FunctionalInterface
-    public static interface ArrayStateConsumer<S> {
-        public void accept(S state, byte[] src, int offset, int length);
+  @FunctionalInterface
+  public static interface ArrayStateConsumer<S> {
+    public void accept(S state, byte[] src, int offset, int length);
+  }
+
+  @FunctionalInterface
+  public static interface ArrayFunction<T, X extends Throwable> {
+    public T apply(byte[] src, int offset, int length) throws X;
+  }
+
+  public static interface FinalHandlerFunction<T, R, X extends Throwable> {
+    public R apply(T t) throws X;
+  }
+
+  @FunctionalInterface
+  public static interface ByteBufferFunction<S> extends Function<ByteBuffer, S> {
+    public S apply(ByteBuffer bb);
+  }
+
+  @FunctionalInterface
+  public static interface ByteBufferBiConsumer<S> extends BiConsumer<S, ByteBuffer> {
+    public void accept(S state, ByteBuffer bb);
+  }
+
+  @FunctionalInterface
+  public static interface StateSupplier<S> extends Function<S, S> {
+    public S apply(S state);
+  }
+
+  private final int buffSize;
+  private AccessibleByteArrayOutputStream buff;
+  private boolean firstData = true;
+  private S state;
+
+  private ArrayStateConsumer<S> arrayUpdater;
+  private FinalHandlerFunction<S, T, X> finalHandler;
+  private StateSupplier<S> stateSupplier = (oldState) -> oldState;
+  private Optional<Function<S, S>> stateCloner = Optional.empty();
+  // If absent, delegates to arrayUpdater
+  private Optional<ByteBufferBiConsumer<S>> bufferUpdater = Optional.empty();
+  // If absent, delegates to arrayUpdater
+  private Optional<ArrayFunction<S, RuntimeException>> initialArrayUpdater = Optional.empty();
+  // If absent, delegates to bufferUpdater or initialArrayUpdater
+  private Optional<ByteBufferFunction<S>> initialBufferUpdater = Optional.empty();
+  // If absent, delegates to firstArrayUpdater+finalHandler
+  private Optional<ArrayFunction<T, X>> singlePassArray = Optional.empty();
+
+  InputBuffer(final int capacity) {
+    if (capacity <= 0) {
+      throw new IllegalArgumentException("Capacity must be positive");
+    }
+    buff = new AccessibleByteArrayOutputStream(0, capacity);
+    buffSize = capacity;
+  }
+
+  public void reset() {
+    buff.reset();
+    firstData = true;
+  }
+
+  public int size() {
+    return buff.size();
+  }
+
+  public InputBuffer<T, S, X> withInitialUpdater(final ArrayFunction<S, RuntimeException> handler) {
+    initialArrayUpdater = Optional.ofNullable(handler);
+    return this;
+  }
+
+  public InputBuffer<T, S, X> withUpdater(final ArrayStateConsumer<S> handler) {
+    arrayUpdater = handler;
+    return this;
+  }
+
+  public InputBuffer<T, S, X> withInitialUpdater(final ByteBufferFunction<S> handler) {
+    initialBufferUpdater = Optional.ofNullable(handler);
+    return this;
+  }
+
+  public InputBuffer<T, S, X> withUpdater(final ByteBufferBiConsumer<S> handler) {
+    bufferUpdater = Optional.ofNullable(handler);
+    return this;
+  }
+
+  public InputBuffer<T, S, X> withDoFinal(final FinalHandlerFunction<S, T, X> handler) {
+    finalHandler = handler;
+    return this;
+  }
+
+  public InputBuffer<T, S, X> withSinglePass(final ArrayFunction<T, X> handler) {
+    singlePassArray = Optional.ofNullable(handler);
+    return this;
+  }
+
+  public InputBuffer<T, S, X> withStateCloner(final Function<S, S> cloner) {
+    stateCloner = Optional.ofNullable(cloner);
+    return this;
+  }
+
+  public InputBuffer<T, S, X> withInitialStateSupplier(final StateSupplier<S> supplier) {
+    stateSupplier = supplier;
+    return this;
+  }
+
+  /**
+   * Copies all requested data from {@code arr} into {@link #buff} if an only if there is sufficient
+   * space. Returns {@code true} if the data was copied.
+   *
+   * @return {@code true} if there was sufficient space in the buffer and data was copied.
+   */
+  private boolean fillBuffer(final byte[] arr, final int offset, final int length) {
+    // Overflow safe comparison. Length might still be negative, but we'll catch
+    // that later.
+    if (buffSize - buff.size() < length) {
+      return false;
+    }
+    try {
+      buff.write(arr, offset, length);
+    } catch (IndexOutOfBoundsException ex) {
+      throw new ArrayIndexOutOfBoundsException(ex.toString());
     }
 
-    @FunctionalInterface
-    public static interface ArrayFunction<T, X extends Throwable> {
-        public T apply(byte[] src, int offset, int length) throws X;
+    return true;
+  }
+
+  /**
+   * Copies {@code val} into {@link #buff} if an only if there is sufficient space. Returns {@code
+   * true} if the data was copied.
+   *
+   * @return {@code true} if there was sufficient space in the buffer and data was copied.
+   */
+  private boolean fillBuffer(final byte val) {
+    // Overflow safe comparison.
+    if (buffSize - buff.size() < 1) {
+      return false;
     }
-
-    public static interface FinalHandlerFunction<T, R, X extends Throwable> {
-	public R apply(T t) throws X;
+    try {
+      buff.write(val);
+    } catch (IndexOutOfBoundsException ex) {
+      throw new ArrayIndexOutOfBoundsException(ex.toString());
     }
+    return true;
+  }
 
-    @FunctionalInterface
-    public static interface ByteBufferFunction<S> extends Function<ByteBuffer, S> {
-        public S apply(ByteBuffer bb);
+  /**
+   * Copies all requested data from {@code src} into {@link #buff} if an only if there is sufficient
+   * space. Returns {@code true} if the data was copied.
+   *
+   * @return {@code true} if there was sufficient space in the buffer and data was copied.
+   */
+  private boolean fillBuffer(final ByteBuffer src) {
+    final int length = src.remaining();
+    // Overflow safe comparison. Length might still be negative, but we'll catch
+    // that later.
+    if (buffSize - buff.size() < length) {
+      return false;
     }
+    buff.write(src);
+    return true;
+  }
 
-    @FunctionalInterface
-    public static interface ByteBufferBiConsumer<S> extends BiConsumer<S, ByteBuffer> {
-        public void accept(S state, ByteBuffer bb);
-    }
-
-    @FunctionalInterface
-    public static interface StateSupplier<S> extends Function<S, S> {
-        public S apply(S state);
-    }
-
-    private final int buffSize;
-    private AccessibleByteArrayOutputStream buff;
-    private boolean firstData = true;
-    private S state;
-
-    private ArrayStateConsumer<S> arrayUpdater;
-    private FinalHandlerFunction<S, T, X> finalHandler;
-    private StateSupplier<S> stateSupplier = (oldState) -> oldState;
-    private Optional<Function<S, S>> stateCloner = Optional.empty();
-    // If absent, delegates to arrayUpdater
-    private Optional<ByteBufferBiConsumer<S>> bufferUpdater = Optional.empty();
-    // If absent, delegates to arrayUpdater
-    private Optional<ArrayFunction<S, RuntimeException>> initialArrayUpdater = Optional.empty();
-    // If absent, delegates to bufferUpdater or initialArrayUpdater
-    private Optional<ByteBufferFunction<S>> initialBufferUpdater = Optional.empty();
-    // If absent, delegates to firstArrayUpdater+finalHandler
-    private Optional<ArrayFunction<T, X>> singlePassArray = Optional.empty();
-
-    InputBuffer(final int capacity) {
-        if (capacity <= 0) {
-            throw new IllegalArgumentException("Capacity must be positive");
-        }
-        buff = new AccessibleByteArrayOutputStream(0, capacity);
-        buffSize = capacity;
-    }
-
-    public void reset() {
+  /**
+   * If there is data in {@link #buff} then delivers it all to the appropriate underlying handler
+   * and empties {@link #buff}. If {@link #buff} is empty then this method is a NOP <em>unless</em>
+   * no data has been previously passed to a handler (e.g., {@link #firstData} is {@code true}) and
+   * {@code forceInit} is also {@code true}.
+   *
+   * @param forceInit if {@code true} guarantees that {@link #state} will be initialized (if
+   *     appropriate) by the time this method returns.
+   */
+  private void processBuffer(boolean forceInit) {
+    if (firstData && (forceInit || buff.size() > 0)) {
+      if (initialArrayUpdater.isPresent()) {
+        state = initialArrayUpdater.get().apply(buff.getDataBuffer(), 0, buff.size());
         buff.reset();
-        firstData = true;
+      } else {
+        state = stateSupplier.apply(state);
+      }
+      firstData = false;
     }
-
-    public int size() {
-        return buff.size();
+    if (buff.size() > 0) {
+      arrayUpdater.accept(state, buff.getDataBuffer(), 0, buff.size());
+      buff.reset();
     }
+  }
 
-    public InputBuffer<T, S, X> withInitialUpdater(final ArrayFunction<S, RuntimeException> handler) {
-        initialArrayUpdater = Optional.ofNullable(handler);
-        return this;
-    }
+  public void update(final ByteBuffer src) {
+    try {
+      // We delegate to the equivalent array handler in any of these cases:
+      // 1. This is not a direct ByteBuffer
+      // 2. firstData is true and we don't have any buffer handlers
+      // 3. firstData is false and we don't have a middleBuffer handler
+      if (!src.isDirect()
+          || (firstData && !initialBufferUpdater.isPresent() && !bufferUpdater.isPresent())
+          || (!firstData && !bufferUpdater.isPresent())) {
+        final ShimArray shim = new ShimArray(src);
+        update(shim.array, shim.offset, shim.length);
+        return;
+      }
+      if (fillBuffer(src)) {
+        return;
+      }
+      processBuffer(false);
+      if (fillBuffer(src)) {
+        return;
+      }
 
-    public InputBuffer<T, S, X> withUpdater(final ArrayStateConsumer<S> handler) {
-        arrayUpdater = handler;
-        return this;
-    }
-
-    public InputBuffer<T, S, X> withInitialUpdater(final ByteBufferFunction<S> handler) {
-        initialBufferUpdater = Optional.ofNullable(handler);
-        return this;
-    }
-
-    public InputBuffer<T, S, X> withUpdater(final ByteBufferBiConsumer<S> handler) {
-        bufferUpdater = Optional.ofNullable(handler);
-        return this;
-    }
-
-    public InputBuffer<T, S, X> withDoFinal(final FinalHandlerFunction<S, T, X> handler) {
-        finalHandler = handler;
-        return this;
-    }
-
-    public InputBuffer<T, S, X> withSinglePass(final ArrayFunction<T, X> handler) {
-        singlePassArray = Optional.ofNullable(handler);
-        return this;
-    }
-
-    public InputBuffer<T, S, X> withStateCloner(final Function<S, S> cloner) {
-        stateCloner = Optional.ofNullable(cloner);
-        return this;
-    }
-
-
-    public InputBuffer<T, S, X> withInitialStateSupplier(final StateSupplier<S> supplier) {
-        stateSupplier = supplier;
-        return this;
-    }
-
-    /**
-     * Copies all requested data from {@code arr} into {@link #buff} if an only if there is
-     * sufficient space. Returns {@code true} if the data was copied.
-     * @return {@code true} if there was sufficient space in the buffer and data was copied.
-     */
-    private boolean fillBuffer(final byte[] arr, final int offset, final int length) {
-        // Overflow safe comparison. Length might still be negative, but we'll catch
-        // that later.
-        if (buffSize - buff.size() < length) {
-            return false;
-        }
-        try {
-            buff.write(arr, offset, length);
-        } catch (IndexOutOfBoundsException ex) {
-            throw new ArrayIndexOutOfBoundsException(ex.toString());
-        }
-
-        return true;
-    }
-
-    /**
-     * Copies {@code val} into {@link #buff} if an only if there is
-     * sufficient space. Returns {@code true} if the data was copied.
-     * @return {@code true} if there was sufficient space in the buffer and data was copied.
-     */
-    private boolean fillBuffer(final byte val) {
-        // Overflow safe comparison.
-        if (buffSize - buff.size() < 1) {
-            return false;
-        }
-        try {
-            buff.write(val);
-        } catch (IndexOutOfBoundsException ex) {
-            throw new ArrayIndexOutOfBoundsException(ex.toString());
-        }
-        return true;
-    }
-
-    /**
-     * Copies all requested data from {@code src} into {@link #buff} if an only if there is
-     * sufficient space. Returns {@code true} if the data was copied.
-     * @return {@code true} if there was sufficient space in the buffer and data was copied.
-     */
-    private boolean fillBuffer(final ByteBuffer src) {
-        final int length = src.remaining();
-        // Overflow safe comparison. Length might still be negative, but we'll catch
-        // that later.
-        if (buffSize - buff.size() < length) {
-            return false;
-        }
-        buff.write(src);
-        return true;
-    }
-
-    /**
-     * If there is data in {@link #buff} then delivers it all to the appropriate underlying handler
-     * and empties {@link #buff}. If {@link #buff} is empty then this method is a NOP <em>unless</em>
-     * no data has been previously passed to a handler (e.g., {@link #firstData} is {@code true}) and
-     * {@code forceInit} is also {@code true}.
-     *
-     * @param forceInit if {@code true} guarantees that {@link #state} will be initialized (if
-     *        appropriate) by the time this method returns.
-     */
-    private void processBuffer(boolean forceInit) {
-        if (firstData && (forceInit || buff.size() > 0)) {
-            if (initialArrayUpdater.isPresent()) {
-                state = initialArrayUpdater.get().apply(buff.getDataBuffer(), 0, buff.size());
-                buff.reset();
-            } else {
-                state = stateSupplier.apply(state);
-            }
-            firstData = false;
-        }
-        if (buff.size() > 0) {
-            arrayUpdater.accept(state, buff.getDataBuffer(), 0, buff.size());
-            buff.reset();
-        }
-    }
-
-    public void update(final ByteBuffer src) {
-        try {
-            // We delegate to the equivalent array handler in any of these cases:
-            // 1. This is not a direct ByteBuffer
-            // 2. firstData is true and we don't have any buffer handlers
-            // 3. firstData is false and we don't have a middleBuffer handler
-            if (!src.isDirect() ||
-                    (firstData && !initialBufferUpdater.isPresent() && !bufferUpdater.isPresent()) ||
-                    (!firstData && !bufferUpdater.isPresent())) {
-                final ShimArray shim = new ShimArray(src);
-                update(shim.array, shim.offset, shim.length);
-                return;
-            }
-            if (fillBuffer(src)) {
-                return;
-            }
-            processBuffer(false);
-            if (fillBuffer(src)) {
-                return;
-            }
-
-            if (firstData) {
-                if (initialBufferUpdater.isPresent()) {
-                    state = initialBufferUpdater.get().apply(src.slice());
-                } else {
-                    state = stateSupplier.apply(state);
-                    bufferUpdater.get().accept(state, src.slice());
-                }
-            } else {
-                bufferUpdater.get().accept(state, src.slice());
-            }
-            firstData = false;
-        } finally {
-            src.position(src.limit());
-        }
-    }
-
-    public void update(final byte[] src, final int offset, final int length) {
-        if (fillBuffer(src, offset, length)) {
-            return;
-        }
-        processBuffer(false);
-        if (fillBuffer(src, offset, length)) {
-            return;
-        }
-
-        if (firstData) {
-            if (initialArrayUpdater.isPresent()) {
-                state = initialArrayUpdater.get().apply(src, offset, length);
-            } else {
-                state = stateSupplier.apply(state);
-                arrayUpdater.accept(state, src, offset, length);
-            }
+      if (firstData) {
+        if (initialBufferUpdater.isPresent()) {
+          state = initialBufferUpdater.get().apply(src.slice());
         } else {
-            arrayUpdater.accept(state, src, offset, length);
+          state = stateSupplier.apply(state);
+          bufferUpdater.get().accept(state, src.slice());
         }
-        firstData = false;
+      } else {
+        bufferUpdater.get().accept(state, src.slice());
+      }
+      firstData = false;
+    } finally {
+      src.position(src.limit());
+    }
+  }
+
+  public void update(final byte[] src, final int offset, final int length) {
+    if (fillBuffer(src, offset, length)) {
+      return;
+    }
+    processBuffer(false);
+    if (fillBuffer(src, offset, length)) {
+      return;
     }
 
-    public void update(final byte val) {
-        if (fillBuffer(val)) {
-            return;
-        }
-        processBuffer(false);
-        if (fillBuffer(val)) {
-            return;
-        }
+    if (firstData) {
+      if (initialArrayUpdater.isPresent()) {
+        state = initialArrayUpdater.get().apply(src, offset, length);
+      } else {
+        state = stateSupplier.apply(state);
+        arrayUpdater.accept(state, src, offset, length);
+      }
+    } else {
+      arrayUpdater.accept(state, src, offset, length);
+    }
+    firstData = false;
+  }
 
-        // We explicitly do not support capacities of zero where we cannot even append a single byte.
-        throw new AssertionError("Unreachable code. Cannot buffer even a single byte");
+  public void update(final byte val) {
+    if (fillBuffer(val)) {
+      return;
+    }
+    processBuffer(false);
+    if (fillBuffer(val)) {
+      return;
     }
 
-    public T doFinal() throws X {
-        if (!firstData || !singlePassArray.isPresent()) {
-            processBuffer(true);
-            return finalHandler.apply(state);
-        } else {
-            return singlePassArray.get().apply(buff.getDataBuffer(), 0, buff.size());
-        }
+    // We explicitly do not support capacities of zero where we cannot even append a single byte.
+    throw new AssertionError("Unreachable code. Cannot buffer even a single byte");
+  }
+
+  public T doFinal() throws X {
+    if (!firstData || !singlePassArray.isPresent()) {
+      processBuffer(true);
+      return finalHandler.apply(state);
+    } else {
+      return singlePassArray.get().apply(buff.getDataBuffer(), 0, buff.size());
     }
+  }
 
-    /**
-     * WARNING! This only does a shallow copy of the handlers, so any which refer to external state
-     * (so, any values not passed in as arguments) may be incorrect and need to be fixed prior to
-     * use.
-     */
-    @Override
-    protected InputBuffer<T, S, X> clone() throws CloneNotSupportedException {
-        if (state != null && !stateCloner.isPresent()) {
-            throw new CloneNotSupportedException("No stateCloner configured");
-        }
-        @SuppressWarnings("unchecked")
-        final InputBuffer<T, S, X> clonedObject = (InputBuffer<T, S, X>) super.clone();
-
-        clonedObject.state = state != null ? stateCloner.get().apply(state) : null;
-        clonedObject.buff = buff.clone();
-
-        return clonedObject;
+  /**
+   * WARNING! This only does a shallow copy of the handlers, so any which refer to external state
+   * (so, any values not passed in as arguments) may be incorrect and need to be fixed prior to use.
+   */
+  @Override
+  protected InputBuffer<T, S, X> clone() throws CloneNotSupportedException {
+    if (state != null && !stateCloner.isPresent()) {
+      throw new CloneNotSupportedException("No stateCloner configured");
     }
+    @SuppressWarnings("unchecked")
+    final InputBuffer<T, S, X> clonedObject = (InputBuffer<T, S, X>) super.clone();
 
-    /**
-     * An array view over a bytebuffer - either directly aliasing the underlying bytebuffer, or a
-     * copy of the byte buffer's data.
-     */
-    private static class ShimArray {
-        private final ByteBuffer backingBuffer;
-        public final byte[] array;
-        public final int offset, length;
+    clonedObject.state = state != null ? stateCloner.get().apply(state) : null;
+    clonedObject.buff = buff.clone();
 
-        public ShimArray(final ByteBuffer buffer) {
-            this.backingBuffer = buffer.slice();
-            this.length = backingBuffer.limit();
+    return clonedObject;
+  }
 
-            final boolean hasArray = backingBuffer.hasArray();
-            byte[] tmpArray = hasArray ? backingBuffer.array() : null;
-            if (tmpArray == null) {
-                tmpArray = new byte[length];
-                backingBuffer.duplicate().get(tmpArray);
-                offset = 0;
-            } else {
-                offset = backingBuffer.arrayOffset() + backingBuffer.position();
-            }
+  /**
+   * An array view over a bytebuffer - either directly aliasing the underlying bytebuffer, or a copy
+   * of the byte buffer's data.
+   */
+  private static class ShimArray {
+    private final ByteBuffer backingBuffer;
+    public final byte[] array;
+    public final int offset, length;
 
-            this.array = tmpArray;
-        }
+    public ShimArray(final ByteBuffer buffer) {
+      this.backingBuffer = buffer.slice();
+      this.length = backingBuffer.limit();
+
+      final boolean hasArray = backingBuffer.hasArray();
+      byte[] tmpArray = hasArray ? backingBuffer.array() : null;
+      if (tmpArray == null) {
+        tmpArray = new byte[length];
+        backingBuffer.duplicate().get(tmpArray);
+        offset = 0;
+      } else {
+        offset = backingBuffer.arrayOffset() + backingBuffer.position();
+      }
+
+      this.array = tmpArray;
     }
+  }
 }

--- a/src/com/amazon/corretto/crypto/provider/Janitor.java
+++ b/src/com/amazon/corretto/crypto/provider/Janitor.java
@@ -1,6 +1,5 @@
 // Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-
 package com.amazon.corretto.crypto.provider;
 
 import java.lang.ref.ReferenceQueue;
@@ -11,360 +10,395 @@ import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.concurrent.locks.ReentrantLock;
 
 /**
- * This class implements an alternative to traditional finalizers, which allows finalizable references to be cancelled
- * if cleanup happens synchronously.
- * <br/>
- * Typical usage will create one long-lived Janitor which will serve for the lifetime of the process, and clean up any
- * Messes which aren't explicitly cleaned before being unreferenced.
- * <br/>
- * In specialized use cases, the Janitor instance itself can be unreferenced; the background cleanup thread will then
- * terminate when all associated Messes are cleaned (and the GC notices the loss of the Janitor reference).
- * <br/>
- * The function of this class is similar to Java 9's {@link java.lang.ref.Cleaner}, but it avoids a single lock on the
- * data structure responsible for keeping the phantom references alive (and is compatible with Java 8).
+ * This class implements an alternative to traditional finalizers, which allows finalizable
+ * references to be cancelled if cleanup happens synchronously. <br>
+ * Typical usage will create one long-lived Janitor which will serve for the lifetime of the
+ * process, and clean up any Messes which aren't explicitly cleaned before being unreferenced. <br>
+ * In specialized use cases, the Janitor instance itself can be unreferenced; the background cleanup
+ * thread will then terminate when all associated Messes are cleaned (and the GC notices the loss of
+ * the Janitor reference). <br>
+ * The function of this class is similar to Java 9's {@link java.lang.ref.Cleaner}, but it avoids a
+ * single lock on the data structure responsible for keeping the phantom references alive (and is
+ * compatible with Java 8).
  */
 class Janitor {
-    // Every CLEAN_INTERVAL refs we create on a particular shard, we'll check the reference queue for uncleaned entries
-    private static final int CLEAN_INTERVAL = 32;
-    // When we check the reference queue, we'll process up to CLEAN_BATCH_SIZE entries
-    private static final int CLEAN_BATCH_SIZE = 128;
-    // Time (in ms) to wait on a single ref queue before rechecking the others
-    private static final long CLEAN_TIMEOUT = 1000;
+  // Every CLEAN_INTERVAL refs we create on a particular shard, we'll check the reference queue for
+  // uncleaned entries
+  private static final int CLEAN_INTERVAL = 32;
+  // When we check the reference queue, we'll process up to CLEAN_BATCH_SIZE entries
+  private static final int CLEAN_BATCH_SIZE = 128;
+  // Time (in ms) to wait on a single ref queue before rechecking the others
+  private static final long CLEAN_TIMEOUT = 1000;
 
-    // Overriding this property directly sets the number of stripes to allocate
-    private static final String PROP_NSTRIPES = "janitor.stripes";
-    // By default we apply a multiplier to the number of CPUs
-    private static final int DEFAULT_PROCESSOR_MULTIPLER = 4; // 4 stripes per CPU (rounded up to a power of two)
+  // Overriding this property directly sets the number of stripes to allocate
+  private static final String PROP_NSTRIPES = "janitor.stripes";
+  // By default we apply a multiplier to the number of CPUs
+  private static final int DEFAULT_PROCESSOR_MULTIPLER =
+      4; // 4 stripes per CPU (rounded up to a power of two)
 
-    private final JanitorState state;
+  private final JanitorState state;
 
-    Janitor() {
-        state = new JanitorState(this);
-    }
+  Janitor() {
+    state = new JanitorState(this);
+  }
 
-    Janitor(ThreadFactory factory) {
-        state = new JanitorState(this, factory);
-    }
+  Janitor(ThreadFactory factory) {
+    state = new JanitorState(this, factory);
+  }
 
-    Mess register(Object referent, Runnable cleaner) {
-        return state.register(referent, cleaner);
-    }
+  Mess register(Object referent, Runnable cleaner) {
+    return state.register(referent, cleaner);
+  }
 
+  /**
+   * For testing only. Immediately awakens the cleaner thread, which will examine all reference
+   * queues for garbage to process. This is not guaranteed to find any garbage, of course; normally,
+   * one would want to run this in a loop with a sleep for some time in the hopes that reference
+   * processing will catch up.
+   */
+  void wake() {
+    state.cleaner.interrupt();
+  }
+
+  /** For testing only. Returns the stripe count for this janitor. */
+  int getStripeCount() {
+    return state.stripes.length;
+  }
+
+  /**
+   * Represents a pending cleanup action tracked by a Janitor. By invoking clean() on a Mess, the
+   * cleanup action will execute immediately, and the overhead for tracking the pending cleanup can
+   * be avoided.
+   *
+   * <p>It is not necessary to keep a reference to the Mess if explicit cleanup is not necessary (or
+   * possible); the Janitor will ensure that the cleanup action is invoked when the associated
+   * reference is collected regardless of whether the Mess object is reachable.
+   */
+  interface Mess {
     /**
-     * For testing only. Immediately awakens the cleaner thread, which will examine all reference queues for garbage
-     * to process. This is not guaranteed to find any garbage, of course; normally, one would want to run this in a loop
-     * with a sleep for some time in the hopes that reference processing will catch up.
+     * Invokes the cleanup action associated with this Mess. This method is idempotent and
+     * thread-safe; the cleanup action will only be invoked once. If multiple invocations occur in
+     * parallel, however, it is not guaranteed that the cleanup action will be complete before
+     * returning; duplicate invocations may result in an immediate return without waiting for the
+     * cleanup to complete.
      */
-    void wake() {
-        state.cleaner.interrupt();
+    void clean();
+  }
+
+  /**
+   * The actual implementation of the Mess. Each HeldReference is a weak reference to the referent
+   * associated with the cleanup action. We use WeakReferences instead of phantom references as
+   * phantom references keep their referent alive (but inaccessible) until the phantom reference is
+   * explicitly cleared or becomes dead; we don't need that behavior, so we use a weak reference to
+   * allow the GC to clear the referent pointer implicitly.
+   *
+   * <p>HeldReferences need to remain strongly reachable until their cleanup action is executed. To
+   * accomplish this, we maintain a circular (intrusive) doubly linked list through held references.
+   * Each Stripe is associated with one such list, and manipulation of the list is protected by the
+   * Stripe object monitor.
+   */
+  private static final class HeldReference extends WeakReference<Object> implements Mess {
+    // TODO: Use VarHandle when we no longer need to support Java 8
+    private static final AtomicReferenceFieldUpdater<HeldReference, Runnable> F_CLEANER =
+        AtomicReferenceFieldUpdater.newUpdater(HeldReference.class, Runnable.class, "cleaner");
+
+    private final Stripe owningStripe;
+
+    // @GuardedBy("owningStripe") // Restore once replacement for JSR-305 available
+    private HeldReference prev, next;
+
+    @SuppressWarnings("unused") // accessed reflectively via F_CLEANER
+    private volatile Runnable cleaner;
+
+    HeldReference(final Object referent, final Stripe owningStripe, Runnable cleaner) {
+      super(referent, owningStripe.queue);
+      this.owningStripe = owningStripe;
+      this.cleaner = cleaner;
+    }
+
+    @Override
+    public final void clean() {
+      // Swap the cleaner with null. The idea here is to ensure we invoke the cleaner only once but
+      // avoid taking
+      // an additional lock to protect the cleanup action.
+
+      Runnable cleaner = F_CLEANER.getAndSet(this, null);
+
+      if (cleaner == null) {
+        return;
+      }
+
+      try {
+        cleaner.run();
+      } catch (Throwable t) {
+        // We ignore all exceptions, even Errors. This is because an Error leaked from the user
+        // cleanup callback
+        // would otherwise result in the cleaner thread as a whole dying, resulting in a permanent
+        // memory leak.
+        // If the user cleaner fails there isn't much we can do about it anyway.
+
+        // This behavior is consistent with the behavior of ordinary finalizers. The JDK 9 cleaner
+        // chooses a
+        // different approach - uncaught throwables result in the VM being terminated.
+      }
+
+      // Remove the underlying reference to the referent. This isn't strictly necessary, but it
+      // means the GC
+      // doesn't have to keep the referent alive until reference processing completes (if the
+      // reference has not
+      // yet been found dead).
+      clear();
+
+      synchronized (owningStripe) {
+        owningStripe.outstandingRefs--;
+
+        next.prev = prev;
+        prev.next = next;
+        next = prev = this;
+      }
+    }
+  }
+
+  /**
+   * We organize our reference lists and reference queues into a number of "stripes"; each Java
+   * thread is permanently and randomly bound to one of the Stripes, and any messes it creates are
+   * assigned to this stripe. This helps avoid contention between multiple threads when creating
+   * messes or processing the mess reference queues.
+   */
+  private static final class Stripe {
+    private static final AtomicIntegerFieldUpdater<Stripe> F_OBJS_CREATED_SINCE =
+        AtomicIntegerFieldUpdater.newUpdater(Stripe.class, "objectsCreatedSinceLastClean");
+
+    private final ReferenceQueue<Object> queue = new ReferenceQueue<>();
+
+    // We hold our own lock around the reference queue to avoid blocking on the implicit internal
+    // queue lock when
+    // performing opportunistic cleanup.
+    private final ReentrantLock queueLock = new ReentrantLock();
+
+    // The head element of the doubly-linked list of references. This reference will never be
+    // enqueued and thus
+    // will remain in the list indefinitely.
+    private final HeldReference head;
+
+    // The number of objects that have been created since the last attempted synchronous cleanup.
+    @SuppressWarnings("unused") // accessed reflectively via F_OBJS_CREATED_SINCE
+    private volatile int objectsCreatedSinceLastClean = 0;
+
+    // The number of outstanding references, not including the head element.
+    private long outstandingRefs = 0;
+
+    Stripe() {
+      // The head reference uses the queue itself as its referent to ensure that it will never be
+      // enqueued.
+      this.head = new HeldReference(queue, this, () -> {});
+      this.head.prev = this.head.next = this.head;
+    }
+
+    synchronized boolean hasOutstandingRefs() {
+      return outstandingRefs != 0;
+    }
+
+    Mess add(Object referent, Runnable cleaner) {
+      // n = (n + 1) % CLEAN_INTERVAL; check for rollover
+      // We avoid holding the lock to ensure we don't have any sort of lock inversion issue, or
+      // deadlocks caused
+      // by user cleaner code doing who-knows-what.
+      if (F_OBJS_CREATED_SINCE.updateAndGet(this, n -> n >= CLEAN_INTERVAL - 1 ? 0 : n + 1) == 0) {
+        tryClean(false);
+      }
+
+      synchronized (this) {
+        // It is essential that we take the monitor _before_ creating this reference. Once we create
+        // this
+        // reference, it's very possible that referent no longer has any strong references, and is
+        // immediately
+        // eligible to be enqueued. Since we haven't finished setting up the DLL yet, this means the
+        // node could
+        // be removed from the list before it is added - thus becoming stuck in the doubly linked
+        // list forever.
+        //
+        // Holding the monitor means that, even if this were to occur, the cleaner thread will be
+        // stuck waiting
+        // for the monitor (in HeldReference.clean()), and by the time it's released, we'll have
+        // finished
+        // establishing the doubly linked list.
+        HeldReference ref = new HeldReference(referent, this, cleaner);
+
+        outstandingRefs++;
+
+        ref.prev = head;
+        ref.next = head.next;
+        ref.next.prev = ref;
+        ref.prev.next = ref;
+
+        return ref;
+      }
     }
 
     /**
-     * For testing only. Returns the stripe count for this janitor.
-     */
-    int getStripeCount() {
-        return state.stripes.length;
-    }
-
-    /**
-     * Represents a pending cleanup action tracked by a Janitor. By invoking clean() on a Mess, the cleanup action will
-     * execute immediately, and the overhead for tracking the pending cleanup can be avoided.
+     * Cleans up to CLEAN_BATCH_SIZE objects.
      *
-     * It is not necessary to keep a reference to the Mess if explicit cleanup is not necessary (or possible); the
-     * Janitor will ensure that the cleanup action is invoked when the associated reference is collected regardless
-     * of whether the Mess object is reachable.
+     * @param block True to block for CLEAN_WAIT_INTERVAL until objects are available to clean
+     * @return The number of objects cleaned
      */
-    interface Mess {
-        /**
-         * Invokes the cleanup action associated with this Mess. This method is idempotent and thread-safe; the cleanup
-         * action will only be invoked once. If multiple invocations occur in parallel, however, it is not guaranteed
-         * that the cleanup action will be complete before returning; duplicate invocations may result in an immediate
-         * return without waiting for the cleanup to complete.
-         */
-        void clean();
+    private int tryClean(boolean block) {
+      if (block) {
+        queueLock.lock();
+      } else {
+        if (!queueLock.tryLock()) {
+          return 0;
+        }
+      }
+
+      try {
+        for (int i = 0; i < CLEAN_BATCH_SIZE; i++) {
+          HeldReference ref;
+          try {
+            ref = (HeldReference) (block ? queue.remove(CLEAN_TIMEOUT) : queue.poll());
+          } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return i;
+          }
+
+          if (ref == null) {
+            return i;
+          }
+
+          ref.clean();
+
+          // Only block on the first reference
+          block = false;
+        }
+
+        return CLEAN_BATCH_SIZE;
+      } finally {
+        queueLock.unlock();
+      }
+    }
+  }
+
+  private static final class JanitorState {
+    private final int stripeIndexMask;
+    private final Stripe[] stripes;
+    private final Thread cleaner;
+
+    JanitorState(Janitor parent) {
+      this(
+          parent,
+          task -> {
+            Thread cleaner = new Thread(task);
+
+            cleaner.setDaemon(true);
+            cleaner.setName("Native reference cleanup thread");
+            cleaner.setPriority(
+                Thread.MAX_PRIORITY
+                    - 2); // same as the thread priority for the Java 9 Cleaner thread
+            return cleaner;
+          });
     }
 
-    /**
-     * The actual implementation of the Mess. Each HeldReference is a weak reference to the referent associated with the
-     * cleanup action. We use WeakReferences instead of phantom references as phantom references keep their referent
-     * alive (but inaccessible) until the phantom reference is explicitly cleared or becomes dead; we don't need that
-     * behavior, so we use a weak reference to allow the GC to clear the referent pointer implicitly.
-     *
-     * HeldReferences need to remain strongly reachable until their cleanup action is executed. To accomplish this, we
-     * maintain a circular (intrusive) doubly linked list through held references. Each Stripe is associated with one
-     * such list, and manipulation of the list is protected by the Stripe object monitor.
-     */
-    private static final class HeldReference extends WeakReference<Object> implements Mess {
-        // TODO: Use VarHandle when we no longer need to support Java 8
-        private static final AtomicReferenceFieldUpdater<HeldReference, Runnable> F_CLEANER
-                = AtomicReferenceFieldUpdater.newUpdater(HeldReference.class, Runnable.class, "cleaner");
+    JanitorState(Janitor parent, ThreadFactory factory) {
+      int nstripes;
 
-        private final Stripe owningStripe;
+      if (Loader.getProperty(PROP_NSTRIPES) != null) {
+        nstripes = Integer.parseInt(Loader.getProperty(PROP_NSTRIPES));
+      } else {
+        nstripes = Runtime.getRuntime().availableProcessors() * DEFAULT_PROCESSOR_MULTIPLER;
+      }
 
-        // @GuardedBy("owningStripe") // Restore once replacement for JSR-305 available
-        private HeldReference prev, next;
+      if (nstripes <= 0) {
+        throw new IllegalArgumentException(
+            "Bad value for " + PROP_NSTRIPES + " property; must be positive");
+      }
 
-        @SuppressWarnings("unused") // accessed reflectively via F_CLEANER
-        private volatile Runnable cleaner;
+      // Round nstripes up to a power of two
+      // To do this, we note that we can almost achieve this by clearing all but the top bit. This
+      // will leave
+      // a power of two unchanged, and everything else will be rounded _down_ to a power of two.
+      // To avoid rounding down, we can then multiply by two, but this means that numbers that are
+      // already
+      // a power of two are now doubled - and to fix this, we subtract one at the start.
 
-        HeldReference(final Object referent, final Stripe owningStripe, Runnable cleaner) {
-            super(referent, owningStripe.queue);
-            this.owningStripe = owningStripe;
-            this.cleaner = cleaner;
-        }
+      // Note that this does not work with an input of 1, so we'll hardcode a minimum of 1.
+      nstripes = Math.max(1, 2 * Integer.highestOneBit(nstripes - 1));
 
-        @Override
-        public final void clean() {
-            // Swap the cleaner with null. The idea here is to ensure we invoke the cleaner only once but avoid taking
-            // an additional lock to protect the cleanup action.
+      stripes = new Stripe[nstripes];
 
-            Runnable cleaner = F_CLEANER.getAndSet(this, null);
+      // This mask is ANDed with thread hash codes to obtain the stripe index for that thread. This
+      // is equivalent
+      // to computing modulo stripes.length, assuming stripes.length is a power of 2.
+      stripeIndexMask = stripes.length - 1;
 
-            if (cleaner == null) {
-                return;
-            }
+      for (int i = 0; i < stripes.length; i++) {
+        stripes[i] = new Stripe();
+      }
 
-            try {
-                cleaner.run();
-            } catch (Throwable t) {
-                // We ignore all exceptions, even Errors. This is because an Error leaked from the user cleanup callback
-                // would otherwise result in the cleaner thread as a whole dying, resulting in a permanent memory leak.
-                // If the user cleaner fails there isn't much we can do about it anyway.
+      // This reference keeps the cleaner thread alive - it will terminate when zero outstanding
+      // refs remain, so
+      // by keeping a reference around watching the outer Janitor, we ensure that when all
+      // outstanding registered
+      // refs are gone AND the Janitor is dead (thus, no new refs can be created), we'll terminate
+      // the cleanup
+      // thread.
 
-                // This behavior is consistent with the behavior of ordinary finalizers. The JDK 9 cleaner chooses a
-                // different approach - uncaught throwables result in the VM being terminated.
-            }
+      // We don't need an explicit cleanup action here, it's enough that it implicitly updates the
+      // outstandingRefs
+      // counters.
+      stripes[0].add(parent, () -> {});
 
-            // Remove the underlying reference to the referent. This isn't strictly necessary, but it means the GC
-            // doesn't have to keep the referent alive until reference processing completes (if the reference has not
-            // yet been found dead).
-            clear();
-
-            synchronized (owningStripe) {
-                owningStripe.outstandingRefs--;
-
-                next.prev = prev;
-                prev.next = next;
-                next = prev = this;
-            }
-        }
+      cleaner = factory.newThread(this::cleanerThread);
+      cleaner.start();
     }
 
-    /**
-     * We organize our reference lists and reference queues into a number of "stripes"; each Java thread is permanently
-     * and randomly bound to one of the Stripes, and any messes it creates are assigned to this stripe. This helps avoid
-     * contention between multiple threads when creating messes or processing the mess reference queues.
-     */
-    private static final class Stripe {
-        private static final AtomicIntegerFieldUpdater<Stripe> F_OBJS_CREATED_SINCE =
-                AtomicIntegerFieldUpdater.newUpdater(Stripe.class, "objectsCreatedSinceLastClean");
+    private void cleanerThread() {
+      int sleepIndex = 0;
 
-        private final ReferenceQueue<Object> queue = new ReferenceQueue<>();
+      while (true) {
+        boolean cleanedSomeRefs = false;
+        boolean outstandingRefsRemain = false;
 
-        // We hold our own lock around the reference queue to avoid blocking on the implicit internal queue lock when
-        // performing opportunistic cleanup.
-        private final ReentrantLock queueLock = new ReentrantLock();
+        // First, we'll clean some refs from every stripe, without blocking.
+        for (int i = 0; i < stripes.length; i++) {
+          if (stripes[i].tryClean(false) > 0) {
+            cleanedSomeRefs = true;
+          }
 
-        // The head element of the doubly-linked list of references. This reference will never be enqueued and thus
-        // will remain in the list indefinitely.
-        private final HeldReference head;
-
-        // The number of objects that have been created since the last attempted synchronous cleanup.
-        @SuppressWarnings("unused") // accessed reflectively via F_OBJS_CREATED_SINCE
-        private volatile int objectsCreatedSinceLastClean = 0;
-
-        // The number of outstanding references, not including the head element.
-        private long outstandingRefs = 0;
-
-        Stripe() {
-            // The head reference uses the queue itself as its referent to ensure that it will never be enqueued.
-            this.head = new HeldReference(queue, this, () -> {});
-            this.head.prev = this.head.next =  this.head;
+          outstandingRefsRemain = outstandingRefsRemain || stripes[i].hasOutstandingRefs();
         }
 
-        synchronized boolean hasOutstandingRefs() {
-            return outstandingRefs != 0;
+        if (cleanedSomeRefs) {
+          // Don't sleep unless we run out of refs to process on all stripes.
+          continue;
         }
 
-        Mess add(Object referent, Runnable cleaner) {
-            // n = (n + 1) % CLEAN_INTERVAL; check for rollover
-            // We avoid holding the lock to ensure we don't have any sort of lock inversion issue, or deadlocks caused
-            // by user cleaner code doing who-knows-what.
-            if (F_OBJS_CREATED_SINCE.updateAndGet(this, n -> n >= CLEAN_INTERVAL - 1 ? 0 : n + 1) == 0) {
-                tryClean(false);
-            }
-
-            synchronized (this) {
-                // It is essential that we take the monitor _before_ creating this reference. Once we create this
-                // reference, it's very possible that referent no longer has any strong references, and is immediately
-                // eligible to be enqueued. Since we haven't finished setting up the DLL yet, this means the node could
-                // be removed from the list before it is added - thus becoming stuck in the doubly linked list forever.
-                //
-                // Holding the monitor means that, even if this were to occur, the cleaner thread will be stuck waiting
-                // for the monitor (in HeldReference.clean()), and by the time it's released, we'll have finished
-                // establishing the doubly linked list.
-                HeldReference ref = new HeldReference(referent, this, cleaner);
-
-                outstandingRefs++;
-
-                ref.prev = head;
-                ref.next = head.next;
-                ref.next.prev = ref;
-                ref.prev.next = ref;
-
-                return ref;
-            }
+        if (!outstandingRefsRemain) {
+          // We've drained all refs, which means the Janitor is also gone and our work is done.
+          return;
         }
 
-        /**
-         * Cleans up to CLEAN_BATCH_SIZE objects.
-         *
-         * @param block True to block for CLEAN_WAIT_INTERVAL until objects are available to clean
-         * @return The number of objects cleaned
-         */
-        private int tryClean(boolean block) {
-            if (block) {
-                queueLock.lock();
-            } else {
-                if (!queueLock.tryLock()) {
-                    return 0;
-                }
-            }
-
-            try {
-                for (int i = 0; i < CLEAN_BATCH_SIZE; i++) {
-                    HeldReference ref;
-                    try {
-                        ref = (HeldReference) (block ? queue.remove(CLEAN_TIMEOUT) : queue.poll());
-                    } catch (InterruptedException e) {
-                        Thread.currentThread().interrupt();
-                        return i;
-                    }
-
-                    if (ref == null) {
-                        return i;
-                    }
-
-                    ref.clean();
-
-                    // Only block on the first reference
-                    block = false;
-                }
-
-                return CLEAN_BATCH_SIZE;
-            } finally {
-                queueLock.unlock();
-            }
+        // Go to sleep on an arbitrary stripe. If we don't end up finding anything on this stripe,
+        // move on to
+        // the next stripe on the next iteration (if there's only one thread generating garbage we
+        // hope to end
+        // up stuck on that thread).
+        if (stripes[sleepIndex].tryClean(true) == 0) {
+          sleepIndex = (sleepIndex + 1) & stripeIndexMask;
         }
+
+        // We use the thread interrupt to wake the thread from its slumber to make unit tests more
+        // reproducible.
+        // Now that we're awake we can clear the interrupt flag.
+        Thread.interrupted();
+      }
     }
 
-    private static final class JanitorState {
-        private final int stripeIndexMask;
-        private final Stripe[] stripes;
-        private final Thread cleaner;
-
-        JanitorState(Janitor parent) {
-            this(parent, task -> {
-                Thread cleaner = new Thread(task);
-
-                cleaner.setDaemon(true);
-                cleaner.setName("Native reference cleanup thread");
-                cleaner.setPriority(Thread.MAX_PRIORITY - 2); // same as the thread priority for the Java 9 Cleaner thread
-                return cleaner;
-            });
-        }
-
-        JanitorState(Janitor parent, ThreadFactory factory) {
-            int nstripes;
-
-            if (Loader.getProperty(PROP_NSTRIPES) != null) {
-                nstripes = Integer.parseInt(Loader.getProperty(PROP_NSTRIPES));
-            } else {
-                nstripes = Runtime.getRuntime().availableProcessors() * DEFAULT_PROCESSOR_MULTIPLER;
-            }
-
-            if (nstripes <= 0) {
-                throw new IllegalArgumentException("Bad value for " + PROP_NSTRIPES + " property; must be positive");
-            }
-
-            // Round nstripes up to a power of two
-            // To do this, we note that we can almost achieve this by clearing all but the top bit. This will leave
-            // a power of two unchanged, and everything else will be rounded _down_ to a power of two.
-            // To avoid rounding down, we can then multiply by two, but this means that numbers that are already
-            // a power of two are now doubled - and to fix this, we subtract one at the start.
-
-            // Note that this does not work with an input of 1, so we'll hardcode a minimum of 1.
-            nstripes = Math.max(1, 2 * Integer.highestOneBit(nstripes - 1));
-
-            stripes = new Stripe[nstripes];
-
-            // This mask is ANDed with thread hash codes to obtain the stripe index for that thread. This is equivalent
-            // to computing modulo stripes.length, assuming stripes.length is a power of 2.
-            stripeIndexMask = stripes.length - 1;
-
-            for (int i = 0; i < stripes.length; i++) {
-                stripes[i] = new Stripe();
-            }
-
-            // This reference keeps the cleaner thread alive - it will terminate when zero outstanding refs remain, so
-            // by keeping a reference around watching the outer Janitor, we ensure that when all outstanding registered
-            // refs are gone AND the Janitor is dead (thus, no new refs can be created), we'll terminate the cleanup
-            // thread.
-
-            // We don't need an explicit cleanup action here, it's enough that it implicitly updates the outstandingRefs
-            // counters.
-            stripes[0].add(parent, () -> {});
-
-            cleaner = factory.newThread(this::cleanerThread);
-            cleaner.start();
-        }
-
-        private void cleanerThread() {
-            int sleepIndex = 0;
-
-            while (true) {
-                boolean cleanedSomeRefs = false;
-                boolean outstandingRefsRemain = false;
-
-                // First, we'll clean some refs from every stripe, without blocking.
-                for (int i = 0; i < stripes.length; i++) {
-                    if (stripes[i].tryClean(false) > 0) {
-                        cleanedSomeRefs = true;
-                    }
-
-                    outstandingRefsRemain = outstandingRefsRemain || stripes[i].hasOutstandingRefs();
-                }
-
-                if (cleanedSomeRefs) {
-                    // Don't sleep unless we run out of refs to process on all stripes.
-                    continue;
-                }
-
-                if (!outstandingRefsRemain) {
-                    // We've drained all refs, which means the Janitor is also gone and our work is done.
-                    return;
-                }
-
-                // Go to sleep on an arbitrary stripe. If we don't end up finding anything on this stripe, move on to
-                // the next stripe on the next iteration (if there's only one thread generating garbage we hope to end
-                // up stuck on that thread).
-                if (stripes[sleepIndex].tryClean(true) == 0) {
-                    sleepIndex = (sleepIndex + 1) & stripeIndexMask;
-                }
-
-                // We use the thread interrupt to wake the thread from its slumber to make unit tests more reproducible.
-                // Now that we're awake we can clear the interrupt flag.
-                Thread.interrupted();
-            }
-        }
-
-        private Stripe getStripe() {
-            return stripes[System.identityHashCode(Thread.currentThread()) & stripeIndexMask];
-        }
-
-        Mess register(Object referent, Runnable cleanup) {
-            return getStripe().add(referent, cleanup);
-        }
+    private Stripe getStripe() {
+      return stripes[System.identityHashCode(Thread.currentThread()) & stripeIndexMask];
     }
 
+    Mess register(Object referent, Runnable cleanup) {
+      return getStripe().add(referent, cleanup);
+    }
+  }
 }


### PR DESCRIPTION
*Issue #, if available:*
n/a

*Description of changes:*
These files were previously excluded due to JML syntax breaking the
formatter rules. Now that we removed the JML syntax, we can apply
consistent formatting.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
