### PR TITLE
Fix NullPointerException on invalid keys

### DIFF
--- a/src/com/amazon/corretto/crypto/provider/EvpKeyFactory.java
+++ b/src/com/amazon/corretto/crypto/provider/EvpKeyFactory.java
@@ -27,6 +27,8 @@ import java.security.spec.RSAPublicKeySpec;
 import java.security.spec.X509EncodedKeySpec;
 
 abstract class EvpKeyFactory extends KeyFactorySpi {
+  private static final String PKCS8_FORMAT = "PKCS#8";
+  private static final String X509_FORMAT = "X.509";
   private final EvpKeyType type;
   private final AmazonCorrettoCryptoProvider provider;
 
@@ -91,11 +93,11 @@ abstract class EvpKeyFactory extends KeyFactorySpi {
   protected <T extends KeySpec> T engineGetKeySpec(Key key, Class<T> keySpec)
       throws InvalidKeySpecException {
     if (keySpec.isAssignableFrom(PKCS8EncodedKeySpec.class)
-        && key.getFormat().equalsIgnoreCase("PKCS#8")) {
+        && PKCS8_FORMAT.equalsIgnoreCase(key.getFormat())) {
       return keySpec.cast(new PKCS8EncodedKeySpec(requireNonNullEncoding(key)));
     }
     if (keySpec.isAssignableFrom(X509EncodedKeySpec.class)
-        && key.getFormat().equalsIgnoreCase("X.509")) {
+        && X509_FORMAT.equalsIgnoreCase(key.getFormat())) {
       return keySpec.cast(new X509EncodedKeySpec(requireNonNullEncoding(key)));
     }
 
@@ -110,10 +112,10 @@ abstract class EvpKeyFactory extends KeyFactorySpi {
 
     try {
       final EvpKey result;
-      if (key.getFormat().equalsIgnoreCase("PKCS#8")) {
+      if (PKCS8_FORMAT.equalsIgnoreCase(key.getFormat())) {
         result =
             (EvpKey) engineGeneratePrivate(new PKCS8EncodedKeySpec(requireNonNullEncoding(key)));
-      } else if (key.getFormat().equalsIgnoreCase("X.509")) {
+      } else if (X509_FORMAT.equalsIgnoreCase(key.getFormat())) {
         result = (EvpKey) engineGeneratePublic(new X509EncodedKeySpec(requireNonNullEncoding(key)));
       } else {
         throw new InvalidKeyException("Cannot convert key of format " + key.getFormat());

--- a/tst/com/amazon/corretto/crypto/provider/test/EvpKeyFactoryTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/EvpKeyFactoryTest.java
@@ -251,6 +251,45 @@ public class EvpKeyFactoryTest {
 
   @ParameterizedTest(name = "{1}")
   @MethodSource("allPairs")
+  public void nullAlgorithm(final KeyPair keyPair, final String testName) throws Exception {
+    final KeyFactory nativeFactory =
+        KeyFactory.getInstance(keyPair.getPublic().getAlgorithm(), NATIVE_PROVIDER);
+    final Key nullPublicKey = new NullDataKey(keyPair.getPublic(), true, false, false);
+    final Key nullPrivateKey = new NullDataKey(keyPair.getPrivate(), true, false, false);
+
+    assertThrows(InvalidKeyException.class, () -> nativeFactory.translateKey(nullPublicKey));
+
+    assertThrows(InvalidKeyException.class, () -> nativeFactory.translateKey(nullPrivateKey));
+  }
+
+  @ParameterizedTest(name = "{1}")
+  @MethodSource("allPairs")
+  public void nullFormat(final KeyPair keyPair, final String testName) throws Exception {
+    final KeyFactory nativeFactory =
+        KeyFactory.getInstance(keyPair.getPublic().getAlgorithm(), NATIVE_PROVIDER);
+    final Key nullPublicKey = new NullDataKey(keyPair.getPublic(), false, true, false);
+    final Key nullPrivateKey = new NullDataKey(keyPair.getPrivate(), false, true, false);
+
+    assertThrows(InvalidKeyException.class, () -> nativeFactory.translateKey(nullPublicKey));
+
+    assertThrows(InvalidKeyException.class, () -> nativeFactory.translateKey(nullPrivateKey));
+  }
+
+  @ParameterizedTest(name = "{1}")
+  @MethodSource("allPairs")
+  public void nullEncoding(final KeyPair keyPair, final String testName) throws Exception {
+    final KeyFactory nativeFactory =
+        KeyFactory.getInstance(keyPair.getPublic().getAlgorithm(), NATIVE_PROVIDER);
+    final Key nullPublicKey = new NullDataKey(keyPair.getPublic(), false, false, true);
+    final Key nullPrivateKey = new NullDataKey(keyPair.getPrivate(), false, false, true);
+
+    assertThrows(InvalidKeyException.class, () -> nativeFactory.translateKey(nullPublicKey));
+
+    assertThrows(InvalidKeyException.class, () -> nativeFactory.translateKey(nullPrivateKey));
+  }
+
+  @ParameterizedTest(name = "{1}")
+  @MethodSource("allPairs")
   public void testPKCS8Encoding(final KeyPair keyPair, final String testName) throws Exception {
     final PrivateKey privKey = keyPair.getPrivate();
     final String algorithm = privKey.getAlgorithm();
@@ -668,6 +707,40 @@ public class EvpKeyFactoryTest {
     Samples(T nativeSample, T jceSample) {
       this.nativeSample = nativeSample;
       this.jceSample = jceSample;
+    }
+  }
+
+  public static class NullDataKey implements Key {
+    private static final long serialVersionUID = 1;
+    private final Key delegate;
+    private final boolean nullAlgorithm;
+    private final boolean nullFormat;
+    private final boolean nullEncoded;
+
+    public NullDataKey(
+        final Key delegate,
+        final boolean nullAlgorithm,
+        final boolean nullFormat,
+        final boolean nullEncoded) {
+      this.delegate = delegate;
+      this.nullAlgorithm = nullAlgorithm;
+      this.nullFormat = nullFormat;
+      this.nullEncoded = nullEncoded;
+    }
+
+    @Override
+    public String getAlgorithm() {
+      return nullAlgorithm ? null : delegate.getAlgorithm();
+    }
+
+    @Override
+    public String getFormat() {
+      return nullFormat ? null : delegate.getFormat();
+    }
+
+    @Override
+    public byte[] getEncoded() {
+      return nullEncoded ? null : delegate.getEncoded();
     }
   }
 }


### PR DESCRIPTION
ACCP can throw an incorrect `NullPointerException` when attempting to translate invalid keys with `null` formats. Per the JDK documentation this should throw an `InvalidKeySpecException` instead. By throwing the incorrect exception ACCP prevents the JCA from correctly falling back to providers which might support the keys.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
