### PR TITLE
Undoing PR 376

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.4.1
+
+### Patch
+* [PR 388: Revert PR 376](https://github.com/corretto/amazon-corretto-crypto-provider/pull/388)
+
 ## 2.4.0
 
 ### Minor

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ plugins {
 }
 
 group = 'software.amazon.cryptools'
-version = '2.4.0'
+version = '2.4.1'
 ext.isFips = Boolean.getBoolean('FIPS')
 if (ext.isFips) {
     ext.awsLcGitVersionId = 'AWS-LC-FIPS-2.0.13'

--- a/examples/gradle-kt-dsl/lib/build.gradle.kts
+++ b/examples/gradle-kt-dsl/lib/build.gradle.kts
@@ -1,4 +1,4 @@
-val accpVersion = "2.4.0"
+val accpVersion = "2.4.1"
 val accpLocalJar: String by project
 val fips: Boolean by project
 val PLATFORMS_WITHOUT_FIPS_SUPPORT = setOf("osx-x86_64", "osx-aarch_64")

--- a/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
+++ b/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
@@ -145,23 +145,10 @@ public final class AmazonCorrettoCryptoProvider extends java.security.Provider {
               "DEFAULT")
           .setSelfTest(LibCryptoRng.SPI.SELF_TEST);
 
-      // Following lines are a workaround to ensure that the SecureRandom service
-      // is seen as ThreadSafe by SecureRandom, when using the alias name DEFAULT
-      // See https://bugs.openjdk.org/browse/JDK-8329754
-
-      // We add additional tests to confirm the DEFAULT algorithm is actually ThreadSafe
-      // This is to prevent issues in case a future code change set DEFAULT to a non-ThreadSafe
-      // algorithm
-
-      // Get the name of the algorithm pointed by the alias name DEFAULT
-      String algorithmUsedForDEFAULT = getProperty("Alg.Alias.SecureRandom.DEFAULT");
-      // If this alias exists and the algorithm pointed by it is thread safe, then mark DEFAULT
-      // ThreadSafe
-      if (algorithmUsedForDEFAULT != null
-          && "true"
-              .equals(getProperty("SecureRandom." + algorithmUsedForDEFAULT + " ThreadSafe"))) {
-        setProperty("SecureRandom.DEFAULT ThreadSafe", "true");
-      }
+      // If we `setProperty("SecureRandom.DEFAULT ThreadSafe", "true")`, then
+      // TestProviderInstallation::testProviderInstallation fails. The unique thing about this test
+      // is that it does `new SecureRandom` immediately after installing ACCP and expects to be
+      // backed by ACCP.
     }
 
     addSignatures();

--- a/tst/com/amazon/corretto/crypto/provider/test/TestProviderInstallation.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/TestProviderInstallation.java
@@ -15,6 +15,7 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.security.MessageDigest;
 import java.security.Provider;
+import java.security.SecureRandom;
 import java.security.Security;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
@@ -47,6 +48,8 @@ public class TestProviderInstallation {
             .equals(MessageDigest.getInstance("SHA-256").getProvider().getName()));
 
     AmazonCorrettoCryptoProvider.install();
+
+    assertEquals("AmazonCorrettoCryptoProvider", new SecureRandom().getProvider().getName());
 
     assertEquals(
         "AmazonCorrettoCryptoProvider",
@@ -99,8 +102,5 @@ public class TestProviderInstallation {
     assertEquals(
         "true",
         AmazonCorrettoCryptoProvider.INSTANCE.getProperty("SecureRandom.LibCryptoRng ThreadSafe"));
-    assertEquals(
-        "true",
-        AmazonCorrettoCryptoProvider.INSTANCE.getProperty("SecureRandom.DEFAULT ThreadSafe"));
   }
 }


### PR DESCRIPTION
*Description of changes:*

+ With PR 376, when ACCP is set as the first provider and immediately new SecureRandom is used, the SecureRandom will not be backed by ACCP.

+ A unit test is modified to check that `new SecureRandom` immediately after `install` is backed by ACCP.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
