### PR TITLE
Let ECDSA Signature objects accept parameters

### DIFF
--- a/src/com/amazon/corretto/crypto/provider/EcUtils.java
+++ b/src/com/amazon/corretto/crypto/provider/EcUtils.java
@@ -220,6 +220,18 @@ final class EcUtils {
     return name;
   }
 
+  static boolean ecParameterSpecsAreEqual(final ECParameterSpec a, final ECParameterSpec b) {
+    if (a == b) {
+      return true;
+    } else if (a == null || b == null) {
+      return false;
+    }
+    return a.getCofactor() == b.getCofactor()
+        && a.getOrder().equals(b.getOrder())
+        && a.getCurve().equals(b.getCurve())
+        && a.getGenerator().equals(b.getGenerator());
+  }
+
   static final class ECInfo {
     private final ThreadLocal<NativeGroup> group =
         new ThreadLocal<NativeGroup>() {


### PR DESCRIPTION
The OpenJDK expects ECDSA signature objects to support calls to `setParameter()`. This can be seen in their [SignatureParameters](https://github.com/openjdk/jdk/blob/master/test/jdk/sun/security/ec/SignatureParameters.java) test.  The proposed change matches the default JDK behavior in that it requires that the set parameters be equal to those from the key.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
