### PR TITLE
Provide improved exception messages around bounds checks

### DIFF
--- a/src/com/amazon/corretto/crypto/provider/AccessibleByteArrayOutputStream.java
+++ b/src/com/amazon/corretto/crypto/provider/AccessibleByteArrayOutputStream.java
@@ -44,6 +44,7 @@ class AccessibleByteArrayOutputStream extends OutputStream implements Cloneable 
 
   @Override
   public void write(final byte[] b, final int off, final int len) {
+    Utils.checkArrayLimits(b, off, len);
     growCapacity(count + len);
     System.arraycopy(b, off, buf, count, len);
     count += len;
@@ -54,6 +55,7 @@ class AccessibleByteArrayOutputStream extends OutputStream implements Cloneable 
    * you know it would be the last time something needs to be written to the buffer.
    */
   void finalWrite(final byte[] b, final int off, final int len) {
+    Utils.checkArrayLimits(b, off, len);
     growCapacity(count + len, true);
     System.arraycopy(b, off, buf, count, len);
     count += len;
@@ -102,12 +104,9 @@ class AccessibleByteArrayOutputStream extends OutputStream implements Cloneable 
   }
 
   private void growCapacity(final int newCapacity, final boolean doNotAllocateMoreThanNeeded) {
-    if (newCapacity < 0) {
-      throw new OutOfMemoryError();
-    }
-    if (newCapacity > limit) {
+    if (newCapacity < 0 || newCapacity > limit) {
       throw new IllegalArgumentException(
-          String.format("Exceeded capacity limit %d. Requested %d", limit, newCapacity));
+          String.format("Invalid capacity. Limit: %d, Requested: %d.", limit, newCapacity));
     }
     if (newCapacity <= buf.length) {
       return;

--- a/src/com/amazon/corretto/crypto/provider/InputBuffer.java
+++ b/src/com/amazon/corretto/crypto/provider/InputBuffer.java
@@ -256,6 +256,7 @@ public class InputBuffer<T, S, X extends Throwable> implements Cloneable {
   }
 
   public void update(final byte[] src, final int offset, final int length) {
+    Utils.checkArrayLimits(src, offset, length);
     if (fillBuffer(src, offset, length)) {
       return;
     }

--- a/tst/com/amazon/corretto/crypto/provider/test/AccessibleByteArrayOutputStreamTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/AccessibleByteArrayOutputStreamTest.java
@@ -58,7 +58,8 @@ public class AccessibleByteArrayOutputStreamTest {
   public void intMaxOverflow() throws Throwable {
     OutputStream instance = getInstance();
     instance.write(new byte[1024]);
-    assertThrows(IllegalArgumentException.class, () -> instance.write(null, 0, Integer.MAX_VALUE - 512));
+    assertThrows(
+        IllegalArgumentException.class, () -> instance.write(null, 0, Integer.MAX_VALUE - 512));
   }
 
   @Test

--- a/tst/com/amazon/corretto/crypto/provider/test/AccessibleByteArrayOutputStreamTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/AccessibleByteArrayOutputStreamTest.java
@@ -55,10 +55,10 @@ public class AccessibleByteArrayOutputStreamTest {
   }
 
   @Test
-  public void outOfMemory() throws Throwable {
+  public void intMaxOverflow() throws Throwable {
     OutputStream instance = getInstance();
     instance.write(new byte[1024]);
-    assertThrows(OutOfMemoryError.class, () -> instance.write(null, 0, Integer.MAX_VALUE - 512));
+    assertThrows(IllegalArgumentException.class, () -> instance.write(null, 0, Integer.MAX_VALUE - 512));
   }
 
   @Test

--- a/tst/com/amazon/corretto/crypto/provider/test/InputBufferTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/InputBufferTest.java
@@ -57,8 +57,9 @@ public class InputBufferTest {
 
     assertThrows(
         IndexOutOfBoundsException.class,
-        () -> { buffer.update(data, start, end); }
-    );
+        () -> {
+          buffer.update(data, start, end);
+        });
   }
 
   @Test

--- a/tst/com/amazon/corretto/crypto/provider/test/InputBufferTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/InputBufferTest.java
@@ -48,6 +48,20 @@ public class InputBufferTest {
   }
 
   @Test
+  public void testNegativeLength() throws Throwable {
+    assumeMinimumVersion("1.6.1", NATIVE_PROVIDER);
+    final InputBuffer<byte[], ByteBuffer, RuntimeException> buffer = getBuffer(4);
+    final byte[] data = new byte[32];
+    final int start = 0;
+    final int end = -31;
+
+    assertThrows(
+        IndexOutOfBoundsException.class,
+        () -> { buffer.update(data, start, end); }
+    );
+  }
+
+  @Test
   public void minimalCase() {
     assumeMinimumVersion("1.6.1", NATIVE_PROVIDER);
     // Just tests the bare minimum configuration and ensures things are properly buffered

--- a/tst/com/amazon/corretto/crypto/provider/test/SHA256Test.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/SHA256Test.java
@@ -40,8 +40,9 @@ public class SHA256Test {
 
     assertThrows(
         IndexOutOfBoundsException.class,
-        () -> { digest.update(data, start, end); }
-    );
+        () -> {
+          digest.update(data, start, end);
+        });
   }
 
   @Test

--- a/tst/com/amazon/corretto/crypto/provider/test/SHA256Test.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/SHA256Test.java
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.amazon.corretto.crypto.provider.test;
 
+import static com.amazon.corretto.crypto.provider.test.TestUtil.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -27,6 +28,20 @@ public class SHA256Test {
 
   private MessageDigest getDigest() throws Exception {
     return MessageDigest.getInstance(SHA_256, TestUtil.NATIVE_PROVIDER);
+  }
+
+  @Test
+  public void testNegativeLength() throws Exception {
+    final byte[] data = new byte[32];
+    final int start = 0;
+    final int end = -31;
+
+    final MessageDigest digest = getDigest();
+
+    assertThrows(
+        IndexOutOfBoundsException.class,
+        () -> { digest.update(data, start, end); }
+    );
   }
 
   @Test


### PR DESCRIPTION
*Issue #, if available:*
P129094931

*Description of changes:*
Some customers have noticed that passing in a negative length to hash update functions results in an `java.lang.OutOfMemoryError` instead of an `IndexOutOfBoundsException`. To more closely match the behavior of other Java Crypto Providers, this PR updates ACCP to return an `IndexOutOfBoundsException`. 

Separately, this PR also updates ACCP to never throw `java.lang.OutOfMemoryError`, and instead throw an `IllegalArgumentException`. In Java, [Errors are unrecoverable in almost all circumstances (such as the JVM itself running out of memory) and should usually never be caught by applications, while Exceptions can almost always be caught by applications, logged, and allow applications to resume operations as normal](https://stackoverflow.com/a/40225083). Applications that pass in invalid arguments should receive a standard Java Exception so that they can catch the issue and log it, and not think that the JVM is crashing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
