### PR TITLE
Workaround to mark the DEFAULT SecureRandom algorithm thread-safe

### DIFF
--- a/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
+++ b/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
@@ -121,6 +121,9 @@ public final class AmazonCorrettoCryptoProvider extends java.security.Provider {
               singletonMap("ThreadSafe", "true"),
               "DEFAULT")
           .setSelfTest(LibCryptoRng.SPI.SELF_TEST);
+      // Following line is a workaround to ensure that the SecureRandom service
+      // is seens as ThreadSafe by SecureRandom, when using the alias name DEFAULT
+      setProperty("SecureRandom.DEFAULT ThreadSafe", "true");
     }
 
     addSignatures();

--- a/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
+++ b/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
@@ -121,9 +121,24 @@ public final class AmazonCorrettoCryptoProvider extends java.security.Provider {
               singletonMap("ThreadSafe", "true"),
               "DEFAULT")
           .setSelfTest(LibCryptoRng.SPI.SELF_TEST);
-      // Following line is a workaround to ensure that the SecureRandom service
-      // is seens as ThreadSafe by SecureRandom, when using the alias name DEFAULT
-      setProperty("SecureRandom.DEFAULT ThreadSafe", "true");
+
+      // Following lines are a workaround to ensure that the SecureRandom service
+      // is seen as ThreadSafe by SecureRandom, when using the alias name DEFAULT
+      // See https://bugs.openjdk.org/browse/JDK-8329754
+
+      // We add additional tests to confirm the DEFAULT algorithm is actually ThreadSafe
+      // This is to prevent issues in case a future code change set DEFAULT to a non-ThreadSafe
+      // algorithm
+
+      // Get the name of the algorithm pointed by the alias name DEFAULT
+      String algorithmUsedForDEFAULT = getProperty("Alg.Alias.SecureRandom.DEFAULT");
+      // If this alias exists and the algorithm pointed by it is thread safe, then mark DEFAULT
+      // ThreadSafe
+      if (algorithmUsedForDEFAULT != null
+          && "true"
+              .equals(getProperty("SecureRandom." + algorithmUsedForDEFAULT + " ThreadSafe"))) {
+        setProperty("SecureRandom.DEFAULT ThreadSafe", "true");
+      }
     }
 
     addSignatures();

--- a/tst/com/amazon/corretto/crypto/provider/test/TestProviderInstallation.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/TestProviderInstallation.java
@@ -89,4 +89,18 @@ public class TestProviderInstallation {
       result.assertHealthy();
     }
   }
+
+  /**
+   * Check that the SecureRandom algorithm `LibCryptoRng` and its alias `DEFAULT` are both marked
+   * thread safe
+   */
+  @Test
+  public void testSecureRandomThreadSafe() {
+    assertEquals(
+        "true",
+        AmazonCorrettoCryptoProvider.INSTANCE.getProperty("SecureRandom.LibCryptoRng ThreadSafe"));
+    assertEquals(
+        "true",
+        AmazonCorrettoCryptoProvider.INSTANCE.getProperty("SecureRandom.DEFAULT ThreadSafe"));
+  }
 }


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

This is a workaround to ensure that the `nextBytes` calls to SecureRandom are not synchronized when specifying the alias algorithm `DEFAULT` of ACCP SecureRandom provider. Without this workaround, the `nextBytes` calls are synchronized and the multi-threaded performance of ACCP SecureRandom drops: concretely, with x threads concurrently generating randomness, average time per thread gets multiplied by x.

In more details, OpenJDK/Corretto requires thread safe implementations of SecureRandom to specify the attribute ThreadSafe (https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/security/SecureRandom.html). If this attribute is not set to true, the nextBytes calls are synchronized. ACCP sets this attribute when registering SecureRandom. It also registers an alias `DEFAULT` to the algorithm `LibCryptoRng` that it registers.

Attributes of services are converted to attributes at the provider level, using the naming convention: `Service.Algorithm Attribute`. Thus, setting the `ThreadSafe` attribute leads to setting `SecureRandom.LibCryptoRng ThreadSafe=true`, but not `SecureRandom.DEFAULT ThreadSafe=true`.

Unfortunately, the JDK does not follow aliases and thus the DEFAULT algorithm is not considered thread safe. See, e.g., https://github.com/corretto/corretto-17/blob/e0d038c50d5c61683a9270218b32c5aed2b0b466/src/java.base/share/classes/java/security/SecureRandom.java#L229-L236

FAQ:

> Who is affected by the performance drop if this workaround is not applied?

Anyone instantiating explicitly the `DEFAULT` algorithm of ACCP SecureRandom (i.e., `SecureRandom.getInstance("DEFAULT", "AmazonCorrettoCryptoProvider")`) and using it concurrently in multiple threads.

This includes the benchmarks in the subfolder `benchmarks/` of this repo.

> I am using `new SecureRandom`, am I affected?

No. `new SecureRandom()` uses the algorithm `LibCryptoRng` and not the alias `DEFAULT` (assuming ACCP is set as first cryptographic provider).

> I did not register ACCP SecureRandom, am I affected?

No.

> Can this workaround impact other crypto providers like BouncyCastle (which also provides a `DEFAULT` algorithm for SecureRandom)?

No, attributes are stored at the provider level. This change will not affect other providers.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
