### PR TITLE
Fix input wiping on decryption failure

### DIFF
--- a/src/com/amazon/corretto/crypto/provider/AesGcmSpi.java
+++ b/src/com/amazon/corretto/crypto/provider/AesGcmSpi.java
@@ -707,8 +707,8 @@ final class AesGcmSpi extends CipherSpi {
                       workingInputArray,
                       workingInputOffset,
                       workingInputLength,
-                      output,
-                      outputOffset,
+                      workingInputArray, // Output
+                      workingInputOffset, // Output Offset
                       tagLength,
                       key,
                       iv,
@@ -730,8 +730,8 @@ final class AesGcmSpi extends CipherSpi {
                 workingInputArray,
                 workingInputOffset,
                 workingInputLength,
-                output,
-                outputOffset,
+                workingInputArray, // Output
+                workingInputOffset, // Output Offset
                 tagLength,
                 key,
                 iv,
@@ -747,12 +747,9 @@ final class AesGcmSpi extends CipherSpi {
         }
       }
       // Decryption completed successfully.
+      // Copy from working buffer into actual output
+      System.arraycopy(workingInputArray, workingInputOffset, output, outputOffset, outLen);
       return outLen;
-    } catch (AEADBadTagException e) {
-      final int maxFillSize = output.length - outputOffset;
-      Arrays.fill(
-          output, outputOffset, Math.min(maxFillSize, engineGetOutputSize(inputLen)), (byte) 0);
-      throw e;
     } finally {
       stateReset();
     }


### PR DESCRIPTION
PR #298 appears to have introduced a bug wherein when there is decryption failure can cause the input buffer to be wiped. Specifically, this happens for AES-GCM in-place decryption. (Ideally, the output buffer would remain unchanged in all failure cases, but that change is more understandable.)

This change:

* Returns to using a staging buffer to hold the unauthenticated plaintext
* Uses the pre-existing input buffer to avoid memory allocation. (This wasn’t possible prior to PR # 298 because the input buffer wasn’t always used.)
* Copies the plaintext over to the output buffer only upon successful decryption
* Introduces a unit tests to avoid regression


So, this new change does incur a new memory copy relative to the current situation (but the same as before PR # 298) but does not incur any new memory allocation (so we keep that win from # 298).



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
