### PR TITLE
Fix IllegalArgumentException upon GCM decryption failure.

### DIFF
--- a/src/com/amazon/corretto/crypto/provider/AesGcmSpi.java
+++ b/src/com/amazon/corretto/crypto/provider/AesGcmSpi.java
@@ -801,8 +801,8 @@ final class AesGcmSpi extends CipherSpi {
           decryptAADBuf.size());
     } catch (final AEADBadTagException e) {
       final int maxFillSize = output.length - outputOffset;
-      Arrays.fill(
-          output, outputOffset, Math.min(maxFillSize, engineGetOutputSize(inputLen)), (byte) 0);
+      final int endIndex = outputOffset + Math.min(maxFillSize, engineGetOutputSize(inputLen));
+      Arrays.fill(output, outputOffset, endIndex, (byte) 0);
       throw e;
     } finally {
       stateReset();


### PR DESCRIPTION
ACCP can throw an incorrect `IllegalArgumentException` upon GCM decryption failure when `Cipher.doFinal(input, inputOffset, length, output, outputOffset)` is used. This is because `Arrays.fill()` (used to zero out the failed decryption) takes the end index as the third parameter and not the length.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
