### PR TITLE
Update PyYAML Dependency in CI

### DIFF
--- a/tests/ci/cdk/setup.py
+++ b/tests/ci/cdk/setup.py
@@ -25,7 +25,7 @@ setuptools.setup(
         "aws-cdk.aws-ecr==1.97.0",
         "aws-cdk.aws-iam==1.97.0",
         # PyYAML is a YAML parser and emitter for Python. Used to read build_spec.yaml.
-        "pyyaml==5.4",
+        "pyyaml==6.0.1",
         # A formatter for Python code.
         "yapf==0.30.0",
     ],


### PR DESCRIPTION
*Issue #, if available:*
nil

*Description of changes:*

This version no longer installs successfully because one of its
dependencies uses a deprecated setup.cfg key.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
