### PR TITLE
Make ACCP compatible with SunJCE when decrypting empty array with CBC with padding

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ plugins {
 }
 
 group = 'software.amazon.cryptools'
-version = '2.3.4'
+version = '2.4.0'
 ext.isFips = Boolean.getBoolean('FIPS')
 if (ext.isFips) {
     ext.awsLcGitVersionId = 'AWS-LC-FIPS-2.0.2'

--- a/csrc/aes_cbc.cpp
+++ b/csrc/aes_cbc.cpp
@@ -264,8 +264,8 @@ public:
             JBinaryBlob last_block(jenv_, nullptr, j_last_block);
             int last_block_len = last_block.get()[AES_CBC_BLOCK_SIZE_IN_BYTES];
             if (last_block_len != AES_CBC_BLOCK_SIZE_IN_BYTES) {
-                // This can happen if the input is empty.
-                throw java_ex(EX_BADPADDING, "Bad padding");
+                throw java_ex(
+                    EX_ERROR, "THIS SHOULD NOT BE REACHABLE: in the Java layer we ensure that this never happens.");
             }
             // First, we decrypt the last block.
             result = update(last_block.get(), last_block_len, output, unprocessed_input);

--- a/src/com/amazon/corretto/crypto/provider/AesCbcSpi.java
+++ b/src/com/amazon/corretto/crypto/provider/AesCbcSpi.java
@@ -250,6 +250,7 @@ class AesCbcSpi extends CipherSpi {
     this.iv = iv;
     this.key = keyBytes;
     this.unprocessedInput = 0;
+    this.inputIsEmpty = true;
     initLastBlock();
   }
 
@@ -377,7 +378,9 @@ class AesCbcSpi extends CipherSpi {
       final byte[] outputArray,
       final int outputOffset) {
 
-    inputIsEmpty = inputIsEmpty && (inputLen == 0);
+    if (inputLen > 0) {
+      inputIsEmpty = false;
+    }
 
     // Unlike, doFinal (which needs to decide if a context should be released or not), update always
     // has to save the context.
@@ -549,7 +552,9 @@ class AesCbcSpi extends CipherSpi {
       final byte[] outputArray,
       final int outputOffset) {
 
-    inputIsEmpty = inputIsEmpty && (inputLen == 0);
+    if (inputLen > 0) {
+      inputIsEmpty = false;
+    }
 
     if (inputIsEmpty && (opMode == DEC_MODE) && (!noPadding())) {
       // AWS-LC's behavior in treating empty input when decrypting with padding differs from SunJCE.

--- a/src/com/amazon/corretto/crypto/provider/AesCbcSpi.java
+++ b/src/com/amazon/corretto/crypto/provider/AesCbcSpi.java
@@ -118,6 +118,10 @@ class AesCbcSpi extends CipherSpi {
   // and written to in the native code. In the Java side, we only set it to zero whenever we
   // initialized.
   private byte[] lastBlock;
+  // This flag is initially true. Whenever a non-zero input is passed, it is set to false, and it
+  // remains false till the cipher is done processing. This is used during decryption with padding
+  // to produce empty output when nothing is passed to the cipher.
+  private boolean inputIsEmpty;
 
   AesCbcSpi(final Padding padding, final boolean saveContext) {
     this.padding = padding.getValue();
@@ -129,6 +133,7 @@ class AesCbcSpi extends CipherSpi {
     this.nativeCtx = null;
     this.saveContext = saveContext;
     this.lastBlock = null;
+    this.inputIsEmpty = true;
   }
 
   private boolean noPadding() {
@@ -372,6 +377,8 @@ class AesCbcSpi extends CipherSpi {
       final byte[] outputArray,
       final int outputOffset) {
 
+    inputIsEmpty = inputIsEmpty && (inputLen == 0);
+
     // Unlike, doFinal (which needs to decide if a context should be released or not), update always
     // has to save the context.
 
@@ -542,6 +549,14 @@ class AesCbcSpi extends CipherSpi {
       final byte[] outputArray,
       final int outputOffset) {
 
+    inputIsEmpty = inputIsEmpty && (inputLen == 0);
+
+    if (inputIsEmpty && (opMode == DEC_MODE) && (!noPadding())) {
+      // AWS-LC's behavior in treating empty input when decrypting with padding differs from SunJCE.
+      // Here we return zero plaintext.
+      return 0;
+    }
+
     // There are four possibilities:
     // 1. Save context AND Cipher is in INITIALIZED state => nInitUpdateFinal(saveContext == true)
     // 2. Save context AND Cipher is in UPDATED state => nUpdateFinal(saveContext == true)
@@ -663,6 +678,7 @@ class AesCbcSpi extends CipherSpi {
 
       cipherState = CipherState.INITIALIZED;
       unprocessedInput = 0;
+      inputIsEmpty = true;
       if (lastBlock != null) {
         Arrays.fill(lastBlock, (byte) 0);
       }

--- a/tst/com/amazon/corretto/crypto/provider/test/AesCbcIso10126Test.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/AesCbcIso10126Test.java
@@ -16,6 +16,7 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -64,6 +65,44 @@ public class AesCbcIso10126Test {
     } catch (final Exception e) {
       throw new RuntimeException(e);
     }
+  }
+
+  @Test
+  public void emptyCipherTextWithPaddingEnabledShouldProduceEmptyPlaintext() throws Exception {
+    // For empty cipher text, SunJCE returns empty plain text when decrypting with padding enabled.
+    // This is despite the fact that Cipher text with padding is always at least 16 bytes. This test
+    // shows that ACCP is compatible with SunJCE in this manner.
+    final SecretKeySpec key = genAesKey(10, 128);
+    final IvParameterSpec iv = genIv(10, 16);
+    final Cipher accp = accpCipher();
+    final Cipher sun = sunCipher();
+
+    accp.init(Cipher.DECRYPT_MODE, key, iv);
+    sun.init(Cipher.DECRYPT_MODE, key, iv);
+
+    final byte[] empty = new byte[0];
+
+    assertEquals(0, accp.doFinal().length);
+    assertEquals(sun.doFinal().length, sun.doFinal().length);
+
+    assertEquals(0, accp.doFinal(empty).length);
+    assertEquals(sun.doFinal().length, sun.doFinal(empty).length);
+
+    assertNull(accp.update(empty));
+    assertEquals(sun.update(empty), sun.update(empty));
+    assertEquals(0, accp.doFinal().length);
+    assertEquals(sun.doFinal().length, sun.doFinal().length);
+
+    assertNull(accp.update(empty));
+    assertEquals(sun.update(empty), sun.update(empty));
+    assertEquals(0, accp.doFinal(empty).length);
+    assertEquals(sun.doFinal(empty).length, sun.doFinal(empty).length);
+
+    // On the other hand, encrypting an empty array produces 16 bytes of cipher text:
+    accp.init(Cipher.ENCRYPT_MODE, key, iv);
+    sun.init(Cipher.ENCRYPT_MODE, key, iv);
+    assertEquals(16, accp.doFinal().length);
+    assertEquals(16, sun.doFinal().length);
   }
 
   @ParameterizedTest

--- a/tst/com/amazon/corretto/crypto/provider/test/AesCbcTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/AesCbcTest.java
@@ -133,6 +133,39 @@ public class AesCbcTest {
   }
 
   @Test
+  public void ensureInputEmptyIsResetAfterAnOperation() throws Exception {
+    final SecretKeySpec key = genAesKey(10, 128);
+    final IvParameterSpec iv = genIv(10, 16);
+    final Cipher accp = accpAesCbcCipher(true);
+
+    accp.init(Cipher.ENCRYPT_MODE, key, iv);
+
+    // First we encrypt with a non-empty input.
+    assertEquals(16, accp.doFinal(genData(10, 10)).length);
+    // Now we decrypt with the same cipher object and empty input:
+    accp.init(Cipher.DECRYPT_MODE, key, iv);
+    assertEquals(0, accp.doFinal().length);
+  }
+
+  @Test
+  public void ensureInputEmptyIsResetAfterAnOperationWithBadPaddingToo() throws Exception {
+    final SecretKeySpec key = genAesKey(10, 128);
+    final IvParameterSpec iv = genIv(10, 16);
+    final Cipher accp = accpAesCbcCipher(true);
+
+    accp.init(Cipher.DECRYPT_MODE, key, iv);
+    accp.update(new byte[8]);
+    // inputIsEmpty is false. We pass bad cipher text to cause bad padding.
+    assertThrows(BadPaddingException.class, () -> accp.doFinal(new byte[8]));
+    // The cipher must need re-initialization.
+    assertThrows(IllegalStateException.class, () -> accp.doFinal());
+    // After initialization, inputIsEmpty should be rest to true and produce zero output when
+    // decrypting empty input.
+    accp.init(Cipher.DECRYPT_MODE, key, iv);
+    assertEquals(0, accp.doFinal().length);
+  }
+
+  @Test
   public void testPkcs7Name() throws Exception {
     // SunJCE does not recognize AES/CBC/PKCS7Padding, but BouncyCastle does:
     assertThrows(


### PR DESCRIPTION
*Description of changes:*

For empty cipher text, SunJCE returns empty plain text when decrypting with padding enabled. This is despite the fact that cipher text with padding is always at least 16 bytes.  AWS-LC has a different behavior: `EVP_CipherFinal` fails when no input is passed during decryption with PKCS7Padding. For compatibility reasons, we follow SunJCE's approach.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
