### PR TITLE
Avoid calling RSA_check_key after key generation since it's redundant

### DIFF
--- a/csrc/keyutils.h
+++ b/csrc/keyutils.h
@@ -140,7 +140,8 @@ public:
 
 const EVP_MD* digestFromJstring(raii_env& env, jstring digestName);
 
-// The generated RSA structure will own n and d.
+// The generated RSA structure will own n and d. The generated private key has blinding disabled since for blinding, one
+// needs the public exponent.
 RSA* RSA_new_private_key_no_e(BIGNUM* n, BIGNUM* d);
 
 }

--- a/csrc/rsa_gen.cpp
+++ b/csrc/rsa_gen.cpp
@@ -44,10 +44,6 @@ JNIEXPORT jlong JNICALL Java_com_amazon_corretto_crypto_provider_RsaGen_generate
             if (RSA_generate_key_ex(r, bits, bne, NULL) != 1) {
                 throw_openssl("Unable to generate key");
             }
-
-            if (checkConsistency && RSA_check_key(r) != 1) {
-                throw_openssl("Key failed consistency check");
-            }
         }
 
         EVP_PKEY_auto result = EVP_PKEY_auto::from(EVP_PKEY_new());


### PR DESCRIPTION
*Description of changes:*

Avoid calling RSA_check_key after key generation since it's redundant.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
