### PR TITLE
Use `LibCryptoRng` instead of `DEFAULT` in Random benchmark

### DIFF
--- a/benchmarks/lib/src/jmh/java/com/amazon/corretto/crypto/provider/benchmarks/Random.java
+++ b/benchmarks/lib/src/jmh/java/com/amazon/corretto/crypto/provider/benchmarks/Random.java
@@ -53,7 +53,7 @@ public class Random {
     // !!! WARNING: java.util.random is not a secure randomness generator
     // !!! WARNING: we add it here just for comparison
     @Param({
-      AmazonCorrettoCryptoProvider.PROVIDER_NAME + "/DEFAULT",
+      AmazonCorrettoCryptoProvider.PROVIDER_NAME + "/LibCryptoRng",
       "BC/DEFAULT",
       "SUN/NativePrng",
       "SUN/DRBG",


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Following reversal of PR #376 in PR #388, using the ACCP SecureRandom algorithm `DEFAULT` (which is an alias of `LibCryptoRng`) yields lower performance in multi-threaded settings.
See #376 for details.

This PR is meant to use the algorithm `LibCryptoRng` in the benchmark, instead of its alias `DEFAULT`. This solves the performance drop in multi-threaded settings.

This also corresponds to the most common use of ACCP SecureRandom. Indeed, if ACCP is the first security provider and if ACCP SecureRandom
 is registered, then when instantiating SecureRandom as
 `new SecureRandom()`, the algorithm `LibCryptoRng` will be selected.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
