### PR TITLE
Address -Xcheck:jni warnings for AES/CBC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -687,11 +687,9 @@ add_custom_target(check-with-jni-flag
     COMMAND ${TEST_JAVA_EXECUTABLE}
         -Xcheck:jni
         ${TEST_RUNNER_ARGUMENTS}
-        --select-class=com.amazon.corretto.crypto.provider.test.AesTest
-        --select-class=com.amazon.corretto.crypto.provider.test.AesGcmKatTest
-        --select-class=com.amazon.corretto.crypto.provider.test.AesCbcTest
-        --select-class=com.amazon.corretto.crypto.provider.test.AesCbcNistTest
-        --select-class=com.amazon.corretto.crypto.provider.test.AesCbcIso10126Test
+        --select-package=com.amazon.corretto.crypto.provider.test
+        --exclude-package=com.amazon.corretto.crypto.provider.test.integration
+        --exclude-classname=com.amazon.corretto.crypto.provider.test.SecurityManagerTest
 
     DEPENDS accp-jar tests-jar)
 
@@ -840,7 +838,7 @@ else()
         check-junit-AesLazy
         check-junit-AesEager
         check-junit-DifferentTempDir
-        # check-with-jni-flag for macos, we disable this check due to failures in java.net.Inet6AddressImpl.lookupAllHostAddr
+        # check-with-jni-flag for macos, we disable this check due to failures in java.net.Inet6AddressImpl.lookupAllHostAddr: https://bugs.openjdk.org/browse/JDK-8205076
     )
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -683,6 +683,18 @@ add_custom_target(check-junit-SecurityManager
 
     DEPENDS accp-jar tests-jar)
 
+add_custom_target(check-with-jni-flag
+    COMMAND ${TEST_JAVA_EXECUTABLE}
+        -Xcheck:jni
+        ${TEST_RUNNER_ARGUMENTS}
+        --select-class=com.amazon.corretto.crypto.provider.test.AesTest
+        --select-class=com.amazon.corretto.crypto.provider.test.AesGcmKatTest
+        --select-class=com.amazon.corretto.crypto.provider.test.AesCbcTest
+        --select-class=com.amazon.corretto.crypto.provider.test.AesCbcNistTest
+        --select-class=com.amazon.corretto.crypto.provider.test.AesCbcIso10126Test
+
+    DEPENDS accp-jar tests-jar)
+
 add_custom_target(check-junit-AesLazy
     COMMAND ${TEST_JAVA_EXECUTABLE}
         -Dcom.amazon.corretto.crypto.provider.nativeContextReleaseStrategy=LAZY
@@ -804,17 +816,33 @@ add_custom_target(check-install-via-properties-with-debug
 
     DEPENDS accp-jar tests-jar)
 
-add_custom_target(check
-    DEPENDS check-recursive-init
-    check-install-via-properties
-    check-install-via-properties-with-debug
-    check-junit
-    check-junit-SecurityManager
-    check-external-lib
-    check-junit-AesLazy
-    check-junit-AesEager
-    check-junit-DifferentTempDir
-)
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+    add_custom_target(check
+        DEPENDS check-recursive-init
+        check-install-via-properties
+        check-install-via-properties-with-debug
+        check-junit
+        check-junit-SecurityManager
+        check-external-lib
+        check-junit-AesLazy
+        check-junit-AesEager
+        check-junit-DifferentTempDir
+        check-with-jni-flag
+    )
+else()
+    add_custom_target(check
+        DEPENDS check-recursive-init
+        check-install-via-properties
+        check-install-via-properties-with-debug
+        check-junit
+        check-junit-SecurityManager
+        check-external-lib
+        check-junit-AesLazy
+        check-junit-AesEager
+        check-junit-DifferentTempDir
+        # check-with-jni-flag for macos, we disable this check due to failures in java.net.Inet6AddressImpl.lookupAllHostAddr
+    )
+endif()
 
 if(ENABLE_NATIVE_TEST_HOOKS)
     add_custom_target(check-keyutils

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -814,33 +814,22 @@ add_custom_target(check-install-via-properties-with-debug
 
     DEPENDS accp-jar tests-jar)
 
+set(check_targets check-recursive-init
+    check-install-via-properties
+    check-install-via-properties-with-debug
+    check-junit
+    check-junit-SecurityManager
+    check-external-lib
+    check-junit-AesLazy
+    check-junit-AesEager
+    check-junit-DifferentTempDir)
+
 if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
-    add_custom_target(check
-        DEPENDS check-recursive-init
-        check-install-via-properties
-        check-install-via-properties-with-debug
-        check-junit
-        check-junit-SecurityManager
-        check-external-lib
-        check-junit-AesLazy
-        check-junit-AesEager
-        check-junit-DifferentTempDir
-        check-with-jni-flag
-    )
-else()
-    add_custom_target(check
-        DEPENDS check-recursive-init
-        check-install-via-properties
-        check-install-via-properties-with-debug
-        check-junit
-        check-junit-SecurityManager
-        check-external-lib
-        check-junit-AesLazy
-        check-junit-AesEager
-        check-junit-DifferentTempDir
-        # check-with-jni-flag for macos, we disable this check due to failures in java.net.Inet6AddressImpl.lookupAllHostAddr: https://bugs.openjdk.org/browse/JDK-8205076
-    )
+  set(check_targets ${check_targets} check-with-jni-flag)
 endif()
+# For MacOS, check-with-jni-flag is not added due to failures in java.net.Inet6AddressImpl.lookupAllHostAddr: https://bugs.openjdk.org/browse/JDK-8205076
+
+add_custom_target(check DEPENDS ${check_targets})
 
 if(ENABLE_NATIVE_TEST_HOOKS)
     add_custom_target(check-keyutils

--- a/csrc/aes_cbc.cpp
+++ b/csrc/aes_cbc.cpp
@@ -322,18 +322,14 @@ extern "C" JNIEXPORT jint JNICALL Java_com_amazon_corretto_crypto_provider_AesCb
             aes_cbc_cipher.init(opMode, padding, j_key.get(), keyLen, j_iv.get());
         }
 
-        int result = 0;
         // update
-        JBinaryBlob output(env, outputDirect, outputArray);
-        {
-            JBinaryBlob input(env, inputDirect, inputArray);
-            result = aes_cbc_cipher.extended_update(
-                is_iso10126, is_enc, lastBlock, input.get() + inputOffset, inputLen, output.get() + outputOffset, 0);
-        }
+        JIOBlobs io_blobs(env, inputDirect, inputArray, outputDirect, outputArray);
+        int result = aes_cbc_cipher.extended_update(is_iso10126, is_enc, lastBlock, io_blobs.get_input() + inputOffset,
+            inputLen, io_blobs.get_output() + outputOffset, 0);
 
         // final
         result += aes_cbc_cipher.extended_do_final(
-            is_iso10126, is_enc, lastBlock, output.get() + outputOffset + result, inputLen - result);
+            is_iso10126, is_enc, lastBlock, io_blobs.get_output() + outputOffset + result, inputLen - result);
 
         return result;
 
@@ -371,11 +367,10 @@ extern "C" JNIEXPORT jint JNICALL Java_com_amazon_corretto_crypto_provider_AesCb
         }
 
         // update
-        JBinaryBlob output(env, outputDirect, outputArray);
-        JBinaryBlob input(env, inputDirect, inputArray);
+        JIOBlobs io_blobs(env, inputDirect, inputArray, outputDirect, outputArray);
 
         return aes_cbc_cipher.extended_update(is_iso10126_padding(padding), is_encryption_mode(opMode), lastBlock,
-            input.get() + inputOffset, inputLen, output.get() + outputOffset, 0);
+            io_blobs.get_input() + inputOffset, inputLen, io_blobs.get_output() + outputOffset, 0);
 
     } catch (java_ex& ex) {
         ex.throw_to_java(env);
@@ -402,11 +397,10 @@ extern "C" JNIEXPORT jint JNICALL Java_com_amazon_corretto_crypto_provider_AesCb
         AesCbcCipher aes_cbc_cipher(env, nullptr, ctxPtr, true);
 
         // update
-        JBinaryBlob output(env, outputDirect, outputArray);
-        JBinaryBlob input(env, inputDirect, inputArray);
+        JIOBlobs io_blobs(env, inputDirect, inputArray, outputDirect, outputArray);
 
         return aes_cbc_cipher.extended_update(is_iso10126_padding(padding), is_encryption_mode(opMode), lastBlock,
-            input.get() + inputOffset, inputLen, output.get() + outputOffset, unprocessedInput);
+            io_blobs.get_input() + inputOffset, inputLen, io_blobs.get_output() + outputOffset, 0);
 
     } catch (java_ex& ex) {
         ex.throw_to_java(env);
@@ -436,21 +430,17 @@ extern "C" JNIEXPORT jint JNICALL Java_com_amazon_corretto_crypto_provider_AesCb
         bool is_iso10126 = is_iso10126_padding(padding);
         bool is_enc = is_encryption_mode(opMode);
 
-        int result = 0;
         int up = unprocessedInput;
 
         // update
-        JBinaryBlob output(env, outputDirect, outputArray);
-        {
-            JBinaryBlob input(env, inputDirect, inputArray);
-            result = aes_cbc_cipher.extended_update(
-                is_iso10126, is_enc, lastBlock, input.get() + inputOffset, inputLen, output.get() + outputOffset, up);
-        }
+        JIOBlobs io_blobs(env, inputDirect, inputArray, outputDirect, outputArray);
+        int result = aes_cbc_cipher.extended_update(is_iso10126, is_enc, lastBlock, io_blobs.get_input() + inputOffset,
+            inputLen, io_blobs.get_output() + outputOffset, up);
 
         // final
         up = (inputLen + unprocessedInput) - result;
         result += aes_cbc_cipher.extended_do_final(
-            is_iso10126, is_enc, lastBlock, output.get() + outputOffset + result, up);
+            is_iso10126, is_enc, lastBlock, io_blobs.get_output() + outputOffset + result, up);
 
         return result;
 

--- a/tst/com/amazon/corretto/crypto/provider/test/AesCbcTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/AesCbcTest.java
@@ -1166,6 +1166,30 @@ public class AesCbcTest {
     assertArrayEquals(cipherText, cipher.doFinal(input));
 
     cipher.init(Cipher.DECRYPT_MODE, key, iv);
+    // Using cipher.update will produce same result, but this should be doFinal. Please have a look
+    // at the following test for the reason.
+    assertArrayEquals(input, cipher.doFinal(cipherText));
+  }
+
+  @ParameterizedTest
+  @MethodSource("paddings")
+  public void
+      whenInputIsAMultipleOfBlockSizeUpdateAndDoFinalProduceSameResultDuringDecrypt_expectSuccess(
+          final boolean isPaddingEnabled) throws Exception {
+    final IvParameterSpec iv = genIv(1, 16);
+    final SecretKeySpec key = genAesKey(1, 128);
+    final byte[] input = new byte[16];
+
+    final Cipher sunCipher = sunAesCbcCipher(isPaddingEnabled);
+    sunCipher.init(Cipher.ENCRYPT_MODE, key, iv);
+    final byte[] cipherText = sunCipher.doFinal(input);
+
+    final Cipher cipher = accpAesCbcCipher(isPaddingEnabled);
+
+    cipher.init(Cipher.DECRYPT_MODE, key, iv);
+    assertArrayEquals(input, cipher.doFinal(cipherText));
+    // Update will produce the same result as doFinal even padding is enabled. The reason is that
+    // when input is aligned, decrypt-final does not produce any output.
     assertArrayEquals(input, cipher.update(cipherText));
   }
 }


### PR DESCRIPTION
*Description of changes:*

+ If one of the input/output buffers is a direct byte buffer and the other one is a byte[], there is a chance that we call GetDirectBufferAddress after calling GetPrimitiveArrayCritical. This triggers a warning and this PR addresses that.
+ JIOBlobs is introduced that handles both input and output buffers. This class helps with addressing the warnings caused by -Xcheck:jni and it also avoids calling GetPrimitiveArrayCritical twice if the same byte[] is used for input and output.
+ When decrypting in AES/CBC/PKCS7Padding mode, AWS-LC touches the output buffer beyond its returned length. This means in ACCP we need to over allocate when calling update in multi-step decryption.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
