### PR TITLE
Do not destroy linked public keys

### DIFF
--- a/src/com/amazon/corretto/crypto/provider/EvpEcPrivateKey.java
+++ b/src/com/amazon/corretto/crypto/provider/EvpEcPrivateKey.java
@@ -23,10 +23,12 @@ class EvpEcPrivateKey extends EvpEcKey implements ECPrivateKey, CanDerivePublicK
 
   @Override
   public EvpEcPublicKey getPublicKey() {
-    ephemeral =
-        false; // Once our internal key could be elsewhere, we can no longer safely release it when
-    // done
-    return new EvpEcPublicKey(internalKey);
+    // Once our internal key could be elsewhere, we can no longer safely release it when done
+    ephemeral = false;
+    sharedKey = true;
+    final EvpEcPublicKey result = new EvpEcPublicKey(internalKey);
+    result.sharedKey = true;
+    return result;
   }
 
   @Override

--- a/src/com/amazon/corretto/crypto/provider/EvpRsaPrivateCrtKey.java
+++ b/src/com/amazon/corretto/crypto/provider/EvpRsaPrivateCrtKey.java
@@ -45,10 +45,12 @@ class EvpRsaPrivateCrtKey extends EvpRsaPrivateKey
 
   @Override
   public EvpRsaPublicKey getPublicKey() {
-    ephemeral =
-        false; // Once our internal key could be elsewhere, we can no longer safely release it when
-    // done
-    return new EvpRsaPublicKey(internalKey);
+    // Once our internal key could be elsewhere, we can no longer safely release it when done
+    ephemeral = false;
+    sharedKey = true;
+    final EvpRsaPublicKey result = new EvpRsaPublicKey(internalKey);
+    result.sharedKey = true;
+    return result;
   }
 
   @Override

--- a/src/com/amazon/corretto/crypto/provider/EvpRsaPrivateKey.java
+++ b/src/com/amazon/corretto/crypto/provider/EvpRsaPrivateKey.java
@@ -47,6 +47,7 @@ class EvpRsaPrivateKey extends EvpRsaKey implements RSAPrivateKey {
   @Override
   protected byte[] internalGetEncoded() {
     // RSA private keys in Java may lack CRT parameters and thus need custom serialization
+    assertNotDestroyed();
     byte[] result = encoded;
     if (result == null) {
       synchronized (this) {

--- a/tst/com/amazon/corretto/crypto/provider/test/EcGenTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/EcGenTest.java
@@ -294,6 +294,12 @@ public class EcGenTest {
   }
 
   @Test
+  public void separateDestruction() throws Exception {
+    final KeyPair keyPair = nativeGen.generateKeyPair();
+    RsaGenTest.testSeparateDestruction(keyPair);
+  }
+
+  @Test
   public void threadStorm() throws Throwable {
     final byte[] rngSeed = TestUtil.getRandomBytes(20);
     System.out.println("RNG Seed: " + Arrays.toString(rngSeed));

--- a/tst/com/amazon/corretto/crypto/provider/test/EvpKeyFactoryTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/EvpKeyFactoryTest.java
@@ -179,7 +179,7 @@ public class EvpKeyFactoryTest {
     return result;
   }
 
-  private static long getRawPointer(Object evpKey) throws Exception {
+  static long getRawPointer(final Object evpKey) throws Exception {
     final Object internalKey = sneakyGetField(evpKey, "internalKey");
     final Object cell = sneakyGetField(internalKey, "cell");
     return (long) sneakyGetField(cell, "ptr");


### PR DESCRIPTION
ACCP private keys currently support destruction to make it easier to clean up sensitive data from memory. Currently the logic has three issues which need to be fixed:

1. When both a private and a public key share a single native resource (as happens when ACCP generates them), destroying the private key also destroys the public key.
2. Destroying a private key does not result in clearing the PKCS#8 encoded key.
3. Attempting to use a destroyed key results in an IllegalStateException with a message references “Use after free.” This is misleading and might cause users to worry.




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
