### PR TITLE
Revert "Reduce build time by 35% (#354)"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -430,6 +430,22 @@ task test_extra_checks(type: Copy) {
     into "${buildDir}/reports/unit-tests"
 }
 
+task test_exec(type: Exec) {
+    dependsOn executeCmake
+    workingDir "${buildDir}/cmake"
+    commandLine 'make', 'check'
+}
+
+task unit_tests(type: Copy) {
+    doFirst {
+        mkdir "${buildDir}/reports/unit-tests"
+    }
+    dependsOn test_exec
+    from "${buildDir}/cmake/unit-tests/"
+    into "${buildDir}/reports/unit-tests"
+}
+test.dependsOn unit_tests
+
 task single_test(type: Exec) {
     dependsOn executeCmake
     workingDir "${buildDir}/cmake"
@@ -556,20 +572,13 @@ task coverage_cpp_report {
 task coverage {
     dependsOn coverage_java_report, coverage_cpp_report
 }
-test.dependsOn coverage
-
-task unit_tests(type: Copy) {
-    doFirst {
-        mkdir "${buildDir}/reports/unit-tests"
-    }
-    dependsOn coverage_exec
-    from "${buildDir}/cmake/unit-tests/"
-    into "${buildDir}/reports/unit-tests"
-}
-test.dependsOn unit_tests
 
 task release {
-    dependsOn build, test, javadoc, src_jar
+    if (isLegacyBuild) {
+        dependsOn build, test, javadoc, src_jar
+    } else {
+        dependsOn build, test, coverage, javadoc, src_jar
+    }
 }
 
 task overkill {


### PR DESCRIPTION
*Description of changes:*

This reverts commit 6e716d723ac6833044637c702dffffcbe1e10b11.

Coverage calculation requires building a jar with debug flags and it cannot be performed on a pre-built jar. [This commit](6e716d723ac6833044637c702dffffcbe1e10b11) made testing depend on coverage, and as a result, when test task is run, a jar is built and tested. Oracle JDK requires the jar to be signed, therefore, one cannot run coverage with Oracle JDK. This PR reverts [this change](6e716d723ac6833044637c702dffffcbe1e10b11) so that the test task would not depend on coverage.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
