### PR TITLE
AES-CBC with ISO10126 Padding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## 2.3.4
+## 2.4.0
+
+### Minor
+* [PR 380:](https://github.com/corretto/amazon-corretto-crypto-provider/pull/380) Support for AES-CBC with NoPadding, PKCS5Padding, PKCS7Padding
+* [PR 381:](https://github.com/corretto/amazon-corretto-crypto-provider/pull/381) Support for AES-CBC with ISO10126Padding
 
 ### Patch
 * [PR 353: Static linking to libcrypto](https://github.com/corretto/amazon-corretto-crypto-provider/pull/353)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -691,6 +691,7 @@ add_custom_target(check-junit-AesLazy
         --select-class=com.amazon.corretto.crypto.provider.test.AesGcmKatTest
         --select-class=com.amazon.corretto.crypto.provider.test.AesCbcTest
         --select-class=com.amazon.corretto.crypto.provider.test.AesCbcNistTest
+        --select-class=com.amazon.corretto.crypto.provider.test.AesCbcIso10126Test
 
     DEPENDS accp-jar tests-jar)
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Cipher algorithms:
 * AES/CBC/PKCS5Padding
   * AES_\<n\>/CBC/PKCS5Padding, where n can be 128, 192, or 256
   * PKCS7Padding is also accepted with AES/CBC and it is treated the same as PKCS5.
+* AES/CBC/ISO10126Padding
+    * AES_\<n\>/CBC/ISO10126Padding, where n can be 128, 192, or 256
 * RSA/ECB/NoPadding
 * RSA/ECB/PKCS1Padding
 * RSA/ECB/OAEPPadding

--- a/csrc/aes_cbc.cpp
+++ b/csrc/aes_cbc.cpp
@@ -60,12 +60,6 @@ class AesCbcCipher {
         }
     }
 
-    // For ISO10126, we use CBC with no padding.
-    static int padding_to_be_used(int padding)
-    {
-        return is_iso10126_padding(padding) ? com_amazon_corretto_crypto_provider_AesCbcSpi_NO_PADDING : padding;
-    }
-
 public:
     AesCbcCipher(JNIEnv* jenv, jlongArray ctx_container, jlong ctx_ptr, bool save_ctx)
         : jenv_(jenv)

--- a/csrc/aes_cbc.cpp
+++ b/csrc/aes_cbc.cpp
@@ -2,11 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 #include "buffer.h"
 #include "env.h"
+#include "generated-headers.h"
 #include "util.h"
 #include <openssl/err.h>
 #include <openssl/evp.h>
+#include <openssl/rand.h>
 #include <cstring>
-#include <jni.h>
 
 #define AES_CBC_BLOCK_SIZE_IN_BYTES 16
 #define KEY_LEN_AES128              16
@@ -14,6 +15,15 @@
 #define KEY_LEN_AES256              32
 
 namespace AmazonCorrettoCryptoProvider {
+
+static bool is_iso10126_padding(int padding)
+{
+    return padding == com_amazon_corretto_crypto_provider_AesCbcSpi_ISO10126_PADDING;
+}
+
+static bool is_enc(jint op_mode) { return op_mode == com_amazon_corretto_crypto_provider_AesCbcSpi_ENC_MODE; }
+
+static int min(int a, int b) { return a <= b ? a : b; }
 
 class AesCbcCipher {
     JNIEnv* jenv_;
@@ -45,6 +55,12 @@ class AesCbcCipher {
             // This should not be reachable since we check this in Java.
             throw java_ex(EX_ERROR, "unprocessed_input is not in [0, 16] range.");
         }
+    }
+
+    // For ISO10126, we use CBC with no padding.
+    static int padding_to_be_used(int padding)
+    {
+        return is_iso10126_padding(padding) ? com_amazon_corretto_crypto_provider_AesCbcSpi_NO_PADDING : padding;
     }
 
 public:
@@ -110,7 +126,7 @@ public:
         }
 
         // This method always returns 1 and succeeds.
-        if (EVP_CIPHER_CTX_set_padding(ctx_, padding) != 1) {
+        if (EVP_CIPHER_CTX_set_padding(ctx_, padding_to_be_used(padding)) != 1) {
             throw_openssl(EX_RUNTIME_CRYPTO, "EVP_CIPHER_CTX_set_padding failed.");
         }
     }
@@ -136,6 +152,68 @@ public:
         return result;
     }
 
+    int extended_update(bool is_iso10126_padding,
+        bool is_enc,
+        jbyteArray j_last_block,
+        uint8_t const* input,
+        int input_len,
+        uint8_t* output,
+        int unprocessed_input)
+    {
+        if (!is_iso10126_padding || is_enc) {
+            return update(input, input_len, output, unprocessed_input);
+        }
+        // We are decrypting and padding is ISO10126. In this case, we must not decrypt the last block until do_final.
+        // The last_block is used to store this information.
+        JBinaryBlob last_block(jenv_, nullptr, j_last_block);
+        // The last byte of last_block stores the number of bytes in it from the previous call.
+        int last_block_len = last_block.get()[AES_CBC_BLOCK_SIZE_IN_BYTES];
+        // This is the total number of bytes that we have. Some must be stored in the last_block and the rest must be
+        // passed to the cipher.
+        int all = last_block_len + input_len;
+        int rem = all % AES_CBC_BLOCK_SIZE_IN_BYTES;
+        // We need to store no more than 16 bytes of all the input. c holds the number of bytes that must be copied into
+        // last_block.
+        int c = rem == 0 ? min(AES_CBC_BLOCK_SIZE_IN_BYTES, all) : rem;
+        // p is the total number of bytes that must be passed to the cipher.
+        int p = all - c;
+        // p1 is the number of bytes that must be pass to the cipher from last_block.
+        int p1 = min(p, last_block_len);
+        // p2 is the number of bytes that must be pass to the cipher from input.
+        int p2 = p - p1;
+        // c2 is the number of bytes that must be copied from input to last_block.
+        int c2 = min(c, input_len);
+        // c1 is the number of bytes that must be copied from last_block to itself.
+        int c1 = c - c2;
+
+        // Processing step: passing bytes to the cipher. This includes passing bytes from last_block and input:
+        // Passing bytes from last_block:
+        int up = unprocessed_input - last_block_len;
+        int result = update(last_block.get(), p1, output, up);
+        up = (p1 + up) - result;
+
+        // Passing bytes from input
+        result += update(input, p2, output + result, up);
+
+        // Copying step: storing bytes into last_byte. This includes copy from last_block into itself and from input
+        // to last_block.
+        // Copy c1 bytes from last_block to itself.
+        int from_index = last_block_len - c1;
+        for (int i = 0; i < c1; i++) {
+            last_block.get()[i] = last_block.get()[from_index + i];
+        }
+        // Copy c2 from input to last_block.
+        from_index = input_len - c2;
+        for (int i = 0; i < c2; i++) {
+            last_block.get()[c1 + i] = input[from_index + i];
+        }
+        // Record the new size of last_block.
+        // Since c <= 16, the following cast is fine.
+        last_block.get()[AES_CBC_BLOCK_SIZE_IN_BYTES] = (uint8_t)c;
+
+        return result;
+    }
+
     int do_final(uint8_t* output)
     {
         int result = 0;
@@ -146,6 +224,61 @@ public:
                 throw_openssl(EX_RUNTIME_CRYPTO, "EVP_CipherFinal_ex failed.");
             }
         }
+        return result;
+    }
+
+    int extended_do_final(
+        bool is_iso10126_padding, bool is_enc, jbyteArray j_last_block, uint8_t* output, int unprocessed_input)
+    {
+        if (!is_iso10126_padding) {
+            return do_final(output);
+        }
+
+        int result = 0;
+        if (is_enc) {
+
+            // The cipher is in encryption mode. We need to add padding.
+            // The logic of padding is as follows:
+            // 1. Find the number of bytes needed to make input's length a multiple of AES block size. Let's call this
+            // number pl. This number is 16 in case the input was already a multiple of block size, otherwise, it's less
+            // than 16.
+            int pl = AES_CBC_BLOCK_SIZE_IN_BYTES - unprocessed_input;
+            // 2. Generate (pl - 1) random bytes.
+            uint8_t padding_bytes[AES_CBC_BLOCK_SIZE_IN_BYTES];
+            if (RAND_bytes(padding_bytes, pl - 1) != 1) {
+                throw_openssl(EX_RUNTIME_CRYPTO, "RAND_bytes failed.");
+            }
+            // 3. Set the last byte of the padding to pl.
+            padding_bytes[pl - 1] = (uint8_t)pl;
+            // 4. Pass the padding bytes to the cipher and continue encryption:
+            result = update(padding_bytes, pl, output, unprocessed_input);
+            // 5. Finalize the encryption
+            result += do_final(output + result);
+
+        } else {
+
+            // The cipher is in decryption mode. We need to remove the padding.
+            JBinaryBlob last_block(jenv_, nullptr, j_last_block);
+            int last_block_len = last_block.get()[AES_CBC_BLOCK_SIZE_IN_BYTES];
+            if (last_block_len != AES_CBC_BLOCK_SIZE_IN_BYTES) {
+                // This can happen if the input is empty.
+                throw java_ex(EX_BADPADDING, "Bad padding");
+            }
+            // First, we decrypt the last block.
+            result = update(last_block.get(), last_block_len, output, unprocessed_input);
+            if (do_final(output + result) != 0) {
+                throw java_ex(EX_ERROR, "THIS SHOULD NOT BE REACHABLE: ISO10126 decrypt do_final produced output.");
+            }
+            // The last byte records the length of the padding.
+            unsigned int size_of_padding = output[result - 1];
+            if (size_of_padding > AES_CBC_BLOCK_SIZE_IN_BYTES) {
+                // This can happen if wrong key is used or if the last block has been tampered.
+                throw java_ex(EX_BADPADDING, "Bad padding");
+            }
+            // Remove padding by adjusting the output size.
+            result -= size_of_padding;
+        }
+
         return result;
     }
 };
@@ -164,6 +297,7 @@ extern "C" JNIEXPORT jint JNICALL Java_com_amazon_corretto_crypto_provider_AesCb
     jlongArray ctxContainer,
     jlong ctxPtr,
     jboolean saveCtx,
+    jbyteArray lastBlock,
     jobject inputDirect,
     jbyteArray inputArray,
     jint inputOffset,
@@ -174,6 +308,10 @@ extern "C" JNIEXPORT jint JNICALL Java_com_amazon_corretto_crypto_provider_AesCb
 {
     try {
         AesCbcCipher aes_cbc_cipher(env, ctxContainer, ctxPtr, saveCtx);
+
+        bool is_iso10126_padding_flag = is_iso10126_padding(padding);
+        bool is_enc_flag = is_enc(opMode);
+
         // init
         {
             JBinaryBlob j_key(env, nullptr, key);
@@ -182,19 +320,20 @@ extern "C" JNIEXPORT jint JNICALL Java_com_amazon_corretto_crypto_provider_AesCb
         }
 
         int result = 0;
-
         // update
         JBinaryBlob output(env, outputDirect, outputArray);
-
         {
             JBinaryBlob input(env, inputDirect, inputArray);
-            result = aes_cbc_cipher.update(input.get() + inputOffset, inputLen, output.get() + outputOffset, 0);
+            result = aes_cbc_cipher.extended_update(is_iso10126_padding_flag, is_enc_flag, lastBlock,
+                input.get() + inputOffset, inputLen, output.get() + outputOffset, 0);
         }
 
         // final
-        result += aes_cbc_cipher.do_final(output.get() + outputOffset + result);
+        result += aes_cbc_cipher.extended_do_final(
+            is_iso10126_padding_flag, is_enc_flag, lastBlock, output.get() + outputOffset + result, inputLen - result);
 
         return result;
+
     } catch (java_ex& ex) {
         ex.throw_to_java(env);
         return -1;
@@ -210,6 +349,7 @@ extern "C" JNIEXPORT jint JNICALL Java_com_amazon_corretto_crypto_provider_AesCb
     jbyteArray iv,
     jlongArray ctxContainer,
     jlong ctxPtr,
+    jbyteArray lastBlock,
     jobject inputDirect,
     jbyteArray inputArray,
     jint inputOffset,
@@ -231,7 +371,8 @@ extern "C" JNIEXPORT jint JNICALL Java_com_amazon_corretto_crypto_provider_AesCb
         JBinaryBlob output(env, outputDirect, outputArray);
         JBinaryBlob input(env, inputDirect, inputArray);
 
-        return aes_cbc_cipher.update(input.get() + inputOffset, inputLen, output.get() + outputOffset, 0);
+        return aes_cbc_cipher.extended_update(is_iso10126_padding(padding), is_enc(opMode), lastBlock,
+            input.get() + inputOffset, inputLen, output.get() + outputOffset, 0);
 
     } catch (java_ex& ex) {
         ex.throw_to_java(env);
@@ -241,12 +382,15 @@ extern "C" JNIEXPORT jint JNICALL Java_com_amazon_corretto_crypto_provider_AesCb
 
 extern "C" JNIEXPORT jint JNICALL Java_com_amazon_corretto_crypto_provider_AesCbcSpi_nUpdate(JNIEnv* env,
     jclass,
+    jint opMode,
+    jint padding,
     jlong ctxPtr,
+    jbyteArray lastBlock,
     jobject inputDirect,
     jbyteArray inputArray,
     jint inputOffset,
     jint inputLen,
-    jint unprocessed_input,
+    jint unprocessedInput,
     jobject outputDirect,
     jbyteArray outputArray,
     jint outputOffset)
@@ -258,8 +402,8 @@ extern "C" JNIEXPORT jint JNICALL Java_com_amazon_corretto_crypto_provider_AesCb
         JBinaryBlob output(env, outputDirect, outputArray);
         JBinaryBlob input(env, inputDirect, inputArray);
 
-        return aes_cbc_cipher.update(
-            input.get() + inputOffset, inputLen, output.get() + outputOffset, unprocessed_input);
+        return aes_cbc_cipher.extended_update(is_iso10126_padding(padding), is_enc(opMode), lastBlock,
+            input.get() + inputOffset, inputLen, output.get() + outputOffset, unprocessedInput);
 
     } catch (java_ex& ex) {
         ex.throw_to_java(env);
@@ -269,8 +413,11 @@ extern "C" JNIEXPORT jint JNICALL Java_com_amazon_corretto_crypto_provider_AesCb
 
 extern "C" JNIEXPORT jint JNICALL Java_com_amazon_corretto_crypto_provider_AesCbcSpi_nUpdateFinal(JNIEnv* env,
     jclass,
+    jint opMode,
+    jint padding,
     jlong ctxPtr,
     jboolean saveCtx,
+    jbyteArray lastBlock,
     jobject inputDirect,
     jbyteArray inputArray,
     jint inputOffset,
@@ -283,21 +430,27 @@ extern "C" JNIEXPORT jint JNICALL Java_com_amazon_corretto_crypto_provider_AesCb
     try {
         AesCbcCipher aes_cbc_cipher(env, nullptr, ctxPtr, saveCtx);
 
+        bool is_iso10126_padding_flag = is_iso10126_padding(padding);
+        bool is_enc_flag = is_enc(opMode);
+
         int result = 0;
+        int up = unprocessedInput;
 
         // update
         JBinaryBlob output(env, outputDirect, outputArray);
-
         {
             JBinaryBlob input(env, inputDirect, inputArray);
-            result = aes_cbc_cipher.update(
-                input.get() + inputOffset, inputLen, output.get() + outputOffset, unprocessedInput);
+            result = aes_cbc_cipher.extended_update(is_iso10126_padding_flag, is_enc_flag, lastBlock,
+                input.get() + inputOffset, inputLen, output.get() + outputOffset, up);
         }
 
         // final
-        result += aes_cbc_cipher.do_final(output.get() + outputOffset + result);
+        up = (inputLen + unprocessedInput) - result;
+        result += aes_cbc_cipher.extended_do_final(
+            is_iso10126_padding_flag, is_enc_flag, lastBlock, output.get() + outputOffset + result, up);
 
         return result;
+
     } catch (java_ex& ex) {
         ex.throw_to_java(env);
         return -1;

--- a/examples/gradle-kt-dsl/lib/build.gradle.kts
+++ b/examples/gradle-kt-dsl/lib/build.gradle.kts
@@ -1,4 +1,4 @@
-val accpVersion = "2.3.4"
+val accpVersion = "2.4.0"
 val accpLocalJar: String by project
 val fips: Boolean by project
 val PLATFORMS_WITHOUT_FIPS_SUPPORT = setOf("osx-x86_64", "osx-aarch_64")

--- a/src/com/amazon/corretto/crypto/provider/AesCbcSpi.java
+++ b/src/com/amazon/corretto/crypto/provider/AesCbcSpi.java
@@ -31,8 +31,10 @@ class AesCbcSpi extends CipherSpi {
   // https://github.com/aws/aws-lc/blob/main/include/openssl/cipher.h#L294-L297
   public static final int NO_PADDING = 0;
   public static final int PKCS7_PADDING = 1;
+  public static final int ISO10126_PADDING = 2;
   public static final Set<String> AES_CBC_NO_PADDING_NAMES;
   public static final Set<String> AES_CBC_PKCS7_PADDING_NAMES;
+  public static final Set<String> AES_CBC_ISO10126_PADDING_NAMES;
 
   static {
     Loader.load();
@@ -54,6 +56,12 @@ class AesCbcSpi extends CipherSpi {
     AES_CBC_PKCS7_PADDING_NAMES.add("AES_128/CBC/PKCS5Padding".toLowerCase());
     AES_CBC_PKCS7_PADDING_NAMES.add("AES_192/CBC/PKCS5Padding".toLowerCase());
     AES_CBC_PKCS7_PADDING_NAMES.add("AES_256/CBC/PKCS5Padding".toLowerCase());
+
+    AES_CBC_ISO10126_PADDING_NAMES = new HashSet<>();
+    AES_CBC_ISO10126_PADDING_NAMES.add("AES/CBC/ISO10126Padding".toLowerCase());
+    AES_CBC_ISO10126_PADDING_NAMES.add("AES_128/CBC/ISO10126Padding".toLowerCase());
+    AES_CBC_ISO10126_PADDING_NAMES.add("AES_192/CBC/ISO10126Padding".toLowerCase());
+    AES_CBC_ISO10126_PADDING_NAMES.add("AES_256/CBC/ISO10126Padding".toLowerCase());
   }
 
   private static final byte[] EMPTY_ARRAY = new byte[0];
@@ -88,6 +96,8 @@ class AesCbcSpi extends CipherSpi {
   // Determines if the EVP_CIPHER_CTX used should be released after doFinal or not. This is
   // controlled by a system property.
   private final boolean saveContext;
+  // This memory is used during decryption for ISO10126Padding.
+  private byte[] lastBlock;
 
   AesCbcSpi(final int padding, final boolean saveContext) {
     this.padding = padding;
@@ -98,6 +108,11 @@ class AesCbcSpi extends CipherSpi {
     this.iv = null;
     this.nativeCtx = null;
     this.saveContext = saveContext;
+    this.lastBlock = null;
+  }
+
+  private boolean noPadding() {
+    return padding == NO_PADDING;
   }
 
   @Override
@@ -130,7 +145,7 @@ class AesCbcSpi extends CipherSpi {
     final long rem = all % BLOCK_SIZE_IN_BYTES;
 
     // When there is no padding, the output size for enc/dec is at most all.
-    if (padding == NO_PADDING) {
+    if (noPadding()) {
       return (int) (all);
     }
 
@@ -210,6 +225,18 @@ class AesCbcSpi extends CipherSpi {
     this.iv = iv;
     this.key = keyBytes;
     this.unprocessedInput = 0;
+    initLastBlock();
+  }
+
+  private void initLastBlock() {
+    if ((padding != ISO10126_PADDING) || (opMode != DEC_MODE)) {
+      return;
+    }
+    if (lastBlock == null) {
+      lastBlock = new byte[BLOCK_SIZE_IN_BYTES + 1];
+    } else {
+      Arrays.fill(lastBlock, (byte) 0);
+    }
   }
 
   private static int checkOperation(final int opMode) throws InvalidParameterException {
@@ -303,7 +330,7 @@ class AesCbcSpi extends CipherSpi {
       return 0;
     }
     final long rem = all % BLOCK_SIZE_IN_BYTES;
-    if (padding == NO_PADDING || opMode == ENC_MODE || rem != 0) {
+    if (noPadding() || opMode == ENC_MODE || rem != 0) {
       return (int) (all - rem);
     }
     // When all data (inputLen + unprocessedInput) is block-size aligned, padding is enabled, and we
@@ -339,6 +366,7 @@ class AesCbcSpi extends CipherSpi {
                           iv,
                           null,
                           ctxPtr,
+                          lastBlock,
                           inputDirect,
                           inputArray,
                           inputOffset,
@@ -356,6 +384,7 @@ class AesCbcSpi extends CipherSpi {
                   iv,
                   ctxContainer,
                   0,
+                  lastBlock,
                   inputDirect,
                   inputArray,
                   inputOffset,
@@ -372,7 +401,10 @@ class AesCbcSpi extends CipherSpi {
             nativeCtx.use(
                 ctxPtr ->
                     nUpdate(
+                        opMode,
+                        padding,
                         ctxPtr,
+                        lastBlock,
                         inputDirect,
                         inputArray,
                         inputOffset,
@@ -461,10 +493,10 @@ class AesCbcSpi extends CipherSpi {
     final long all = ((long) inputLen) + ((long) unprocessedInput);
     final long rem = all % BLOCK_SIZE_IN_BYTES;
     // If there is no padding or if we are decrypting, all the data must be aligned with block size.
-    if ((opMode == DEC_MODE || padding == NO_PADDING) && rem != 0) {
+    if ((opMode == DEC_MODE || noPadding()) && rem != 0) {
       throw new IllegalBlockSizeException("Input length not multiple of 16 bytes");
     }
-    if (padding == NO_PADDING) {
+    if (noPadding()) {
       return (int) all;
     }
     // When encrypting with padding enabled ...
@@ -510,6 +542,7 @@ class AesCbcSpi extends CipherSpi {
                             null,
                             ctxPtr,
                             true,
+                            lastBlock,
                             inputDirect,
                             inputArray,
                             inputOffset,
@@ -528,6 +561,7 @@ class AesCbcSpi extends CipherSpi {
                     ctxContainer,
                     0,
                     true,
+                    lastBlock,
                     inputDirect,
                     inputArray,
                     inputOffset,
@@ -545,8 +579,11 @@ class AesCbcSpi extends CipherSpi {
               nativeCtx.use(
                   ctxPtr ->
                       nUpdateFinal(
+                          opMode,
+                          padding,
                           ctxPtr,
                           true,
+                          lastBlock,
                           inputDirect,
                           inputArray,
                           inputOffset,
@@ -571,6 +608,7 @@ class AesCbcSpi extends CipherSpi {
                   null,
                   ctxPtr,
                   false,
+                  lastBlock,
                   inputDirect,
                   inputArray,
                   inputOffset,
@@ -582,8 +620,11 @@ class AesCbcSpi extends CipherSpi {
           // Cipher is in UPDATE state and don't need to save the context
           result =
               nUpdateFinal(
+                  opMode,
+                  padding,
                   ctxPtr,
                   false,
+                  lastBlock,
                   inputDirect,
                   inputArray,
                   inputOffset,
@@ -595,8 +636,15 @@ class AesCbcSpi extends CipherSpi {
         }
       }
 
+      if (result < 0) {
+        throw new AssertionError("Result is negative");
+      }
+
       cipherState = CipherState.INITIALIZED;
       unprocessedInput = 0;
+      if (lastBlock != null) {
+        Arrays.fill(lastBlock, (byte) 0);
+      }
 
       return result;
 
@@ -628,6 +676,7 @@ class AesCbcSpi extends CipherSpi {
       long[] ctxContainer,
       long ctxPtr,
       boolean saveCtx,
+      byte[] lastBlock,
       ByteBuffer inputDirect,
       byte[] inputArray,
       int inputOffset,
@@ -645,6 +694,7 @@ class AesCbcSpi extends CipherSpi {
       byte[] iv,
       long[] ctxContainer,
       long ctxPtr,
+      byte[] lastBlock,
       ByteBuffer inputDirect,
       byte[] inputArray,
       int inputOffset,
@@ -655,7 +705,10 @@ class AesCbcSpi extends CipherSpi {
 
   // This method is used the n^th time engineUpdate is used in a multi-step operation, where n >= 2.
   private static native int nUpdate(
+      int opMode,
+      int padding,
       long ctxPtr,
+      byte[] lastBlock,
       ByteBuffer inputDirect,
       byte[] inputArray,
       int inputOffset,
@@ -667,8 +720,11 @@ class AesCbcSpi extends CipherSpi {
 
   // This method is used  when engineDoFinal is used to finalize a multi-step operation.
   private static native int nUpdateFinal(
+      int opMode,
+      int padding,
       long ctxPtr,
       boolean saveCtx,
+      byte[] lastBlock,
       ByteBuffer inputDirect,
       byte[] inputArray,
       int inputOffset,

--- a/src/com/amazon/corretto/crypto/provider/AesCbcSpi.java
+++ b/src/com/amazon/corretto/crypto/provider/AesCbcSpi.java
@@ -236,9 +236,12 @@ class AesCbcSpi extends CipherSpi {
     if ((padding != ISO10126_PADDING) || (opMode != DEC_MODE)) {
       return;
     }
+    // We only need this buffer decrypting a cipher text that was encrypted with ISO10126Padding.
     if (lastBlock == null) {
       // We allocate 17 bytes. The last byte holds how much of this buffer is used to track the tail
-      // of a cipher text during decryption.
+      // of a cipher text during decryption. For example, if there are 4 bytes in this array, its
+      // content would look something like the following:
+      // [0x00, 0x01, 0x02, 0x03, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0x04]
       lastBlock = new byte[BLOCK_SIZE_IN_BYTES + 1];
     } else {
       Arrays.fill(lastBlock, (byte) 0);
@@ -640,10 +643,6 @@ class AesCbcSpi extends CipherSpi {
                   outputArray,
                   outputOffset);
         }
-      }
-
-      if (result < 0) {
-        throw new AssertionError("Result is negative");
       }
 
       cipherState = CipherState.INITIALIZED;

--- a/src/com/amazon/corretto/crypto/provider/AesCbcSpi.java
+++ b/src/com/amazon/corretto/crypto/provider/AesCbcSpi.java
@@ -32,6 +32,22 @@ class AesCbcSpi extends CipherSpi {
   public static final int NO_PADDING = 0;
   public static final int PKCS7_PADDING = 1;
   public static final int ISO10126_PADDING = 2;
+
+  enum Padding {
+    NONE(AesCbcSpi.NO_PADDING),
+    PKCS7(AesCbcSpi.PKCS7_PADDING),
+    ISO10126(AesCbcSpi.ISO10126_PADDING);
+    private final int value;
+
+    Padding(final int value) {
+      this.value = value;
+    }
+
+    int getValue() {
+      return value;
+    }
+  }
+
   public static final Set<String> AES_CBC_NO_PADDING_NAMES;
   public static final Set<String> AES_CBC_PKCS7_PADDING_NAMES;
   public static final Set<String> AES_CBC_ISO10126_PADDING_NAMES;
@@ -103,8 +119,8 @@ class AesCbcSpi extends CipherSpi {
   // initialized.
   private byte[] lastBlock;
 
-  AesCbcSpi(final int padding, final boolean saveContext) {
-    this.padding = padding;
+  AesCbcSpi(final Padding padding, final boolean saveContext) {
+    this.padding = padding.getValue();
     this.cipherState = CipherState.NEEDS_INITIALIZATION;
     this.unprocessedInput = 0;
     this.opMode = MODE_NOT_SET;

--- a/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
+++ b/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.amazon.corretto.crypto.provider;
 
+import static com.amazon.corretto.crypto.provider.AesCbcSpi.AES_CBC_ISO10126_PADDING_NAMES;
 import static com.amazon.corretto.crypto.provider.AesCbcSpi.AES_CBC_NO_PADDING_NAMES;
 import static com.amazon.corretto.crypto.provider.AesCbcSpi.AES_CBC_PKCS7_PADDING_NAMES;
 import static com.amazon.corretto.crypto.provider.HkdfSecretKeyFactorySpi.HKDF_WITH_SHA1;
@@ -107,6 +108,11 @@ public final class AmazonCorrettoCryptoProvider extends java.security.Provider {
     addService("Cipher", "AES_128/CBC/PKCS7Padding", "AesCbcSpi", false);
     addService("Cipher", "AES_192/CBC/PKCS7Padding", "AesCbcSpi", false);
     addService("Cipher", "AES_256/CBC/PKCS7Padding", "AesCbcSpi", false);
+
+    addService("Cipher", "AES/CBC/ISO10126Padding", "AesCbcSpi", false);
+    addService("Cipher", "AES_128/CBC/ISO10126Padding", "AesCbcSpi", false);
+    addService("Cipher", "AES_192/CBC/ISO10126Padding", "AesCbcSpi", false);
+    addService("Cipher", "AES_256/CBC/ISO10126Padding", "AesCbcSpi", false);
 
     addService("Cipher", "RSA/ECB/NoPadding", "RsaCipher$NoPadding");
     addService("Cipher", "RSA/ECB/Pkcs1Padding", "RsaCipher$Pkcs1");
@@ -340,6 +346,14 @@ public final class AmazonCorrettoCryptoProvider extends java.security.Provider {
               AmazonCorrettoCryptoProvider.this.nativeContextReleaseStrategy
                   == Utils.NativeContextReleaseStrategy.LAZY;
           return new AesCbcSpi(AesCbcSpi.NO_PADDING, saveContext);
+        }
+
+        if ("Cipher".equalsIgnoreCase(type)
+            && AES_CBC_ISO10126_PADDING_NAMES.contains(algo.toLowerCase())) {
+          final boolean saveContext =
+              AmazonCorrettoCryptoProvider.this.nativeContextReleaseStrategy
+                  == Utils.NativeContextReleaseStrategy.LAZY;
+          return new AesCbcSpi(AesCbcSpi.ISO10126_PADDING, saveContext);
         }
 
         throw new NoSuchAlgorithmException(String.format("No service class for %s/%s", type, algo));

--- a/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
+++ b/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
@@ -337,7 +337,7 @@ public final class AmazonCorrettoCryptoProvider extends java.security.Provider {
           final boolean saveContext =
               AmazonCorrettoCryptoProvider.this.nativeContextReleaseStrategy
                   == Utils.NativeContextReleaseStrategy.LAZY;
-          return new AesCbcSpi(AesCbcSpi.PKCS7_PADDING, saveContext);
+          return new AesCbcSpi(AesCbcSpi.Padding.PKCS7, saveContext);
         }
 
         if ("Cipher".equalsIgnoreCase(type)
@@ -345,7 +345,7 @@ public final class AmazonCorrettoCryptoProvider extends java.security.Provider {
           final boolean saveContext =
               AmazonCorrettoCryptoProvider.this.nativeContextReleaseStrategy
                   == Utils.NativeContextReleaseStrategy.LAZY;
-          return new AesCbcSpi(AesCbcSpi.NO_PADDING, saveContext);
+          return new AesCbcSpi(AesCbcSpi.Padding.NONE, saveContext);
         }
 
         if ("Cipher".equalsIgnoreCase(type)
@@ -353,7 +353,7 @@ public final class AmazonCorrettoCryptoProvider extends java.security.Provider {
           final boolean saveContext =
               AmazonCorrettoCryptoProvider.this.nativeContextReleaseStrategy
                   == Utils.NativeContextReleaseStrategy.LAZY;
-          return new AesCbcSpi(AesCbcSpi.ISO10126_PADDING, saveContext);
+          return new AesCbcSpi(AesCbcSpi.Padding.ISO10126, saveContext);
         }
 
         throw new NoSuchAlgorithmException(String.format("No service class for %s/%s", type, algo));

--- a/tst/com/amazon/corretto/crypto/provider/test/AesCbcIso10126Test.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/AesCbcIso10126Test.java
@@ -7,7 +7,10 @@ import static com.amazon.corretto.crypto.provider.test.TestUtil.genAesKey;
 import static com.amazon.corretto.crypto.provider.test.TestUtil.genData;
 import static com.amazon.corretto.crypto.provider.test.TestUtil.genIv;
 import static com.amazon.corretto.crypto.provider.test.TestUtil.genPattern;
+import static com.amazon.corretto.crypto.provider.test.TestUtil.mergeByteBuffers;
 import static com.amazon.corretto.crypto.provider.test.TestUtil.multiStepArray;
+import static com.amazon.corretto.crypto.provider.test.TestUtil.multiStepArrayMultiAllocationExplicit;
+import static com.amazon.corretto.crypto.provider.test.TestUtil.multiStepArrayMultiAllocationImplicit;
 import static com.amazon.corretto.crypto.provider.test.TestUtil.oneShotByteBuffer;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -169,6 +172,40 @@ public class AesCbcIso10126Test {
       assertTrue(
           byteBuffersAreEqual(
               dataByteBuff, multiStepArray(accpCipher, processingPattern, sunCipherText)));
+    }
+
+    for (final List<Integer> processingPattern : processingPatterns) {
+      accpCipher.init(Cipher.ENCRYPT_MODE, aesKey, iv);
+      final ByteBuffer accpCipherTextFromChunks =
+          mergeByteBuffers(
+              multiStepArrayMultiAllocationImplicit(accpCipher, processingPattern, data));
+      assertEquals(sunCipherText.length, accpCipherTextFromChunks.remaining());
+      accpCipher.init(Cipher.DECRYPT_MODE, aesKey, iv);
+      assertTrue(
+          byteBuffersAreEqual(
+              dataByteBuff,
+              multiStepArray(
+                  accpCipher,
+                  processingPattern,
+                  accpCipherTextFromChunks.array(),
+                  accpCipherTextFromChunks.remaining())));
+    }
+
+    for (final List<Integer> processingPattern : processingPatterns) {
+      accpCipher.init(Cipher.ENCRYPT_MODE, aesKey, iv);
+      final ByteBuffer accpCipherTextFromChunks =
+          mergeByteBuffers(
+              multiStepArrayMultiAllocationExplicit(accpCipher, processingPattern, data));
+      assertEquals(sunCipherText.length, accpCipherTextFromChunks.remaining());
+      accpCipher.init(Cipher.DECRYPT_MODE, aesKey, iv);
+      assertTrue(
+          byteBuffersAreEqual(
+              dataByteBuff,
+              multiStepArray(
+                  accpCipher,
+                  processingPattern,
+                  accpCipherTextFromChunks.array(),
+                  accpCipherTextFromChunks.remaining())));
     }
   }
 

--- a/tst/com/amazon/corretto/crypto/provider/test/AesCbcIso10126Test.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/AesCbcIso10126Test.java
@@ -1,0 +1,435 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package com.amazon.corretto.crypto.provider.test;
+
+import static com.amazon.corretto.crypto.provider.test.TestUtil.byteBuffersAreEqual;
+import static com.amazon.corretto.crypto.provider.test.TestUtil.genAesKey;
+import static com.amazon.corretto.crypto.provider.test.TestUtil.genData;
+import static com.amazon.corretto.crypto.provider.test.TestUtil.genIv;
+import static com.amazon.corretto.crypto.provider.test.TestUtil.genPattern;
+import static com.amazon.corretto.crypto.provider.test.TestUtil.multiStepArray;
+import static com.amazon.corretto.crypto.provider.test.TestUtil.oneShotByteBuffer;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.ByteBuffer;
+import java.security.InvalidKeyException;
+import java.security.Key;
+import java.security.Provider;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import javax.crypto.BadPaddingException;
+import javax.crypto.Cipher;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@ExtendWith(TestResultLogger.class)
+@Execution(ExecutionMode.SAME_THREAD)
+@ResourceLock(value = TestUtil.RESOURCE_GLOBAL, mode = ResourceAccessMode.READ)
+public class AesCbcIso10126Test {
+  private static final Provider bcProv = new BouncyCastleProvider();
+
+  static Cipher accpCipher() {
+    try {
+      return Cipher.getInstance("AES/CBC/ISO10126Padding", TestUtil.NATIVE_PROVIDER);
+    } catch (final Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  static Cipher sunCipher() {
+    try {
+      return Cipher.getInstance("AES/CBC/ISO10126Padding", "SunJCE");
+    } catch (final Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("arrayTestParams")
+  public void testArrayOneShot(final long seed, final int keySize) throws Exception {
+    final byte[] input = genData(seed, (int) seed);
+    final SecretKeySpec aesKey = genAesKey(seed + 1, keySize);
+    final IvParameterSpec iv = genIv(seed + 2, 16);
+
+    final Cipher accp = accpCipher();
+    final Cipher sun = sunCipher();
+
+    accp.init(Cipher.ENCRYPT_MODE, aesKey, iv);
+    sun.init(Cipher.ENCRYPT_MODE, aesKey, iv);
+    final byte[] accpCipherText = accp.doFinal(input);
+    final byte[] sunCipherText = sun.doFinal(input);
+    assertEquals(sunCipherText.length, accpCipherText.length);
+    // Since the padding is random, the last block of the cipher texts are not necessarily the same.
+    for (int i = 0; i < accpCipherText.length - 16; i++) {
+      assertEquals(sunCipherText[i], accpCipherText[i]);
+    }
+    accp.init(Cipher.DECRYPT_MODE, aesKey, iv);
+    sun.init(Cipher.DECRYPT_MODE, aesKey, iv);
+    assertArrayEquals(input, accp.doFinal(accpCipherText));
+    assertArrayEquals(input, accp.doFinal(sunCipherText));
+    assertArrayEquals(input, sun.doFinal(accpCipherText));
+  }
+
+  @Test
+  public void encryptingSameInputMultipleTimesShouldProduceDifferentCipherTexts() throws Exception {
+    final long seed = 100;
+    final int keySize = 256;
+    final byte[] input = genData(seed, (int) seed);
+    final SecretKeySpec aesKey = genAesKey(seed + 1, keySize);
+    final IvParameterSpec iv = genIv(seed + 2, 16);
+
+    final Cipher accp = accpCipher();
+
+    accp.init(Cipher.ENCRYPT_MODE, aesKey, iv);
+    final byte[] cipherText1 = accp.doFinal(input);
+    final byte[] cipherText2 = accp.doFinal(input);
+    assertFalse(Arrays.equals(cipherText1, cipherText2));
+  }
+
+  @ParameterizedTest
+  @MethodSource("arrayTestParams")
+  public void testOneShotArrayInPlace(final long seed, final int keySize) throws Exception {
+    final int inputLen = (int) seed;
+    final Cipher accpCipher = accpCipher();
+    final SecretKeySpec aesKey = genAesKey(seed, keySize);
+    final IvParameterSpec iv = genIv(seed, 16);
+    accpCipher.init(Cipher.ENCRYPT_MODE, aesKey, iv);
+    final int bufferLen = accpCipher.getOutputSize(inputLen);
+
+    final Cipher sunCipher = sunCipher();
+    final byte[] inputOutput = genData(seed, bufferLen);
+    final byte[] input = Arrays.copyOf(inputOutput, inputLen);
+    final ByteBuffer inputByteBuffer = ByteBuffer.wrap(input);
+
+    sunCipher.init(Cipher.ENCRYPT_MODE, aesKey, iv);
+    final byte[] sunCipherText = sunCipher.doFinal(input);
+    final int cipherTextLen = accpCipher.doFinal(inputOutput, 0, inputLen, inputOutput, 0);
+    assertEquals(sunCipherText.length, cipherTextLen);
+
+    accpCipher.init(Cipher.DECRYPT_MODE, aesKey, iv);
+    assertEquals(inputLen, accpCipher.doFinal(inputOutput, 0, cipherTextLen, inputOutput, 0));
+    assertTrue(byteBuffersAreEqual(inputByteBuffer, ByteBuffer.wrap(inputOutput, 0, inputLen)));
+    assertEquals(
+        inputLen, accpCipher.doFinal(sunCipherText, 0, sunCipherText.length, sunCipherText, 0));
+    assertTrue(byteBuffersAreEqual(inputByteBuffer, ByteBuffer.wrap(sunCipherText, 0, inputLen)));
+  }
+
+  @ParameterizedTest
+  @MethodSource("arrayTestParams")
+  public void testMultiStepArray(final long seed, final int keySize) throws Exception {
+    final int inputLen = (int) seed;
+    final Cipher accpCipher = accpCipher();
+
+    final byte[] data = genData(seed, inputLen);
+    final ByteBuffer dataByteBuff = ByteBuffer.wrap(data);
+    final SecretKeySpec aesKey = genAesKey(seed, keySize);
+    final IvParameterSpec iv = genIv(seed, 16);
+
+    final List<List<Integer>> processingPatterns =
+        Stream.of(-1, 0, 16, 20, 32)
+            .map(c -> genPattern(seed, c, inputLen))
+            .collect(Collectors.toList());
+
+    final Cipher sunCipher = sunCipher();
+    sunCipher.init(Cipher.ENCRYPT_MODE, aesKey, iv);
+    final byte[] sunCipherText = sunCipher.doFinal(data);
+
+    for (final List<Integer> processingPattern : processingPatterns) {
+      accpCipher.init(Cipher.ENCRYPT_MODE, aesKey, iv);
+      final ByteBuffer accpCipherText = multiStepArray(accpCipher, processingPattern, data);
+      assertEquals(sunCipherText.length, accpCipherText.remaining());
+      accpCipher.init(Cipher.DECRYPT_MODE, aesKey, iv);
+      assertTrue(
+          byteBuffersAreEqual(
+              dataByteBuff,
+              multiStepArray(
+                  accpCipher,
+                  processingPattern,
+                  accpCipherText.array(),
+                  accpCipherText.remaining())));
+      assertTrue(
+          byteBuffersAreEqual(
+              dataByteBuff, multiStepArray(accpCipher, processingPattern, sunCipherText)));
+    }
+  }
+
+  private static Stream<Arguments> arrayTestParams() {
+    final List<Arguments> result = new ArrayList<>();
+    for (final int keySize : new int[] {128, 192, 256}) {
+      for (long seed = 0; seed != 1025; seed++) {
+        result.add(Arguments.of(seed, keySize));
+      }
+    }
+    return result.stream();
+  }
+
+  @ParameterizedTest
+  @MethodSource("byteBufferTestParams")
+  public void testOneShotByteBuffer(
+      final long seed,
+      final int keySize,
+      final boolean inputReadOnly,
+      final boolean inputDirect,
+      final boolean outputDirect)
+      throws Exception {
+
+    final int inputLen = (int) seed;
+
+    final Cipher accpCipher = accpCipher();
+    final Cipher sunCipher = sunCipher();
+    final ByteBuffer input = genData(seed, inputLen, inputDirect);
+    final SecretKeySpec aesKey = genAesKey(seed, keySize);
+    final IvParameterSpec iv = genIv(seed, 16);
+
+    accpCipher.init(Cipher.ENCRYPT_MODE, aesKey, iv);
+    final ByteBuffer accpCipherText =
+        genData(seed, accpCipher.getOutputSize(input.remaining()), outputDirect);
+    sunCipher.init(Cipher.ENCRYPT_MODE, aesKey, iv);
+    final int accpOutputLimit = accpCipherText.limit();
+    final int accpOutputPosition = accpCipherText.position();
+    final ByteBuffer accpInput =
+        inputReadOnly ? input.duplicate().asReadOnlyBuffer() : input.duplicate();
+    final int accpCipherLen = accpCipher.doFinal(accpInput, accpCipherText);
+    // all the input must have been processed.
+    assertEquals(0, accpInput.remaining());
+    assertEquals(accpInput.limit(), accpInput.position());
+    // limit for input should not change
+    assertEquals(input.limit(), accpInput.limit());
+    // limit should not change for output
+    assertEquals(accpOutputLimit, accpCipherText.limit());
+    // position of the output should advance by the length of the cipher
+    assertEquals(accpOutputPosition + accpCipherLen, accpCipherText.position());
+
+    accpCipherText.flip();
+
+    final ByteBuffer sunInput = input.duplicate();
+    final ByteBuffer sunCipherText = oneShotByteBuffer(sunCipher, sunInput);
+    assertEquals(sunCipherText.remaining(), accpCipherLen);
+
+    accpCipher.init(Cipher.DECRYPT_MODE, aesKey, iv);
+    assertTrue(
+        byteBuffersAreEqual(input, oneShotByteBuffer(accpCipher, accpCipherText.duplicate())));
+    assertTrue(byteBuffersAreEqual(input, oneShotByteBuffer(accpCipher, sunCipherText)));
+
+    sunCipher.init(Cipher.DECRYPT_MODE, aesKey, iv);
+    assertTrue(byteBuffersAreEqual(input, oneShotByteBuffer(sunCipher, accpCipherText)));
+  }
+
+  private static Stream<Arguments> byteBufferTestParams() {
+    final List<Arguments> result = new ArrayList<>();
+    for (final int keySize : new int[] {128}) {
+      for (int seed = 0; seed != 1024; seed++) {
+        for (final boolean inputReadOnly : new boolean[] {true, false}) {
+          for (final boolean inputDirect : new boolean[] {true, false}) {
+            for (final boolean outputDirect : new boolean[] {true, false}) {
+              result.add(Arguments.of(seed, keySize, inputReadOnly, inputDirect, outputDirect));
+            }
+          }
+        }
+      }
+    }
+    return result.stream();
+  }
+
+  @Test
+  public void whenBadPaddingDuringDecryptOneShot_expectException() throws Exception {
+    final SecretKeySpec key =
+        new SecretKeySpec(
+            TestUtil.decodeHex("000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F"),
+            "AES");
+    final byte[] input =
+        TestUtil.decodeHex(
+            "000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F202122232425262728292A2B2C2D2E2F3031");
+    final IvParameterSpec iv =
+        new IvParameterSpec(TestUtil.decodeHex("000102030405060708090A0B0C0D0E0F"));
+    final Cipher cipher = accpCipher();
+    cipher.init(Cipher.ENCRYPT_MODE, key, iv);
+    final byte[] cipherText = cipher.doFinal(input);
+    cipher.init(Cipher.DECRYPT_MODE, key, iv);
+    boolean badPaddingHappened = false;
+    for (int i = 0; i < 256; i++) {
+      // ISO10126 padding is not a deterministic algorithm. There is chance that we tamper the last
+      // byte, but its decrypted value is less than or equal to 16. So we need to try till we
+      // succeed.
+      cipherText[cipherText.length - 1]++;
+      try {
+        cipher.doFinal(cipherText);
+      } catch (final BadPaddingException e) {
+        // This is good. An exception happened.
+        badPaddingHappened = true;
+        break;
+      }
+    }
+    assertTrue(badPaddingHappened);
+    // The cipher will need to be initialized again.
+    assertThrows(IllegalStateException.class, () -> cipher.doFinal(cipherText));
+  }
+
+  @Test
+  public void whenBadPaddingDuringDecryptMultiStep_expectException() throws Exception {
+    final SecretKeySpec key =
+        new SecretKeySpec(
+            TestUtil.decodeHex("000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F"),
+            "AES");
+    final byte[] input =
+        TestUtil.decodeHex(
+            "000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F202122232425262728292A2B2C2D2E2F3031");
+    final IvParameterSpec iv =
+        new IvParameterSpec(TestUtil.decodeHex("000102030405060708090A0B0C0D0E0F"));
+    final Cipher cbcPadding = accpCipher();
+    cbcPadding.init(Cipher.ENCRYPT_MODE, key, iv);
+    final byte[] cipherText = cbcPadding.doFinal(input);
+    cipherText[cipherText.length - 1] = (byte) (0xFF ^ cipherText[cipherText.length - 1]);
+    cbcPadding.init(Cipher.DECRYPT_MODE, key, iv);
+    assertDoesNotThrow(() -> cbcPadding.update(cipherText, 0, 16));
+    boolean badPaddingHappened = false;
+    for (int i = 0; i < 256; i++) {
+      // ISO10126 padding is not a deterministic algorithm. There is chance that we tamper the last
+      // byte, but its decrypted value is less than or equal to 16. So we need to try till we
+      // succeed.
+      cipherText[cipherText.length - 1]++;
+      try {
+        cbcPadding.doFinal(cipherText, 16, cipherText.length - 16);
+      } catch (final BadPaddingException e) {
+        // This is good. An exception happened.
+        badPaddingHappened = true;
+        break;
+      }
+    }
+    assertTrue(badPaddingHappened);
+    // The cipher will need to be initialized again.
+    assertThrows(IllegalStateException.class, () -> cbcPadding.doFinal(cipherText));
+  }
+
+  @Test
+  public void usingSameKeyIvIsAllowed() throws Exception {
+    final SecretKeySpec key = genAesKey(564, 256);
+    final IvParameterSpec iv = genIv(644, 16);
+    final byte[] input1 = genData(0, 256);
+    final byte[] input2 = genData(1, 256);
+
+    final Cipher accp = accpCipher();
+    final Cipher sun = sunCipher();
+
+    accp.init(Cipher.ENCRYPT_MODE, key, iv);
+    sun.init(Cipher.ENCRYPT_MODE, key, iv);
+    assertDoesNotThrow(() -> accp.doFinal(input1));
+    assertDoesNotThrow(() -> accp.doFinal(input2));
+    assertDoesNotThrow(() -> sun.doFinal(input1));
+    assertDoesNotThrow(() -> sun.doFinal(input2));
+
+    accp.init(Cipher.ENCRYPT_MODE, key, iv);
+    sun.init(Cipher.ENCRYPT_MODE, key, iv);
+    assertDoesNotThrow(() -> accp.doFinal(input1));
+    assertDoesNotThrow(() -> sun.doFinal(input1));
+    accp.init(Cipher.ENCRYPT_MODE, key, iv);
+    sun.init(Cipher.ENCRYPT_MODE, key, iv);
+    assertDoesNotThrow(() -> accp.doFinal(input2));
+    assertDoesNotThrow(() -> sun.doFinal(input2));
+  }
+
+  @ParameterizedTest
+  @MethodSource("wrapUnwrapParams")
+  public void wrapUnwrapIsCompatibleWithSun(final long seed, final int keySize) throws Exception {
+    final int inputLen = (int) seed;
+    final String alg = "SECRET_KEY";
+    final SecretKeySpec wrappingKey = genAesKey(seed, keySize);
+    final IvParameterSpec iv = genIv(seed, 16);
+
+    final Cipher accp = accpCipher();
+    accp.init(Cipher.WRAP_MODE, wrappingKey, iv);
+    final Cipher sun = sunCipher();
+    sun.init(Cipher.WRAP_MODE, wrappingKey, iv);
+
+    final SecretKeySpec keyToBeWrapped = new SecretKeySpec(genData(seed, inputLen), alg);
+
+    final byte[] sunWrappedKey = sun.wrap(keyToBeWrapped);
+    final byte[] accpWrappedKey = accp.wrap(keyToBeWrapped);
+
+    accp.init(Cipher.UNWRAP_MODE, wrappingKey, iv);
+    sun.init(Cipher.UNWRAP_MODE, wrappingKey, iv);
+
+    final Key sunUnwrappedKey = sun.unwrap(accpWrappedKey, alg, Cipher.SECRET_KEY);
+    final Key accpUnwrappedKey1 = accp.unwrap(accpWrappedKey, alg, Cipher.SECRET_KEY);
+    final Key accpUnwrappedKey2 = accp.unwrap(sunWrappedKey, alg, Cipher.SECRET_KEY);
+
+    assertEquals(sunUnwrappedKey.getAlgorithm(), accpUnwrappedKey1.getAlgorithm());
+    assertEquals(sunUnwrappedKey.getFormat(), accpUnwrappedKey1.getFormat());
+    assertEquals(sunUnwrappedKey.getAlgorithm(), accpUnwrappedKey2.getAlgorithm());
+    assertEquals(sunUnwrappedKey.getFormat(), accpUnwrappedKey2.getFormat());
+    assertArrayEquals(keyToBeWrapped.getEncoded(), sunUnwrappedKey.getEncoded());
+    assertArrayEquals(keyToBeWrapped.getEncoded(), accpUnwrappedKey1.getEncoded());
+    assertArrayEquals(keyToBeWrapped.getEncoded(), accpUnwrappedKey2.getEncoded());
+  }
+
+  private static Stream<Arguments> wrapUnwrapParams() {
+    final List<Arguments> result = new ArrayList<>();
+    for (int keySize : new int[] {128}) {
+      for (long i = 16; i != 17; i++) {
+        result.add(Arguments.of(i, keySize));
+      }
+    }
+    return result.stream();
+  }
+
+  @Test
+  public void whenBadPaddingWithUnwrap_expectException() throws Exception {
+    final SecretKeySpec wrappingKey = genAesKey(0, 128);
+    final IvParameterSpec iv = genIv(0, 16);
+    final Cipher accp = accpCipher();
+    accp.init(Cipher.UNWRAP_MODE, wrappingKey, iv);
+    assertThrows(
+        InvalidKeyException.class,
+        () -> accp.unwrap(genData(0, 16), "SECRET_KEY", Cipher.SECRET_KEY));
+  }
+
+  @Test
+  public void whenWrappedKeyIsNotAligned_expectException() throws Exception {
+    final SecretKeySpec wrappingKey = genAesKey(0, 128);
+    final IvParameterSpec iv = genIv(0, 16);
+    final Cipher accp = accpCipher();
+    accp.init(Cipher.UNWRAP_MODE, wrappingKey, iv);
+    assertThrows(
+        InvalidKeyException.class,
+        () -> accp.unwrap(genData(0, 17), "SECRET_KEY", Cipher.SECRET_KEY));
+  }
+
+  @Test
+  public void aesCbcBlockSizeIs16() {
+    assertEquals(sunCipher().getBlockSize(), accpCipher().getBlockSize());
+  }
+
+  @Test
+  public void whenDecryptingWithUnalignedInput_expectException() throws Exception {
+    final IvParameterSpec iv = genIv(1, 16);
+    final SecretKeySpec key = genAesKey(1, 128);
+    final byte[] input = new byte[23];
+
+    final Cipher cipherDec = accpCipher();
+    cipherDec.init(Cipher.DECRYPT_MODE, key, iv);
+    assertThrows(IllegalBlockSizeException.class, () -> cipherDec.doFinal(input));
+
+    // When performing multistep operations, unalignment is only detected during final
+    assertDoesNotThrow(() -> cipherDec.update(input, 0, 20));
+    assertThrows(IllegalBlockSizeException.class, () -> cipherDec.doFinal(input, 20, 3));
+  }
+}

--- a/tst/com/amazon/corretto/crypto/provider/test/AesCbcTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/AesCbcTest.java
@@ -485,7 +485,7 @@ public class AesCbcTest {
   private static Stream<Arguments> byteBufferTestParams() {
     final List<Arguments> result = new ArrayList<>();
     for (final int keySize : new int[] {128}) {
-      for (int i = 0; i != 1024; i++) {
+      for (int i = 0; i != 512; i++) {
         for (final boolean isPaddingEnabled : new boolean[] {true, false}) {
           for (final boolean inputReadOnly : new boolean[] {true, false}) {
             for (final boolean inputDirect : new boolean[] {true, false}) {

--- a/tst/com/amazon/corretto/crypto/provider/test/AesCbcTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/AesCbcTest.java
@@ -2,12 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.amazon.corretto.crypto.provider.test;
 
-import static com.amazon.corretto.crypto.provider.test.TestUtil.ascendingPattern;
 import static com.amazon.corretto.crypto.provider.test.TestUtil.byteBuffersAreEqual;
-import static com.amazon.corretto.crypto.provider.test.TestUtil.constantPattern;
 import static com.amazon.corretto.crypto.provider.test.TestUtil.genAesKey;
 import static com.amazon.corretto.crypto.provider.test.TestUtil.genData;
 import static com.amazon.corretto.crypto.provider.test.TestUtil.genIv;
+import static com.amazon.corretto.crypto.provider.test.TestUtil.genPattern;
 import static com.amazon.corretto.crypto.provider.test.TestUtil.multiStepArray;
 import static com.amazon.corretto.crypto.provider.test.TestUtil.multiStepArrayMultiAllocationExplicit;
 import static com.amazon.corretto.crypto.provider.test.TestUtil.multiStepArrayMultiAllocationImplicit;
@@ -16,7 +15,6 @@ import static com.amazon.corretto.crypto.provider.test.TestUtil.multiStepByteBuf
 import static com.amazon.corretto.crypto.provider.test.TestUtil.multiStepByteBufferMultiAllocation;
 import static com.amazon.corretto.crypto.provider.test.TestUtil.multiStepInPlaceArray;
 import static com.amazon.corretto.crypto.provider.test.TestUtil.oneShotByteBuffer;
-import static com.amazon.corretto.crypto.provider.test.TestUtil.randomPattern;
 import static org.junit.Assert.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -222,16 +220,6 @@ public class AesCbcTest {
               dataByteBuff,
               multiStepArrayMultiAllocationExplicit(accpCipher, processingPattern, sunCipherText)));
     }
-  }
-
-  private static List<Integer> genPattern(final long seed, final int choice, final int inputLen) {
-    if (choice < 0) {
-      return randomPattern(inputLen, seed);
-    }
-    if (choice == 0) {
-      return ascendingPattern(inputLen);
-    }
-    return constantPattern(inputLen, choice);
   }
 
   private static Stream<Arguments> arrayTestParams() {

--- a/tst/com/amazon/corretto/crypto/provider/test/TestUtil.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/TestUtil.java
@@ -592,24 +592,30 @@ public class TestUtil {
 
   public static ByteBuffer multiStepArray(
       final Cipher cipher, final List<Integer> process, final byte[] input) throws Exception {
+    return multiStepArray(cipher, process, input, input.length);
+  }
 
-    final byte[] output = new byte[cipher.getOutputSize(input.length)];
+  public static ByteBuffer multiStepArray(
+      final Cipher cipher, final List<Integer> process, final byte[] input, final int inputLen)
+      throws Exception {
+
+    final byte[] output = new byte[cipher.getOutputSize(inputLen)];
 
     int inputOffset = 0;
     int outputOffset = 0;
 
     for (final Integer p : process) {
-      if (inputOffset == input.length) break;
-      final int toBeProcessed = (p + inputOffset) > input.length ? (input.length - inputOffset) : p;
+      if (inputOffset == inputLen) break;
+      final int toBeProcessed = (p + inputOffset) > inputLen ? (inputLen - inputOffset) : p;
       outputOffset += cipher.update(input, inputOffset, toBeProcessed, output, outputOffset);
       inputOffset += toBeProcessed;
     }
 
-    if (inputOffset == input.length) {
+    if (inputOffset == inputLen) {
       outputOffset += cipher.doFinal(output, outputOffset);
     } else {
       outputOffset +=
-          cipher.doFinal(input, inputOffset, input.length - inputOffset, output, outputOffset);
+          cipher.doFinal(input, inputOffset, inputLen - inputOffset, output, outputOffset);
     }
 
     return ByteBuffer.wrap(output, 0, outputOffset);
@@ -786,5 +792,15 @@ public class TestUtil {
     }
 
     return outputOffset;
+  }
+
+  public static List<Integer> genPattern(final long seed, final int choice, final int inputLen) {
+    if (choice < 0) {
+      return randomPattern(inputLen, seed);
+    }
+    if (choice == 0) {
+      return ascendingPattern(inputLen);
+    }
+    return constantPattern(inputLen, choice);
   }
 }


### PR DESCRIPTION
*Description of changes:*

AES-CBC with ISO10126 Padding
+ AWS-LC does not support ISO10126.
+ The padding and unpadding are handled in ACCP.
+ The padding is explained here: https://www.w3.org/TR/xmlenc-core1/#sec-Padding


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
