### PR TITLE
Control the version of AWS-LC used for FIPS and non-FIPS builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,9 @@ Building this provider requires a 64 bit Linux or MacOS build system with the fo
 **FIPS builds are still experimental and are not yet ready for production use.**
 
 By providing `-DFIPS=true` to `gradlew` you will cause the entire build to be for a "FIPS mode" build.
-The only significant difference is that AWS-LC is built with `FIPS=1`.
+The FIPS builds use a different version of AWS-LC along with `FIPS=1` build flag. Not all releases of
+AWS-LC will have FIPS certification. As a result, ACCP in FIPS mode only uses a version of AWS-LC
+that has FIPS certification or it will have in future.
 
 For performance reasons, ACCP does not register a SecureRandom implementation in FIPS mode.
 Relevant operations within the FIPS module boundary (e.g. key generation, non-deterministic signing, etc.) will still use AWS-LC's internal DRBG.

--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,11 @@ plugins {
 group = 'software.amazon.cryptools'
 version = '2.3.2'
 ext.isFips = Boolean.getBoolean('FIPS')
+if (ext.isFips) {
+    ext.awsLcGitVersionId = 'AWS-LC-FIPS-2.0.0'
+} else {
+    ext.awsLcGitVersionId = 'v1.17.0'
+}
 ext.isLegacyBuild = Boolean.getBoolean('LEGACY_BUILD')
 
 ext.lcovIgnore = System.properties['LCOV_IGNORE']
@@ -170,6 +175,17 @@ task buildAwsLc {
     doFirst {
         if (file(awslcSrcPath).list().size() == 0) {
             throw new GradleException("aws-lc dir empty! run 'git submodule update --init --recursive' to populate.")
+        }
+
+        if (!isLegacyBuild) {
+            exec {
+                workingDir awslcSrcPath
+                commandLine "git", "fetch", "--tags"
+            }
+            exec {
+                workingDir awslcSrcPath
+                commandLine "git", "checkout", awsLcGitVersionId
+            }
         }
         mkdir "${buildDir}/awslc"
         mkdir sharedObjectOutDir


### PR DESCRIPTION
*Description of changes:*
ACCP FIPS uses a different version of AWS-LC. In this PR, we allow the CI tasks to switch to the required version when building in FIPS or non-FIPS mode.

Our legacy build, still requires the use of Git submodules to track the version of AWS-LC used. Once that is deprecated, we can stop using Git submodules and only rely on the value of `ext.awLcGitVersionId` in `build.gradle` as the only place for tracking AWS-LC's version using for ACCP and ACCP-FIPS.

With this PR, we do not need to update the Git submodule for AWS-LC since the build always check the version specified by `ext.awLcGitVersionId` is checked out.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
