### PR TITLE
Reduce build time by 35%

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -432,22 +432,6 @@ task test_extra_checks(type: Copy) {
     into "${buildDir}/reports/unit-tests"
 }
 
-task test_exec(type: Exec) {
-    dependsOn executeCmake
-    workingDir "${buildDir}/cmake"
-    commandLine 'make', 'check'
-}
-
-task unit_tests(type: Copy) {
-    doFirst {
-        mkdir "${buildDir}/reports/unit-tests"
-    }
-    dependsOn test_exec
-    from "${buildDir}/cmake/unit-tests/"
-    into "${buildDir}/reports/unit-tests"
-}
-test.dependsOn unit_tests
-
 task single_test(type: Exec) {
     dependsOn executeCmake
     workingDir "${buildDir}/cmake"
@@ -571,12 +555,23 @@ task coverage_cpp_report {
 task coverage {
     dependsOn coverage_java_report, coverage_cpp_report
 }
+test.dependsOn coverage
+
+task unit_tests(type: Copy) {
+    doFirst {
+        mkdir "${buildDir}/reports/unit-tests"
+    }
+    dependsOn coverage_exec
+    from "${buildDir}/cmake/unit-tests/"
+    into "${buildDir}/reports/unit-tests"
+}
+test.dependsOn unit_tests
 
 task release {
     if (isLegacyBuild) {
         dependsOn build, test, javadoc, src_jar
     } else {
-        dependsOn build, test, coverage, javadoc, src_jar
+        dependsOn build, test, javadoc, src_jar
     }
 }
 


### PR DESCRIPTION
*Issue #, if available:*
CryptoAlg-2210

*Description of changes:*
The gradle tasks coverage_exec and test_exec correspond to the
underlying CMake tasks coverage and check respectively. In CMake,
the coverage task depends on check. Because of how the gradle task
dependencies are wired up we run these tasks separately and end up
running the CMake check task twice. The check target is responsible for
running all of our unit tests which is by far the longest portion of our
build which is why not doing that twice cuts our build time by 35%. This
avoids the redundancy by re-arranging the dependency graph in gradle to
run coverage once and generate both unit test and coverage reports out
of it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
