### PR TITLE
Match SunRsaSign's behavior when setting null params

### DIFF
--- a/src/com/amazon/corretto/crypto/provider/EvpSignatureBase.java
+++ b/src/com/amazon/corretto/crypto/provider/EvpSignatureBase.java
@@ -228,7 +228,7 @@ abstract class EvpSignatureBase extends SignatureSpi {
         throw new InvalidAlgorithmParameterException("Algorithm parameters do not match key");
       }
       // Check passes, no actual changes needed
-    } else if (params != null) {
+    } else {
       throw new InvalidAlgorithmParameterException(
           "Specified parameters supported by this algorithm");
     }

--- a/tst/com/amazon/corretto/crypto/provider/test/EvpSignatureSpecificTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/EvpSignatureSpecificTest.java
@@ -448,6 +448,13 @@ public final class EvpSignatureSpecificTest {
             signature.setParameter(
                 new PSSParameterSpec("SHA-1", "MGF1", MGF1ParameterSpec.SHA1, 4096, 1)));
 
+    // Assert compatiblity with JCE on setting null parameter, BC doesn't throw.
+    assertThrows(InvalidAlgorithmParameterException.class, () -> signature.setParameter(null));
+    assertThrows(
+        InvalidAlgorithmParameterException.class,
+        () -> Signature.getInstance("RSASSA-PSS", "SunRsaSign").setParameter(null));
+    Signature.getInstance("RSASSA-PSS", TestUtil.BC_PROVIDER).setParameter(null);
+
     // "1" should be only valid trailer value.
     for (int ii = -10; ii < 11; ii++) {
       if (ii == 1) {
@@ -478,14 +485,6 @@ public final class EvpSignatureSpecificTest {
 
     signature = Signature.getInstance("RSASSA-PSS", NATIVE_PROVIDER);
     signature.initVerify(pair.getPublic());
-    spec = getPssParams(signature);
-    assertEquals("SHA-1", spec.getDigestAlgorithm());
-    assertEquals("SHA-1", ((MGF1ParameterSpec) spec.getMGFParameters()).getDigestAlgorithm());
-
-    // setting null params OK, shouldn't change from default
-    signature = Signature.getInstance("RSASSA-PSS", NATIVE_PROVIDER);
-    signature.setParameter(null);
-    signature.initSign(pair.getPrivate());
     spec = getPssParams(signature);
     assertEquals("SHA-1", spec.getDigestAlgorithm());
     assertEquals("SHA-1", ((MGF1ParameterSpec) spec.getMGFParameters()).getDigestAlgorithm());

--- a/tst/com/amazon/corretto/crypto/provider/test/EvpSignatureSpecificTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/EvpSignatureSpecificTest.java
@@ -770,14 +770,14 @@ public final class EvpSignatureSpecificTest {
   }
 
   @Test
-  public void ecdsaAcceptsNullParams() throws Exception {
+  public void ecdsaRejectsNullParams() throws Exception {
     final Signature signer = Signature.getInstance("SHA384withECDSA", NATIVE_PROVIDER);
     signer.initSign(ECDSA_PAIR.getPrivate());
-    signer.setParameter(null);
+    assertThrows(InvalidAlgorithmParameterException.class, () -> signer.setParameter(null));
     signer.update(MESSAGE);
     final byte[] signature = signer.sign();
     signer.initVerify(ECDSA_PAIR.getPublic());
-    signer.setParameter(null);
+    assertThrows(InvalidAlgorithmParameterException.class, () -> signer.setParameter(null));
     signer.update(MESSAGE);
     assertTrue(signer.verify(signature));
   }

--- a/tst/com/amazon/corretto/crypto/provider/test/EvpSignatureTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/EvpSignatureTest.java
@@ -87,10 +87,14 @@ public class EvpSignatureTest {
       this.paramSpec = paramSpec;
 
       signer = getNativeSigner();
-      signer.setParameter(paramSpec);
+      if (paramSpec != null) {
+        signer.setParameter(paramSpec);
+      }
       signer.initSign(keyPair.getPrivate());
       verifier = getNativeSigner();
-      verifier.setParameter(paramSpec);
+      if (paramSpec != null) {
+        verifier.setParameter(paramSpec);
+      }
       verifier.initVerify(keyPair.getPublic());
 
       jceVerifier = getJceSigner();


### PR DESCRIPTION
# Notes

We're stuck in a bit of a compatibility pickle -- when null parameters are specified, Sun's behavior is to throw an exception but BC's behavior is to carry on silently. So, which one should we choose? We've decided to go with Sun's behavior because even though this change will mean _more_ cases where an exception is thrown than before (which could amount to a breaking change in some cases),
InvalidAlgorithmParameterException [is a checked exception][1], so the compiler will force callers to handle it in some form. If InvalidAlgorithmParameterException were an unchecked RuntimeException, this change would not be advisable, as callers may not be properly handling that case.

[1]: https://docs.oracle.com/javase/8/docs/api/java/security/InvalidAlgorithmParameterException.html

*Issue #, if available:* t/V921660568

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
