### PR TITLE
Fix IllegalArgumentException on Cipher.getParameters

### DIFF
--- a/src/com/amazon/corretto/crypto/provider/AesGcmSpi.java
+++ b/src/com/amazon/corretto/crypto/provider/AesGcmSpi.java
@@ -290,7 +290,7 @@ final class AesGcmSpi extends CipherSpi {
       if (ivForParams == null) {
         // We aren't initialized so we return default and random values
         ivForParams = new byte[DEFAULT_IV_LENGTH_BYTES];
-        new SecureRandom().nextBytes(ivForParams);
+        new LibCryptoRng().nextBytes(ivForParams);
       }
       parameters.init(new GCMParameterSpec(tagLength * 8, ivForParams));
       return parameters;

--- a/tst/com/amazon/corretto/crypto/provider/test/AesTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/AesTest.java
@@ -1297,6 +1297,23 @@ public class AesTest {
     assertArrayEquals(expectedSuffix, actualSuffix);
   }
 
+  // Per the documentation of Cipher.getParameters(),
+  // when we haven't been initialized we should return default/random parameters.
+  @Test
+  public void unintCipherReturnsParameters() throws GeneralSecurityException {
+    final Cipher cipher = Cipher.getInstance(ALGO_NAME, NATIVE_PROVIDER);
+    final AlgorithmParameters params = cipher.getParameters();
+    final GCMParameterSpec spec = params.getParameterSpec(GCMParameterSpec.class);
+    // Default tag length is 128
+    assertEquals(128, spec.getTLen());
+
+    final byte[] iv = spec.getIV();
+    assertNotNull(iv);
+    assertEquals(12, iv.length); // Default is 96 bits / 12 bytes
+    // The IV must be random. Stating it isn't all zero is good enough.
+    assertFalse(Arrays.equals(new byte[12], iv));
+  }
+
   private byte[] randomIV() {
     return TestUtil.getRandomBytes(16);
   }


### PR DESCRIPTION
`Cipher.getParameters()` is documented as returning “a combination of default and random parameter values used by the underlying cipher implementation if this cipher requires algorithm parameters but was not initialized with any.” However, if called on an AES/GCM/NoPadding cipher in ACCP, we get an exception because it expects the `iv` to be non-null.

This change detects an uninitialized cipher and generates a random 12 byte (96 bit) IV for use in the returned parameters when this happens. It also has a corresponding unit test.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
