### PR TITLE
tt/P124525118: Add alias for RSA/ECB/OAEPWithSHA-1AndMGF1Padding

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,9 +53,10 @@ spotless {
   }
 
   // clang-format is difficult to configure across all of our platforms so we
-  // avoid being really strict about enforcing it in our build for now.
+  // avoid being really strict about enforcing it in our build for now. version
+  // 17.x has a bug, so skip that version.
   def clangFormatVersion = getClangFormatVersion()
-  if (!clangFormatVersion.equals('')) {
+  if (!clangFormatVersion.equals('') && clangFormatVersion.indexOf('17') < 0) {
     cpp {
         target 'csrc/*'
         licenseHeaderFile 'build-tools/license-headers/LicenseHeader.h'

--- a/csrc/auto_free.h
+++ b/csrc/auto_free.h
@@ -79,7 +79,7 @@
         void releaseOwnership() { PTR_NAME(name) = NULL; }                                                             \
         void clear()                                                                                                   \
         {                                                                                                              \
-            CONCAT2(name, _free)(PTR_NAME(name));                                                                      \
+            CONCAT2(name, _free)(PTR_NAME(name));                                                                       \
             PTR_NAME(name) = NULL;                                                                                     \
         }                                                                                                              \
         name* operator->() { return *this; }                                                                           \

--- a/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
+++ b/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
@@ -95,6 +95,7 @@ public final class AmazonCorrettoCryptoProvider extends java.security.Provider {
     addService("Cipher", "RSA/ECB/Pkcs1Padding", "RsaCipher$Pkcs1");
     addService("Cipher", "RSA/ECB/OAEPPadding", "RsaCipher$OAEP");
     addService("Cipher", "RSA/ECB/OAEPWithSHA-1AndMGF1Padding", "RsaCipher$OAEPSha1");
+    addService("Cipher", "RSA/ECB/OAEPWithSHA1AndMGF1Padding", "RsaCipher$OAEPSha1");
 
     for (String hash : new String[] {"MD5", "SHA1", "SHA256", "SHA384", "SHA512"}) {
       addService("Mac", "Hmac" + hash, "EvpHmac$" + hash);


### PR DESCRIPTION


*Issue #, if available:*

t/P124525118

*Description of changes:*

We add this alias to better support [open-source projects using non-JCA-standard algorithm names][1].

[1]: https://github.com/search?q=RSA%2FECB%2FOAEPWithSHA1AndMGF1Padding&type=code

---


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
