### PR TITLE
Allow AccessibleByteArrayOutputStream to shrink

### DIFF
--- a/src/com/amazon/corretto/crypto/provider/BufferShrinkStrategy.java
+++ b/src/com/amazon/corretto/crypto/provider/BufferShrinkStrategy.java
@@ -1,0 +1,103 @@
+package com.amazon.corretto.crypto.provider;
+
+/**
+ * Represents a strategy for downsizing/shrinking a reusable buffer.
+ * For example, {@link AccessibleByteArrayOutputStream} holds a reusable buffer which grows as needed
+ * to accommodate different sized payloads. If this buffer never shrinks, it may waste space (for example
+ * if we see one rare very large payload but subsequent payloads are small, the buffer will remain unnecessarily
+ * large).
+ * Note: implementations are usually stateful and thus instances cannot be safely shared.
+ */
+public interface BufferShrinkStrategy {
+    // TODO: could return 'recommended buffer size' instead of boolean. Value/simplicity?
+    // TODO: should the strategy also handle growth?
+
+    /**
+     * Buffer owners should call this after consumption of every payload.
+     * E.g. handlePayload(byte[] payload) {
+     *   ... maybe grow buffer
+     *   ... encrypt
+     *   if (shouldShrink(payload.length, buffer.length)) shrinkBuf();
+     * }
+     * @param payloadSize The size of the payload processed.
+     * @param bufferSize The size of the buffer.
+     * @return true if the strategy recommends shrinking the buffer. false otherwise.
+     */
+    boolean shouldShrink(int payloadSize, int bufferSize);
+
+    /**
+     * Shrink the buffer when it is too large for the payload ('over-sized') N times in a row.
+     * E.g. if an 800KB payload grows the buffer to 1MB, we shrink the buffer after seeing N consecutive
+     * payloads under 500KB.
+     */
+    class BasicThreshold implements BufferShrinkStrategy {
+        private final int timesOversizedThreshold;
+        private int timesOversized = 0;
+
+        public BasicThreshold() {
+            this.timesOversizedThreshold = 1024;
+        }
+
+        public BasicThreshold(int timesOversizedThreshold) {
+            this.timesOversizedThreshold = timesOversizedThreshold;
+        }
+
+        @Override
+        public boolean shouldShrink(int payloadSize, int bufferSize) {
+            if (bufferSize / 2 > payloadSize) {
+                // The buffer was over-sized for this usage.
+                if (timesOversized++ > timesOversizedThreshold) {
+                    timesOversized = 0;
+                    return true;
+                }
+            } else {
+                // Buffer was not over-sized, reset counter.
+                timesOversized = 0;
+            }
+            return false;
+        }
+    }
+
+    /**
+     * Similar to {@link BasicThreshold}, but the threshold starts at 1 and increases
+     * to the chosen limit. This has the benefit of being somewhat adaptive; it starts
+     * out eager to shrink quickly after a large payload, but slows down every time
+     * re-growth is needed, up to the chosen limit.
+     */
+    class IncreasingThreshold implements BufferShrinkStrategy {
+        private final int maxOversizedThreshold;
+        private int timesOversizedThreshold = 1;
+        private int timesOversized = 0;
+        private int previousBufferSize = Integer.MAX_VALUE;
+
+        public IncreasingThreshold() {
+            this.maxOversizedThreshold = 1024;
+        }
+
+        public IncreasingThreshold(int maxOversizedThreshold) {
+            this.maxOversizedThreshold = maxOversizedThreshold;
+        }
+
+        @Override
+        public boolean shouldShrink(int payloadSize, int bufferSize) {
+            if (bufferSize > previousBufferSize) {
+                // Every time we need to grow, make it harder to shrink in the future (up to a limit).
+                timesOversizedThreshold = Math.min(maxOversizedThreshold, timesOversizedThreshold * 2);
+            }
+            previousBufferSize = bufferSize;
+
+            if (bufferSize / 2 > payloadSize) {
+                // The buffer was over-sized for this usage.
+                if (timesOversized++ > timesOversizedThreshold) {
+                    timesOversized = 0;
+                    return true;
+                }
+            } else {
+                // Buffer was not over-sized, reset counter.
+                timesOversized = 0;
+            }
+
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
Note: this is a draft PR to get feedback on the idea in general. I can add tests etc. if the approach is approved. Let me know if you'd prefer me to create an issue to discuss.

AccessibleByteArrayOutputStream currently can only grow or stay the same size. This could be a problem if it is used for a rare large item, but then used only for small items - the buffer would stay large forever, consuming memory. Since an application may hold many of these buffers via their use particularly in Cipher, the memory impact could be significant.

This simple shrinkage algorithm shrinks the buffer if it has been 'too large' N times in a row. N starts at 1, and grows exponentially up to a limit of 1024 as re-growths are triggered. N starts low to enable reacting quickly, but as more growths are observed it increases to avoid churn. It is capped to avoid degrading into 'never-shrink' behaviour over the long term.

Other ideas were considered, like keeping track of the last N used sizes and making decisions based on those values, but this algorithm has a tiny footprint (2 ints, could be shorts) and low computation overhead.

Here are some example progressions (each column shows the state of the algorithm/buffer at that step, and the action if any taken after that input, e.g. g(128) means grow buffer to 128. s is shrink):

```
// 1 large, many small
       Input size:   100 |    1 |    1 |    1 |    1 |    1 |    1 |    1 |    1 |    1 |    1 |    1 |    1 |    1 |
      Buffer size:     0 |  128 |  128 |  128 |  128 |   64 |   64 |   64 |   64 |   32 |   32 |   32 |   32 |   16 |
 Times over-sized:     0 |    0 |    1 |    2 |    3 |    0 |    1 |    2 |    3 |    0 |    1 |    2 |    3 |    0 |
        Threshold:     1 |    2 |    2 |    2 |    2 |    2 |    2 |    2 |    2 |    2 |    2 |    2 |    2 |    2 |
          Action: g(128) |    - |    - |    - |s(64) |    - |    - |    - |s(32) |    - |    - |    - |s(16) |    - |
          
// large/small oscillation
       Input size:     1 |    2 |    4 |    8 |    2 |    8 |    2 |    8 |    2 |
      Buffer size:     0 |    1 |    2 |    4 |    8 |    8 |    8 |    8 |    8 |
 Times over-sized:     0 |    0 |    0 |    0 |    0 |    1 |    0 |    1 |    0 |
        Threshold:     1 |    2 |    4 |    8 |   16 |   16 |   16 |   16 |   16 |
           Action:  g(1) | g(2) | g(4) | g(8) |    - |    - |    - |    - |    - |
 
 // 6 small 1 large repeat
       Input size:     1 |    1 |    1 |    1 |    1 |    1 |    5 |    1 |    1 |    1 |    1 |    1 |    1 |    5 |    1 |    1 |    1 |    1 |    1 |    1 |    5 |    1 |    1 |    1 |    1 |    1 |    1 |    5 |
      Buffer size:     0 |    1 |    1 |    1 |    1 |    1 |    1 |    8 |    8 |    8 |    8 |    8 |    8 |    4 |    8 |    8 |    8 |    8 |    8 |    8 |    8 |    8 |    8 |    8 |    8 |    8 |    8 |    8 |
 Times over-sized:     0 |    0 |    0 |    0 |    0 |    0 |    0 |    0 |    1 |    2 |    3 |    4 |    5 |    0 |    0 |    1 |    2 |    3 |    4 |    5 |    6 |    0 |    1 |    2 |    3 |    4 |    5 |    6 |
        Threshold:     1 |    2 |    2 |    2 |    2 |    2 |    2 |    4 |    4 |    4 |    4 |    4 |    4 |    4 |    8 |    8 |    8 |    8 |    8 |    8 |    8 |    8 |    8 |    8 |    8 |    8 |    8 |    8 |
           Action:  g(1) |    - |    - |    - |    - |    - | g(8) |    - |    - |    - |    - |    - | s(4) | g(8) |    - |    - |    - |    - |    - |    - |    - |    - |    - |    - |    - |    - |    - |    - |
```

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
