### PR TITLE
Avoid buffering cipher text for one-shot AES-GCM decrypt

### DIFF
--- a/tst/com/amazon/corretto/crypto/provider/test/AccessibleByteArrayOutputStreamTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/AccessibleByteArrayOutputStreamTest.java
@@ -8,6 +8,7 @@ import static com.amazon.corretto.crypto.provider.test.TestUtil.sneakyInvoke;
 import static com.amazon.corretto.crypto.provider.test.TestUtil.sneakyInvoke_int;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
@@ -109,6 +110,27 @@ public class AccessibleByteArrayOutputStreamTest {
     instance.write(expected2);
     assertArrayEquals(expected2, sneakyInvoke(instance, "getDataBuffer"));
     assertArrayEquals(expected, sneakyInvoke(cloned, "getDataBuffer"));
+  }
+
+  @Test
+  public void testFinalWrite() throws Throwable {
+    OutputStream instance = getInstance(0, Integer.MAX_VALUE);
+    final byte[] data = {1, 2, 3, 4, 5, 6, 7};
+    instance.write(data, 0, 3);
+    assertEquals(3, sneakyInvoke_int(instance, "size"));
+    byte[] buf1 = sneakyInvoke(instance, "getDataBuffer");
+    assertEquals(1, buf1[0]);
+    assertEquals(2, buf1[1]);
+    assertEquals(3, buf1[2]);
+    assertEquals(3, buf1.length);
+    instance.write(data, 3, 2);
+    assertEquals(5, sneakyInvoke_int(instance, "size"));
+    byte[] buf2 = sneakyInvoke(instance, "getDataBuffer");
+    assertNotEquals(buf1, buf2);
+    assertEquals(6, buf2.length);
+    sneakyInvoke(instance, "finalWrite", data, 5, 2);
+    byte[] buf3 = sneakyInvoke(instance, "getDataBuffer");
+    assertArrayEquals(data, buf3);
   }
 
   private static OutputStream getInstance(final Object... args) throws Throwable {


### PR DESCRIPTION
*Description of changes:*

AES-GCM decrypt buffers the ciphertext before decryption. This buffering can be avoided for one-shot decryption. Our benchmarks show performance improvement of AES-GCM one-shot decryption by 33% for 128 bit key and 26% for 256 bit key.

Before this PR:
```
Benchmark                         (keyBits)   Mode  Cnt     Score     Error  Units
AesGcmOneShot.oneShot1MiBDecrypt        128  thrpt    5  1953.188 ±  59.826  ops/s
AesGcmOneShot.oneShot1MiBDecrypt        256  thrpt    5  1710.003 ± 108.368  ops/s
```

After this PR:
```
Benchmark                         (keyBits)   Mode  Cnt     Score    Error  Units
AesGcmOneShot.oneShot1MiBDecrypt        128  thrpt    5  2606.189 ± 61.312  ops/s
AesGcmOneShot.oneShot1MiBDecrypt        256  thrpt    5  2161.426 ± 41.597  ops/s
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
