### PR TITLE
Register ACCP's SecureRandom by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -619,9 +619,6 @@ set(COVERAGE_ARGUMENTS
 if(FIPS)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DFIPS_BUILD")
     set(TEST_FIPS_PROPERTY "-DFIPS=true")
-    # ACCP's default behavior in FIPS mode is to not register a SecureRandom implementation.
-    # However, we explicitly register it here to ensure its coverage under test.
-    set(REGISTER_RNG_PROPERTY "-Dcom.amazon.corretto.crypto.provider.registerSecureRandom=true")
 else()
     set(TEST_FIPS_PROPERTY "-DFIPS=false")
 endif()
@@ -635,7 +632,6 @@ set(TEST_RUNNER_ARGUMENTS
     ${TEST_ADD_OPENS}
     ${TEST_FIPS_PROPERTY}
     ${EXTERNAL_LIB_PROPERTY}
-    ${REGISTER_RNG_PROPERTY}
     -Dcom.amazon.corretto.crypto.provider.inTestSuite=hunter2
     -Dtest.data.dir=${TEST_DATA_DIR}
     -Djunit.jupiter.execution.parallel.enabled=true

--- a/README.md
+++ b/README.md
@@ -252,10 +252,6 @@ The FIPS builds use a different version of AWS-LC along with `FIPS=1` build flag
 AWS-LC will have FIPS certification. As a result, ACCP in FIPS mode only uses a version of AWS-LC
 that has FIPS certification or it will have in future.
 
-For performance reasons, ACCP does not register a SecureRandom implementation in FIPS mode.
-Relevant operations within the FIPS module boundary (e.g. key generation, non-deterministic signing, etc.) will still use AWS-LC's internal DRBG.
-Users who require ACCP to provide FIPS-validated pseudo-randomness _outside_ the module boundary via SecureRandom should set `registerSecureRandom=true`.
-
 When changing between FIPS and non-FIPS builds, be sure to do a full `clean` of your build environment.
 
 ##### All targets
@@ -348,13 +344,10 @@ Thus, these should all be set on the JVM command line using `-D`.
   Using JCE's impelmentation is generally recommended unless using ACCP as a standalone provider
   Callers can choose to register ACCP's implementation at runtime with a call to `AmazonCorrettoCryptoProvider.registerEcParams()`
 * `com.amazon.corretto.crypto.provider.registerSecureRandom`
-  Takes in `true` or `false` (defaults to `false` in FIPS mode, defaults to `true` in non-FIPS).
+  Takes in `true` or `false` (defaults to `true`).
   If `true`, then ACCP will register a SecureRandom implementation (`LibCryptoRng`) backed by AWS-LC
   Else, ACCP will not register a SecureRandom implementation, meaning that the JCA will source SecureRandom instances from another registered provider. AWS-LC will still use its internal DRBG for key generation and other operations requiring secure pseudo-randomness.
-  LibCryptoRng is very fast during steady state operation in all cases. In FIPS mode, however, AWS-LC-FIPS's CPU jitter-based entropy source incurs a ~10ms initialization cost for every new thread.
-  This means that there is a slight "pause" before ACCP FIPS's SecureRandom can produce pseudo-random bytes in highly threaded environments.
-  Because, in extreme cases this could present an availability risk, we do not register LibCryptoRng by default in configurations where this initialization cost is incurred (i.e. FIPS mode).
-  Non-FIPS AWS-LC does not use CPU jitter for its DRBG seed's entropy, and therefore does not incur this initialization cost, therefore we register LibCryptoRng by default when not in FIPS mode.
+  LibCryptoRng is very fast during steady state operation in all cases.
 * `com.amazon.corretto.crypto.provider.nativeContextReleaseStrategy`
   Takes in `HYBRID`, `LAZY`, or `EAGER` (defaults ot `HYBRID`). This property only affects
   AES-GCM cipher for now. AES-GCM associates a native object of type `EVP_CIPHER_CTX`

--- a/README.md
+++ b/README.md
@@ -347,7 +347,6 @@ Thus, these should all be set on the JVM command line using `-D`.
   Takes in `true` or `false` (defaults to `true`).
   If `true`, then ACCP will register a SecureRandom implementation (`LibCryptoRng`) backed by AWS-LC
   Else, ACCP will not register a SecureRandom implementation, meaning that the JCA will source SecureRandom instances from another registered provider. AWS-LC will still use its internal DRBG for key generation and other operations requiring secure pseudo-randomness.
-  LibCryptoRng is very fast during steady state operation in all cases.
 * `com.amazon.corretto.crypto.provider.nativeContextReleaseStrategy`
   Takes in `HYBRID`, `LAZY`, or `EAGER` (defaults ot `HYBRID`). This property only affects
   AES-GCM cipher for now. AES-GCM associates a native object of type `EVP_CIPHER_CTX`

--- a/benchmarks/lib/build.gradle.kts
+++ b/benchmarks/lib/build.gradle.kts
@@ -57,7 +57,6 @@ jmh {
     resultFormat.set("JSON")
     duplicateClassesStrategy.set(DuplicatesStrategy.WARN)
     jvmArgs.add("-DversionStr=${accpVersion}")
-    jvmArgs.add("-Dcom.amazon.corretto.crypto.provider.registerSecureRandom=true")
     if (project.hasProperty("nativeContextReleaseStrategy")) {
         jvmArgs.add("-Dcom.amazon.corretto.crypto.provider.nativeContextReleaseStrategy=${nativeContextReleaseStrategy}")
     }

--- a/build.gradle
+++ b/build.gradle
@@ -16,9 +16,9 @@ group = 'software.amazon.cryptools'
 version = '2.4.0'
 ext.isFips = Boolean.getBoolean('FIPS')
 if (ext.isFips) {
-    ext.awsLcGitVersionId = 'AWS-LC-FIPS-2.0.2'
+    ext.awsLcGitVersionId = 'AWS-LC-FIPS-2.0.13'
 } else {
-    ext.awsLcGitVersionId = '32143aae568a64245f9eae54dcbc49043dbf41e4'
+    ext.awsLcGitVersionId = 'v1.30.1'
 }
 ext.isLegacyBuild = Boolean.getBoolean('LEGACY_BUILD')
 

--- a/csrc/ec_utils.cpp
+++ b/csrc/ec_utils.cpp
@@ -97,16 +97,6 @@ JNIEXPORT jint JNICALL Java_com_amazon_corretto_crypto_provider_EcUtils_curveNam
         BigNumObj orderBN;
 
         const EC_POINT* generator = NULL;
-        const EC_METHOD* method = NULL;
-        int fieldNid = 0;
-        int m = 0;
-
-        // Figure out which type of group this is
-        method = EC_GROUP_method_of(group);
-        if (!method) {
-            throw_openssl("Unable to acquire method");
-        }
-        fieldNid = EC_METHOD_get_field_type(method);
 
         if (EC_GROUP_get_cofactor(group, cfBN, NULL) != 1) {
             throw_openssl("Unable to get cofactor");
@@ -118,26 +108,11 @@ JNIEXPORT jint JNICALL Java_com_amazon_corretto_crypto_provider_EcUtils_curveNam
             throw_openssl("Unable to get generator");
         }
 
-        switch (fieldNid) {
-        case NID_X9_62_prime_field:
-            if (EC_GROUP_get_curve_GFp(group, pBN, aBN, bBN, NULL) != 1) {
-                throw_openssl("Unable to get group information");
-            }
-            if (EC_POINT_get_affine_coordinates_GFp(group, generator, gxBN, gyBN, NULL) != 1) {
-                throw_openssl("Unable to get generator coordinates");
-            }
-            break;
-        case NID_X9_62_characteristic_two_field:
-            if (EC_GROUP_get_curve_GFp(group, pBN, aBN, bBN, NULL) != 1) {
-                throw_openssl("Unable to get group information");
-            }
-            if (EC_POINT_get_affine_coordinates_GFp(group, generator, gxBN, gyBN, NULL) != 1) {
-                throw_openssl("Unable to get generator coordinates");
-            }
-            m = EC_GROUP_get_degree(group);
-            env->SetIntArrayRegion(mArr, 0, 1, &m);
-            env.rethrow_java_exception();
-            break;
+        if (EC_GROUP_get_curve_GFp(group, pBN, aBN, bBN, NULL) != 1) {
+            throw_openssl("Unable to get group information");
+        }
+        if (EC_POINT_get_affine_coordinates_GFp(group, generator, gxBN, gyBN, NULL) != 1) {
+            throw_openssl("Unable to get generator coordinates");
         }
 
         gxBN.toJavaArray(env, gxArr);

--- a/csrc/loader.cpp
+++ b/csrc/loader.cpp
@@ -32,9 +32,6 @@ void initialize()
     CRYPTO_library_init();
     ERR_load_crypto_strings();
     OpenSSL_add_all_digests();
-
-    // seed the PRNG
-    RAND_poll();
 }
 
 }

--- a/examples/gradle-kt-dsl/run-tests.sh
+++ b/examples/gradle-kt-dsl/run-tests.sh
@@ -7,7 +7,7 @@ DELAY_BETWEEN_RETRIES=10
 for i in $(seq 1 ${NUMBER_OF_RETRIES})
 do
     echo "Iteration ${i}"
-    ./gradlew lib:test && ./gradlew -Pfips -Dcom.amazon.corretto.crypto.provider.registerSecureRandom=true lib:test
+    ./gradlew lib:test && ./gradlew -Pfips lib:test
     result=$?
     if [[ $result -eq 0 ]]
     then

--- a/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
+++ b/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
@@ -451,13 +451,8 @@ public final class AmazonCorrettoCryptoProvider extends java.security.Provider {
         Utils.getBooleanProperty(PROPERTY_CACHE_SELF_TEST_RESULTS, true);
     this.shouldRegisterEcParams = Utils.getBooleanProperty(PROPERTY_REGISTER_EC_PARAMS, false);
 
-    // AWS-LC-FIPS's DRBG has per-thread initialization latency that can degrade performance in
-    // highly threaded
-    // applications. Until this is resolved, we only register an AWS-LC-backed SecureRandom
-    // implementation
-    // when we're not operating in FIPS mode.
     this.shouldRegisterSecureRandom =
-        Utils.getBooleanProperty(PROPERTY_REGISTER_SECURE_RANDOM, !isFips());
+        Utils.getBooleanProperty(PROPERTY_REGISTER_SECURE_RANDOM, true);
 
     this.nativeContextReleaseStrategy = Utils.getNativeContextReleaseStrategyProperty();
 

--- a/tst/com/amazon/corretto/crypto/provider/test/SecurityPropertyTester.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/SecurityPropertyTester.java
@@ -43,17 +43,9 @@ public final class SecurityPropertyTester {
     @SuppressWarnings("unused")
     KeyPairGenerator kpg = KeyPairGenerator.getInstance("EC", "SunEC");
 
-    // Ensure that FIPS mode determines default behavior for registering SecureRandom and "strong"
-    // random
-    // Applications should never use getInstanceStrong as it is an anti-pattern.
     final SecureRandom strongRng = SecureRandom.getInstanceStrong();
-    if (NATIVE_PROVIDER.isFips()) {
-      assertNotEquals(NATIVE_PROVIDER.getName(), new SecureRandom().getProvider().getName());
-      assertNotEquals(NATIVE_PROVIDER.getName(), strongRng.getProvider().getName());
-    } else {
-      assertEquals(NATIVE_PROVIDER.getName(), new SecureRandom().getProvider().getName());
-      assertEquals(NATIVE_PROVIDER.getName(), strongRng.getProvider().getName());
-    }
+    assertEquals(NATIVE_PROVIDER.getName(), new SecureRandom().getProvider().getName());
+    assertEquals(NATIVE_PROVIDER.getName(), strongRng.getProvider().getName());
 
     // Ensure that we can successfully generate an AES key, regardless of FIPS
     // mode or whether ACCP registers a SecureRandom implementation.


### PR DESCRIPTION
*Description of changes:*

+ Register ACCP's SecureRandom by default.
+ This change also updates the AWS-LC's commits are used with FIPS and none-FIPS builds.
  + As part of updating AWS-LC, EC_METHOD_get_field_type, and RAND_poll are removed since they always return constant values.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
