### PR TITLE
Control the version of AWS-LC used for FIPS builds in CI tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 tests/ci/cdk/.idea
 tests/ci/cdk/venv
 coverage/
+aws-lc

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "aws-lc"]
-	path = aws-lc
-	url = https://github.com/awslabs/aws-lc

--- a/README.md
+++ b/README.md
@@ -197,11 +197,13 @@ but yours will not be.*
 Building this provider requires a 64 bit Linux or MacOS build system with the following prerequisites installed:
 * OpenJDK 10 or newer
 * [cmake](https://cmake.org/) 3.8 or newer
+* Git
+* Golang (required by AWS-LC)
 * C++ build chain
 * [lcov](http://ltp.sourceforge.net/coverage/lcov.php) for coverage metrics
 * [gcovr](https://gcovr.com/en/stable/) for reporting coverage metrics in CodeBuild
 
-1. Download the repository via `git clone --recurse-submodules`
+1. Download the repository via `git clone`
 2. Run `./gradlew release`
 3. The resulting jar is in `build/lib`
 
@@ -209,7 +211,9 @@ Building this provider requires a 64 bit Linux or MacOS build system with the fo
 **FIPS builds are still experimental and are not yet ready for production use.**
 
 By providing `-DFIPS=true` to `gradlew` you will cause the entire build to be for a "FIPS mode" build.
-The only significant difference is that AWS-LC is built with `FIPS=1`.
+The FIPS builds use a different version of AWS-LC along with `FIPS=1` build flag. Not all releases of
+AWS-LC will have FIPS certification. As a result, ACCP in FIPS mode only uses a version of AWS-LC
+that has FIPS certification or it will have in future.
 
 For performance reasons, ACCP does not register a SecureRandom implementation in FIPS mode.
 Relevant operations within the FIPS module boundary (e.g. key generation, non-deterministic signing, etc.) will still use AWS-LC's internal DRBG.

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,8 @@
 // Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import groovy.xml.*
 
 plugins {
@@ -15,6 +17,13 @@ plugins {
 group = 'software.amazon.cryptools'
 version = '2.3.2'
 ext.isFips = Boolean.getBoolean('FIPS')
+
+if (ext.isFips) {
+    ext.awsLcGitVersionId = 'AWS-LC-FIPS-2.0.0'
+} else {
+    ext.awsLcGitVersionId = 'v1.17.0'
+}
+
 ext.isLegacyBuild = Boolean.getBoolean('LEGACY_BUILD')
 
 ext.lcovIgnore = System.properties['LCOV_IGNORE']
@@ -168,8 +177,35 @@ task buildAwsLc {
     outputs.dir("${sharedObjectOutDir}")
 
     doFirst {
-        if (file(awslcSrcPath).list().size() == 0) {
-            throw new GradleException("aws-lc dir empty! run 'git submodule update --init --recursive' to populate.")
+        if (isLegacyBuild) {
+            // The legacy build uses an old Ubuntu version that does not have git. So we use curl for that.
+            def unzipDirName = "aws-lc-${awsLcGitVersionId.substring(1)}"
+            if (isFips) {
+                unzipDirName = "aws-lc-${awsLcGitVersionId}"
+            }
+            exec {
+                workingDir "${projectDir}"
+                commandLine "curl", "-L", "http://github.com/aws/aws-lc/archive/refs/tags/${awsLcGitVersionId}.zip", "--output", "libcrypto-src.zip"
+            }
+            exec {
+                workingDir "${projectDir}"
+                commandLine "unzip", "libcrypto-src.zip"
+            }
+            exec {
+                workingDir "${projectDir}"
+                commandLine "mv", unzipDirName, "aws-lc"
+            }
+        } else {
+            if (!Files.isDirectory(Paths.get(awslcSrcPath))) {
+                exec {
+                    workingDir "${projectDir}"
+                    commandLine "git", "clone", "https://github.com/aws/aws-lc.git"
+                }
+            }
+            exec {
+                workingDir "${awslcSrcPath}"
+                commandLine "git", "checkout", "${awsLcGitVersionId}"
+            }
         }
         mkdir "${buildDir}/awslc"
         mkdir sharedObjectOutDir

--- a/tests/ci/codebuild/run_accp_legacy_build.yml
+++ b/tests/ci/codebuild/run_accp_legacy_build.yml
@@ -6,6 +6,7 @@ version: 0.2
 phases:
   install:
     commands:
+      - apt-get update
       - apt-get -y install curl
       - mkdir go_tmp && cd go_tmp
       - curl https://dl.google.com/go/go1.18.3.linux-amd64.tar.gz --output go.tar.gz


### PR DESCRIPTION
*Description of changes:*

ACCP use Git submodule to identify the exact commit of AWS-LC that it needs. In FIPS mode, we need to use a different version of AWS-LC.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
