### PR TITLE
Fix ByteBuffer position handling

### DIFF
--- a/src/com/amazon/corretto/crypto/provider/AesGcmSpi.java
+++ b/src/com/amazon/corretto/crypto/provider/AesGcmSpi.java
@@ -867,9 +867,8 @@ final class AesGcmSpi extends CipherSpi {
       case NATIVE_MODE_DECRYPT:
         // Our implementation of engineUpdate for decrypt doesn't actually return any data, we
         // simply buffer the ciphertext and leave the output buffer alone, so we don't bother
-        // passing it through.
-        ShimArray cipherText = new ShimArray(input, input.remaining());
-        engineUpdate(cipherText.array, cipherText.offset, cipherText.length, null, 0);
+        // passing it through. We just write it directly to the buffer.
+        decryptInputBuf.write(input);
         return 0;
       case NATIVE_MODE_ENCRYPT:
         ByteBuffer bufferForClear = null;


### PR DESCRIPTION
PR #296 introduced a bug into `ByteBuffer` handling for the AES/GCM decrypt case. Previously, it would correctly update the position of the `ByteBuffer` to mark that all data was consumed but now it leaves it unchanged. This PR makes the following changes:

1. Updates unit tests to prevent regression
2. Moves data directly from the `ByteBuffer` to the underlying `AccessibleByteArrayOutputStream` (which is logically equivalent to what `engineUpdate(byte[], int, int, byte[], int)` does anyway).
    1. This method fixes the `ByteBuffer` position issue
    2. Eliminates yet another byte array copy (which was the motivation for PR # 296 in the first place)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
