### PR TITLE
Fix ArrayIndexOutOfBoundsException when no space needed

### DIFF
--- a/src/com/amazon/corretto/crypto/provider/AesGcmSpi.java
+++ b/src/com/amazon/corretto/crypto/provider/AesGcmSpi.java
@@ -1006,9 +1006,9 @@ final class AesGcmSpi extends CipherSpi {
     if (inputLength < 0 || outputOffset < 0) {
       throw new ArrayIndexOutOfBoundsException();
     }
-    // Allow outputOffset to index into a 0-length empty array. We must trust that the rest of the
-    // code doesn't actually do this.
-    if (outputOffset > output.length || (outputOffset == output.length && output.length != 0)) {
+    // We only allow outputOffset == output.length if we don't actually need any space for data
+    if (outputOffset > output.length
+        || (outputOffset == output.length && requiredBufferSpace > 0)) {
       throw new ArrayIndexOutOfBoundsException();
     }
 

--- a/tst/com/amazon/corretto/crypto/provider/test/AesTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/AesTest.java
@@ -1383,6 +1383,23 @@ public class AesTest {
     assertArraysHexEquals(plaintext, amznC.doFinal(ciphertext));
   }
 
+  @Test
+  public void emptyPlaintextAtEndOfArray() throws GeneralSecurityException {
+    final GCMParameterSpec spec = new GCMParameterSpec(128, randomIV());
+    amznC.init(Cipher.ENCRYPT_MODE, key, spec);
+    final byte[] ciphertext = amznC.doFinal();
+
+    // Decrypt into empty array
+    amznC.init(Cipher.DECRYPT_MODE, key, spec);
+    assertEquals(0, amznC.doFinal(ciphertext, 0, ciphertext.length, new byte[0], 0));
+
+    // Decrypt into non-empty array
+    assertEquals(0, amznC.doFinal(ciphertext, 0, ciphertext.length, new byte[16], 0));
+
+    // Decrypt to end of non-empty array
+    assertEquals(0, amznC.doFinal(ciphertext, 0, ciphertext.length, new byte[16], 16));
+  }
+
   private byte[] randomIV() {
     return TestUtil.getRandomBytes(16);
   }


### PR DESCRIPTION
ACCP incorrectly rejects GCM decryption when no output space is needed and is not provided. ACCP does correctly handle the case when the output buffer is an empty array but fails if the array is not empty. This change fixes this behavior and brings it into agreement with the default GCM implementation provided by the JDK.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
