### PR TITLE
Add AWS-LC src & ref flags to Gradle build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,8 +28,6 @@ else()
   set(Java_VERSION_MINOR ${JAVA_MINOR_VERSION})
 endif()
 
-set(JAVA_AWT_LIBRARY NotNeeded)
-set(JAVA_AWT_INCLUDE_PATH NotNeeded)
 find_package(JNI REQUIRED)
 include(FindOpenSSL)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,8 @@ else()
   set(Java_VERSION_MINOR ${JAVA_MINOR_VERSION})
 endif()
 
+set(JAVA_AWT_LIBRARY NotNeeded)
+set(JAVA_AWT_INCLUDE_PATH NotNeeded)
 find_package(JNI REQUIRED)
 include(FindOpenSSL)
 

--- a/build.gradle
+++ b/build.gradle
@@ -22,8 +22,8 @@ if (ext.isFips) {
 }
 
 // Check for user inputted git version ID.
-if (System.properties["AWSLC_REF"]) {
-    ext.awsLcGitVersionId = System.properties["AWSLC_REF"]
+if (System.env.AWSLC_GITVERSION) {
+    ext.awsLcGitVersionId = System.env.AWSLC_GITVERSION
 }
 
 ext.isLegacyBuild = Boolean.getBoolean('LEGACY_BUILD')
@@ -97,8 +97,8 @@ def getClangFormatVersion() {
 def awslcSrcPath = "${projectDir}/aws-lc/"
 
 // Check for user inputted AWS-LC source directory. 
-if (System.properties["AWSLC_SRC_DIR"]) {
-    awslcSrcPath = System.properties["AWSLC_SRC_DIR"]
+if (System.env.AWSLC_SRC_DIR) {
+    awslcSrcPath = System.env.AWSLC_SRC_DIR
 }
 
 // Execute cmake3 command to see if it exists. Mainly to support AL2.

--- a/build.gradle
+++ b/build.gradle
@@ -22,8 +22,8 @@ if (ext.isFips) {
 }
 
 // Check for user inputted git version ID.
-if (System.env.AWSLC_GITVERSION) {
-    ext.awsLcGitVersionId = System.env.AWSLC_GITVERSION
+if (System.properties["AWSLC_GITVERSION"]) {
+    ext.awsLcGitVersionId = System.properties["AWSLC_GITVERSION"]
 }
 
 ext.isLegacyBuild = Boolean.getBoolean('LEGACY_BUILD')
@@ -97,8 +97,8 @@ def getClangFormatVersion() {
 def awslcSrcPath = "${projectDir}/aws-lc/"
 
 // Check for user inputted AWS-LC source directory. 
-if (System.env.AWSLC_SRC_DIR) {
-    awslcSrcPath = System.env.AWSLC_SRC_DIR
+if (System.properties["AWSLC_SRC_DIR"]) {
+    awslcSrcPath = System.properties["AWSLC_SRC_DIR"]
 }
 
 // Execute cmake3 command to see if it exists. Mainly to support AL2.

--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,12 @@ if (ext.isFips) {
 } else {
     ext.awsLcGitVersionId = 'v1.30.1'
 }
+
+// Check for user inputted git version ID
+if (System.properties["AWSLC_REF"]) {
+    ext.awsLcGitVersionId = System.properties["AWSLC_REF"]
+}
+
 ext.isLegacyBuild = Boolean.getBoolean('LEGACY_BUILD')
 
 ext.lcovIgnore = System.properties['LCOV_IGNORE']
@@ -89,6 +95,10 @@ def getClangFormatVersion() {
 }
 
 def awslcSrcPath = "${projectDir}/aws-lc/"
+if (System.properties["AWSLC_SRC_DIR"]) {
+    awslcSrcPath = System.properties["AWSLC_SRC_DIR"]
+}
+
 
 // Execute cmake3 command to see if it exists. Mainly to support AL2.
 def detect_cmake3 = {

--- a/build.gradle
+++ b/build.gradle
@@ -185,7 +185,11 @@ task buildAwsLc {
 
     doFirst {
         if (file(awslcSrcPath).list().size() == 0) {
-            throw new GradleException("aws-lc dir empty! run 'git submodule update --init --recursive' to populate.")
+            if (System.properties["AWSLC_SRC_DIR"]) {
+                throw new GradleException("aws-lc dir empty! specify another directory or populate with aws-lc source files.")
+            } else {
+                throw new GradleException("aws-lc dir empty! run 'git submodule update --init --recursive' to populate.")
+            }
         }
 
         if (!isLegacyBuild) {

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,6 @@ if (System.properties["AWSLC_REF"]) {
 }
 
 ext.isLegacyBuild = Boolean.getBoolean('LEGACY_BUILD')
-ext.isCustomBuild = Boolean.getBoolean('CUSTOM_BUILD')
 
 ext.lcovIgnore = System.properties['LCOV_IGNORE']
 if (ext.lcovIgnore == null) {
@@ -189,7 +188,7 @@ task buildAwsLc {
         }
         
 
-        if (!isLegacyBuild && !isCustomBuild) {
+        if (!isLegacyBuild) {
             exec {
                 workingDir awslcSrcPath
                 commandLine "git", "fetch", "--tags"

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ if (System.properties["AWSLC_REF"]) {
 }
 
 ext.isLegacyBuild = Boolean.getBoolean('LEGACY_BUILD')
+ext.isCustomBuild = Boolean.getBoolean('CUSTOM_BUILD')
 
 ext.lcovIgnore = System.properties['LCOV_IGNORE']
 if (ext.lcovIgnore == null) {
@@ -186,8 +187,9 @@ task buildAwsLc {
         if (file(awslcSrcPath).list().size() == 0) {
             throw new GradleException("aws-lc dir empty! run 'git submodule update --init --recursive' to populate.")
         }
+        
 
-        if (!isLegacyBuild) {
+        if (!isLegacyBuild && !isCustomBuild) {
             exec {
                 workingDir awslcSrcPath
                 commandLine "git", "fetch", "--tags"

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ if (ext.isFips) {
     ext.awsLcGitVersionId = 'v1.30.1'
 }
 
-// Check for user inputted git version ID
+// Check for user inputted git version ID.
 if (System.properties["AWSLC_REF"]) {
     ext.awsLcGitVersionId = System.properties["AWSLC_REF"]
 }
@@ -95,10 +95,11 @@ def getClangFormatVersion() {
 }
 
 def awslcSrcPath = "${projectDir}/aws-lc/"
+
+// Check for user inputted AWS-LC source directory. 
 if (System.properties["AWSLC_SRC_DIR"]) {
     awslcSrcPath = System.properties["AWSLC_SRC_DIR"]
 }
-
 
 // Execute cmake3 command to see if it exists. Mainly to support AL2.
 def detect_cmake3 = {

--- a/build.gradle
+++ b/build.gradle
@@ -186,7 +186,6 @@ task buildAwsLc {
         if (file(awslcSrcPath).list().size() == 0) {
             throw new GradleException("aws-lc dir empty! run 'git submodule update --init --recursive' to populate.")
         }
-        
 
         if (!isLegacyBuild) {
             exec {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
In case a user needs to build ACCP with a specific version of AWS-LC, this change adds 2 flags that can be passed to Gradle to specify a source directory for AWS-LC or a specific Git reference. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
