### PR TITLE
Apply the rule of 3/5/0 to JByteArrayCritical et al.

### DIFF
--- a/csrc/buffer.h
+++ b/csrc/buffer.h
@@ -599,9 +599,11 @@ public:
     unsigned char* get();
 
 #ifdef HAVE_CPP11
-    // deleting copy constructor and copy assignment to satisfy rule of three
+    // deleting copy & move operations to satisfy rule of five
     JByteArrayCritical(const JByteArrayCritical&) = delete;
     JByteArrayCritical& operator=(const JByteArrayCritical&) = delete;
+    JByteArrayCritical(JByteArrayCritical&&) = delete;
+    JByteArrayCritical& operator=(JByteArrayCritical&&) = delete;
 #endif
 
 private:
@@ -617,9 +619,11 @@ public:
     uint8_t* get_buffer();
 
 #ifdef HAVE_CPP11
-    // deleting copy constructor and copy assignment to satisfy rule of three
+    // deleting copy & move operations to satisfy rule of five
     SimpleBuffer(const SimpleBuffer&) = delete;
     SimpleBuffer& operator=(const SimpleBuffer&) = delete;
+    SimpleBuffer(SimpleBuffer&&) = delete;
+    SimpleBuffer& operator=(SimpleBuffer&&) = delete;
 #endif
 
 private:
@@ -636,9 +640,11 @@ public:
     uint8_t* get();
 
 #ifdef HAVE_CPP11
-    // deleting copy constructor and copy assignment to satisfy rule of three
+    // deleting copy & move operations to satisfy rule of five
     JBinaryBlob(const JBinaryBlob&) = delete;
     JBinaryBlob& operator=(const JBinaryBlob&) = delete;
+    JBinaryBlob(JBinaryBlob&&) = delete;
+    JBinaryBlob& operator=(JBinaryBlob&&) = delete;
 #endif
 
 private:
@@ -668,9 +674,11 @@ public:
     uint8_t* get_output();
 
 #ifdef HAVE_CPP11
-    // deleting copy constructor and copy assignment to satisfy rule of three
+    // deleting copy & move operations to satisfy rule of five
     JIOBlobs(const JIOBlobs&) = delete;
     JIOBlobs& operator=(const JIOBlobs&) = delete;
+    JIOBlobs(JIOBlobs&&) = delete;
+    JIOBlobs& operator=(JIOBlobs&&) = delete;
 #endif
 
 private:

--- a/csrc/buffer.h
+++ b/csrc/buffer.h
@@ -598,6 +598,12 @@ public:
     ~JByteArrayCritical();
     unsigned char* get();
 
+#ifdef HAVE_CPP11
+    // deleting copy constructor and copy assignment to satisfy rule of three
+    JByteArrayCritical(const JByteArrayCritical&) = delete;
+    JByteArrayCritical& operator=(const JByteArrayCritical&) = delete;
+#endif
+
 private:
     void* ptr_;
     JNIEnv* env_;
@@ -609,6 +615,12 @@ public:
     SimpleBuffer(int len);
     ~SimpleBuffer();
     uint8_t* get_buffer();
+
+#ifdef HAVE_CPP11
+    // deleting copy constructor and copy assignment to satisfy rule of three
+    SimpleBuffer(const SimpleBuffer&) = delete;
+    SimpleBuffer& operator=(const SimpleBuffer&) = delete;
+#endif
 
 private:
     uint8_t* buffer_;
@@ -622,6 +634,12 @@ public:
     JBinaryBlob(JNIEnv* env, jobject directByteBuffer, jbyteArray array);
     ~JBinaryBlob();
     uint8_t* get();
+
+#ifdef HAVE_CPP11
+    // deleting copy constructor and copy assignment to satisfy rule of three
+    JBinaryBlob(const JBinaryBlob&) = delete;
+    JBinaryBlob& operator=(const JBinaryBlob&) = delete;
+#endif
 
 private:
     // The native pointer that is either backed by a direct ByteBuffer or a byte array.
@@ -648,6 +666,12 @@ public:
     ~JIOBlobs();
     uint8_t* get_input();
     uint8_t* get_output();
+
+#ifdef HAVE_CPP11
+    // deleting copy constructor and copy assignment to satisfy rule of three
+    JIOBlobs(const JIOBlobs&) = delete;
+    JIOBlobs& operator=(const JIOBlobs&) = delete;
+#endif
 
 private:
     // The native pointers that are either backed by a direct ByteBuffer or a byte array.


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Apply the [rule of 3/5/0](https://en.cppreference.com/w/cpp/language/rule_of_three) to `JByteArrayCritical`, `SimpleBuffer`, `JBinaryBlob`, `JIOBlobs`. This ensures that these objects cannot be copied.

Before, if they were copied (e.g., due to being passed as argument to a function), the destructor would be called twice, which would release the critical region twice or which may release the critical region while another part of the code is still using it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
