### PR TITLE
Avoid accessing RSA struct's internals directly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -586,6 +586,7 @@ set(COVERAGE_ARGUMENTS
 )
 
 if(FIPS)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DFIPS_BUILD")
     set(TEST_FIPS_PROPERTY "-DFIPS=true")
     # ACCP's default behavior in FIPS mode is to not register a SecureRandom implementation.
     # However, we explicitly register it here to ensure its coverage under test.

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ ext.isFips = Boolean.getBoolean('FIPS')
 if (ext.isFips) {
     ext.awsLcGitVersionId = 'AWS-LC-FIPS-2.0.2'
 } else {
-    ext.awsLcGitVersionId = 'v1.17.0'
+    ext.awsLcGitVersionId = '32143aae568a64245f9eae54dcbc49043dbf41e4'
 }
 ext.isLegacyBuild = Boolean.getBoolean('LEGACY_BUILD')
 

--- a/csrc/bn.h
+++ b/csrc/bn.h
@@ -92,6 +92,16 @@ public:
         return result;
     }
 
+    static BigNumObj fromBIGNUM(BIGNUM const* pBN)
+    {
+        BigNumObj result;
+        result.ensure_init();
+        if (!BN_copy(result, pBN)) {
+            throw_openssl("Failed to copy bignum");
+        }
+        return result;
+    }
+
 #ifdef HAVE_CPP11
     BigNumObj(const BigNumObj&) = delete;
     BigNumObj& operator=(const BigNumObj&) = delete;

--- a/csrc/java_evp_keys.cpp
+++ b/csrc/java_evp_keys.cpp
@@ -496,11 +496,10 @@ JNIEXPORT jlong JNICALL Java_com_amazon_corretto_crypto_provider_EvpKeyFactory_r
         if (privateExponentArr) {
             BigNumObj privExp = BigNumObj::fromJavaArray(env, privateExponentArr);
 
-            int res;
+            int res = 1;
             if (BN_is_zero(pubExp)) {
-                // RSA blinding can't be performed without |e|; 0 indicates |e|'s absence.
-                rsa->flags |= RSA_FLAG_NO_BLINDING;
-                res = RSA_set0_key(rsa, modulus, NULL, privExp);
+                // RSA blinding can't be performed without |e|.
+                rsa.set(RSA_new_private_key_no_e(modulus, privExp));
             } else {
                 res = RSA_set0_key(rsa, modulus, pubExp, privExp);
             }

--- a/csrc/keyutils.h
+++ b/csrc/keyutils.h
@@ -139,6 +139,10 @@ public:
 };
 
 const EVP_MD* digestFromJstring(raii_env& env, jstring digestName);
+
+// The generated RSA structure will own n and d.
+RSA* RSA_new_private_key_no_e(BIGNUM* n, BIGNUM* d);
+
 }
 
 #endif


### PR DESCRIPTION
*Description of changes:*

AWS-LC has made the RSA struct opaque. This PR replaces direct accesses to internals of RSA struct with API calls. The FIPS builds do not have an API to disable blinding, therefore, for FIPS builds we still keep accessing the internals until a similar API is provided.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
