### PR TITLE
[PQ] Add experimental support for HPKE

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "aws-lc"]
 	path = aws-lc
-	url = https://github.com/sgmenda-aws/aws-lc
-	branch = experimental-pq-hybrid-with-hpke
+	url = https://github.com/aws/aws-lc
+	branch = experimental-pq-hybrid

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "aws-lc"]
 	path = aws-lc
-	url = https://github.com/awslabs/aws-lc
+	url = https://github.com/sgmenda-aws/aws-lc
+	branch = experimental-pq-hybrid-with-hpke

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -261,6 +261,8 @@ add_library(
         csrc/env.cpp
         csrc/hkdf.cpp
         csrc/hmac.cpp
+        csrc/hpke_cipher.cpp
+        csrc/hpke_gen.cpp
         csrc/keyutils.cpp
         csrc/java_evp_keys.cpp
         csrc/libcrypto_rng.cpp

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # EXPERIMENTAL BRANCH
 
-This branch includes an experimental implementation of KEMs and HPKE.
+This branch includes an experimental implementation of HPKE.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Cipher algorithms:
 * RSA/ECB/OAEPPadding
 * RSA/ECB/OAEPWithSHA-1AndMGF1Padding
 * RSA/ECB/OAEPWithSHA1AndMGF1Padding
+* HPKE
 
 Signature algorithms:
 * SHA1withRSA
@@ -74,6 +75,7 @@ Signature algorithms:
 KeyPairGenerator:
 * EC
 * RSA
+* HPKE
 
 KeyGenerator:
 * AES

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+# EXPERIMENTAL BRANCH
+
+This branch includes an experimental implementation of KEMs and HPKE.
+
+---
+
 # Amazon Corretto Crypto Provider
 The Amazon Corretto Crypto Provider (ACCP) is a collection of high-performance cryptographic implementations exposed via the standard [JCA/JCE](https://docs.oracle.com/en/java/javase/11/security/java-cryptography-architecture-jca-reference-guide.html) interfaces.
 This means that it can be used as a drop in replacement for many different Java applications.

--- a/build.gradle
+++ b/build.gradle
@@ -194,31 +194,11 @@ task buildAwsLc {
         }
 
         if (!isLegacyBuild) {
-            // FIXME: Change to tag once stabilized.
-//            exec {
-//                workingDir projectDir
-//                commandLine "git", "submodule", "sync", "--recursive"
-//            }
-//            exec {
-//                workingDir projectDir
-//                commandLine "git", "submodule", "foreach", "'git fetch --all'"
-//            }
-//            exec {
-//                workingDir projectDir
-//                commandLine "git", "submodule", "update", "--init", "--recursive", "--remote"
-//            }
-//            exec {
-//                workingDir awslcSrcPath
-//                commandLine "git", "fetch", "--all"
-//            }
-//            exec {
-//                workingDir awslcSrcPath
-//                commandLine "git", "checkout", awsLcGitVersionId
-//            }
-//            exec {
-//                workingDir awslcSrcPath
-//                commandLine "git", "pull"
-//            }
+            // FIXME: Commented because it was breaking Github CI
+            // exec {
+            //     workingDir awslcSrcPath
+            //     commandLine "git", "checkout", awsLcGitVersionId
+            // }
         }
         mkdir "${buildDir}/awslc"
         mkdir sharedObjectOutDir

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,8 @@ group = 'software.amazon.cryptools'
 version = '2.4.1'
 ext.isFips = Boolean.getBoolean('FIPS')
 if (ext.isFips) {
-    ext.awsLcGitVersionId = 'AWS-LC-FIPS-2.0.13'
+    // TODO: replace with tags once stable
+    ext.awsLcGitVersionId = '72c276e9c709a2d9b94e41b06da6abf2b3805a4a'
 } else {
     ext.awsLcGitVersionId = '72c276e9c709a2d9b94e41b06da6abf2b3805a4a'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,8 @@ ext.isFips = Boolean.getBoolean('FIPS')
 if (ext.isFips) {
     ext.awsLcGitVersionId = 'AWS-LC-FIPS-2.0.13'
 } else {
-    ext.awsLcGitVersionId = 'v1.30.1'
+    // FIXME: Change to tag once stabilized.
+    ext.awsLcGitVersionId = 'experimental-pq-hybrid-with-hpke'
 }
 
 // Check for user inputted git version ID.
@@ -195,7 +196,7 @@ task buildAwsLc {
         if (!isLegacyBuild) {
             exec {
                 workingDir awslcSrcPath
-                commandLine "git", "fetch", "--tags"
+                commandLine "git", "fetch", "--all"
             }
             exec {
                 workingDir awslcSrcPath

--- a/build.gradle
+++ b/build.gradle
@@ -201,6 +201,10 @@ task buildAwsLc {
             }
             exec {
                 workingDir projectDir
+                commandLine "git", "submodule", "foreach", "'git fetch --all'"
+            }
+            exec {
+                workingDir projectDir
                 commandLine "git", "submodule", "update", "--init", "--recursive", "--remote"
             }
             exec {

--- a/build.gradle
+++ b/build.gradle
@@ -196,6 +196,10 @@ task buildAwsLc {
         if (!isLegacyBuild) {
             // FIXME: Change to tag once stabilized.
             exec {
+                workingDir projectDir
+                commandLine "git", "submodule", "sync"
+            }
+            exec {
                 workingDir awslcSrcPath
                 commandLine "git", "fetch", "--all"
             }

--- a/build.gradle
+++ b/build.gradle
@@ -194,6 +194,7 @@ task buildAwsLc {
         }
 
         if (!isLegacyBuild) {
+            // FIXME: Change to tag once stabilized.
             exec {
                 workingDir awslcSrcPath
                 commandLine "git", "fetch", "--all"
@@ -201,6 +202,10 @@ task buildAwsLc {
             exec {
                 workingDir awslcSrcPath
                 commandLine "git", "checkout", awsLcGitVersionId
+            }
+            exec {
+                workingDir awslcSrcPath
+                commandLine "git", "pull"
             }
         }
         mkdir "${buildDir}/awslc"

--- a/build.gradle
+++ b/build.gradle
@@ -200,6 +200,10 @@ task buildAwsLc {
                 commandLine "git", "submodule", "sync"
             }
             exec {
+                workingDir projectDir
+                commandLine "git", "submodule", "update", "--init", "--remote"
+            }
+            exec {
                 workingDir awslcSrcPath
                 commandLine "git", "fetch", "--all"
             }

--- a/build.gradle
+++ b/build.gradle
@@ -12,15 +12,13 @@ plugins {
     id "io.github.gradle-nexus.publish-plugin" version "1.1.0"
 }
 
-ext.experimentalPqHybrid = true
-
 group = 'software.amazon.cryptools'
 version = '2.4.1'
 ext.isFips = Boolean.getBoolean('FIPS')
 if (ext.isFips) {
     ext.awsLcGitVersionId = 'AWS-LC-FIPS-2.0.13'
 } else {
-    ext.awsLcGitVersionId = 'v1.30.1'
+    ext.awsLcGitVersionId = '72c276e9c709a2d9b94e41b06da6abf2b3805a4a'
 }
 
 // Check for user inputted git version ID.
@@ -194,7 +192,7 @@ task buildAwsLc {
             }
         }
 
-        if (!isLegacyBuild && !experimentalPqHybrid) {
+        if (!isLegacyBuild) {
             exec {
                 workingDir awslcSrcPath
                 commandLine "git", "fetch", "--tags"

--- a/build.gradle
+++ b/build.gradle
@@ -195,30 +195,30 @@ task buildAwsLc {
 
         if (!isLegacyBuild) {
             // FIXME: Change to tag once stabilized.
-            exec {
-                workingDir projectDir
-                commandLine "git", "submodule", "sync", "--recursive"
-            }
-            exec {
-                workingDir projectDir
-                commandLine "git", "submodule", "foreach", "'git fetch --all'"
-            }
-            exec {
-                workingDir projectDir
-                commandLine "git", "submodule", "update", "--init", "--recursive", "--remote"
-            }
-            exec {
-                workingDir awslcSrcPath
-                commandLine "git", "fetch", "--all"
-            }
-            exec {
-                workingDir awslcSrcPath
-                commandLine "git", "checkout", awsLcGitVersionId
-            }
-            exec {
-                workingDir awslcSrcPath
-                commandLine "git", "pull"
-            }
+//            exec {
+//                workingDir projectDir
+//                commandLine "git", "submodule", "sync", "--recursive"
+//            }
+//            exec {
+//                workingDir projectDir
+//                commandLine "git", "submodule", "foreach", "'git fetch --all'"
+//            }
+//            exec {
+//                workingDir projectDir
+//                commandLine "git", "submodule", "update", "--init", "--recursive", "--remote"
+//            }
+//            exec {
+//                workingDir awslcSrcPath
+//                commandLine "git", "fetch", "--all"
+//            }
+//            exec {
+//                workingDir awslcSrcPath
+//                commandLine "git", "checkout", awsLcGitVersionId
+//            }
+//            exec {
+//                workingDir awslcSrcPath
+//                commandLine "git", "pull"
+//            }
         }
         mkdir "${buildDir}/awslc"
         mkdir sharedObjectOutDir

--- a/build.gradle
+++ b/build.gradle
@@ -12,14 +12,15 @@ plugins {
     id "io.github.gradle-nexus.publish-plugin" version "1.1.0"
 }
 
+ext.experimentalPqHybrid = true
+
 group = 'software.amazon.cryptools'
 version = '2.4.1'
 ext.isFips = Boolean.getBoolean('FIPS')
 if (ext.isFips) {
     ext.awsLcGitVersionId = 'AWS-LC-FIPS-2.0.13'
 } else {
-    // FIXME: Change to tag once stabilized.
-    ext.awsLcGitVersionId = 'experimental-pq-hybrid-with-hpke'
+    ext.awsLcGitVersionId = 'v1.30.1'
 }
 
 // Check for user inputted git version ID.
@@ -193,12 +194,15 @@ task buildAwsLc {
             }
         }
 
-        if (!isLegacyBuild) {
-            // FIXME: Commented because it was breaking Github CI
-            // exec {
-            //     workingDir awslcSrcPath
-            //     commandLine "git", "checkout", awsLcGitVersionId
-            // }
+        if (!isLegacyBuild && !experimentalPqHybrid) {
+            exec {
+                workingDir awslcSrcPath
+                commandLine "git", "fetch", "--tags"
+            }
+            exec {
+                workingDir awslcSrcPath
+                commandLine "git", "checkout", awsLcGitVersionId
+            }
         }
         mkdir "${buildDir}/awslc"
         mkdir sharedObjectOutDir

--- a/build.gradle
+++ b/build.gradle
@@ -197,11 +197,11 @@ task buildAwsLc {
             // FIXME: Change to tag once stabilized.
             exec {
                 workingDir projectDir
-                commandLine "git", "submodule", "sync"
+                commandLine "git", "submodule", "sync", "--recursive"
             }
             exec {
                 workingDir projectDir
-                commandLine "git", "submodule", "update", "--init", "--remote"
+                commandLine "git", "submodule", "update", "--init", "--recursive", "--remote"
             }
             exec {
                 workingDir awslcSrcPath

--- a/csrc/auto_free.h
+++ b/csrc/auto_free.h
@@ -6,6 +6,7 @@
 #include "env.h"
 #include <openssl/ec.h>
 #include <openssl/evp.h>
+#include <openssl/hpke.h>
 #include <openssl/mem.h>
 #include <openssl/rsa.h>
 #include <openssl/x509.h>
@@ -103,6 +104,7 @@ OPENSSL_auto(BN_CTX);
 OPENSSL_auto(EVP_MD_CTX);
 OPENSSL_auto(EVP_PKEY);
 OPENSSL_auto(EVP_PKEY_CTX);
+OPENSSL_auto(EVP_HPKE_KEY);
 
 class OPENSSL_buffer_auto {
 private:

--- a/csrc/buffer.h
+++ b/csrc/buffer.h
@@ -402,7 +402,6 @@ public:
     }
 
     size_t len() const { return m_length; }
-    size_t size() const { return len(); }
 
     void zeroize() { OPENSSL_cleanse(data(), len()); }
 };

--- a/csrc/buffer.h
+++ b/csrc/buffer.h
@@ -402,6 +402,7 @@ public:
     }
 
     size_t len() const { return m_length; }
+    size_t size() const { return len(); }
 
     void zeroize() { OPENSSL_cleanse(data(), len()); }
 };

--- a/csrc/hpke_cipher.cpp
+++ b/csrc/hpke_cipher.cpp
@@ -1,0 +1,13 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+#include "auto_free.h"
+#include "bn.h"
+#include "buffer.h"
+#include "env.h"
+#include "generated-headers.h"
+#include "keyutils.h"
+#include "util.h"
+#include <openssl/evp.h>
+#include <openssl/nid.h>
+
+using namespace AmazonCorrettoCryptoProvider;

--- a/csrc/hpke_cipher.cpp
+++ b/csrc/hpke_cipher.cpp
@@ -80,8 +80,8 @@ JNIEXPORT jint JNICALL Java_com_amazon_corretto_crypto_provider_HpkeCipher_hpkeC
                 jni_borrow enc(env, encBuf, "output enc");
                 jni_borrow ct(env, ctBuf, "output ciphertext");
 
-                CHECK_OPENSSL(EVP_HPKE_seal(enc.data(), &enc_len, enc.size(), ct.data(), &ct_len, ct.size(), kem, kdf,
-                    aead, public_key_r.data(), public_key_r_len, info.data(), info.size(), msg.data(), msg.size(),
+                CHECK_OPENSSL(EVP_HPKE_seal(enc.data(), &enc_len, enc.len(), ct.data(), &ct_len, ct.len(), kem, kdf,
+                    aead, public_key_r.data(), public_key_r_len, info.data(), info.size(), msg.data(), msg.len(),
                     ad.data(), ad.size()));
                 if (enc_len != encBufLen) {
                     throw_java_ex(EX_RUNTIME_CRYPTO, "Unexpected error, enc buffer length is wrong!");
@@ -109,8 +109,8 @@ JNIEXPORT jint JNICALL Java_com_amazon_corretto_crypto_provider_HpkeCipher_hpkeC
                 jni_borrow enc(env, encBuf, "input enc");
                 jni_borrow ct(env, ctBuf, "input ciphertext");
 
-                CHECK_OPENSSL(EVP_HPKE_open(msg.data(), &msg_len, msg.size(), key, kdf, aead, enc.data(), enc.size(),
-                    info.data(), info.size(), ct.data(), ct.size(), ad.data(), ad.size()))
+                CHECK_OPENSSL(EVP_HPKE_open(msg.data(), &msg_len, msg.len(), key, kdf, aead, enc.data(), enc.len(),
+                    info.data(), info.size(), ct.data(), ct.len(), ad.data(), ad.size()))
                 result = msg_len;
             }
         } else {

--- a/csrc/hpke_cipher.cpp
+++ b/csrc/hpke_cipher.cpp
@@ -8,6 +8,151 @@
 #include "keyutils.h"
 #include "util.h"
 #include <openssl/evp.h>
+#include <openssl/hpke.h>
 #include <openssl/nid.h>
 
 using namespace AmazonCorrettoCryptoProvider;
+
+/*
+ * Class:     com_amazon_corretto_crypto_provider_HpkeCipher
+ * Method:    hpkeWrap
+ * Signature: (J[BIIII[BI)I
+ */
+JNIEXPORT jint JNICALL Java_com_amazon_corretto_crypto_provider_HpkeCipher_hpkeCipher(JNIEnv* pEnv,
+    jclass,
+    jlong keyHandle,
+    jint javaCipherMode,
+    jint kemId,
+    jint kdfId,
+    jint aeadId,
+    jbyteArray input,
+    jint inputOffset,
+    jint inputLen,
+    jbyteArray output,
+    jint outputOffset)
+{
+    try {
+        raii_env env(pEnv);
+
+        if (!input) {
+            throw_java_ex(EX_NPE, "Empty input array");
+        }
+        if (!output) {
+            throw_java_ex(EX_NPE, "Empty output array");
+        }
+
+        const EVP_HPKE_KEY* key = reinterpret_cast<EVP_HPKE_KEY*>(keyHandle);
+        const auto kem = EVP_HPKE_KEM_find_by_id(kemId);
+        const auto kdf = EVP_HPKE_KDF_find_by_id(kdfId);
+        const auto aead = EVP_HPKE_AEAD_find_by_id(aeadId);
+        const auto aead_overhead = EVP_AEAD_max_overhead(EVP_HPKE_AEAD_aead(aead));
+
+        if (kemId != EVP_HPKE_KEM_id(EVP_HPKE_KEY_kem(key))) {
+            throw_java_ex(EX_RUNTIME_CRYPTO, "KEM in the key does not match the param");
+        }
+
+        // FIXME: support setting these values
+        std::vector<uint8_t> info(0);
+        std::vector<uint8_t> ad(0);
+
+        size_t result = -1;
+
+        if (javaCipherMode == 3 /* Wrap */) {
+            // Serialize public key
+            std::vector<uint8_t> public_key_r(EVP_HPKE_KEM_public_key_len(kem));
+            size_t public_key_r_len;
+            CHECK_OPENSSL(EVP_HPKE_KEY_public_key(key, public_key_r.data(), &public_key_r_len, public_key_r.size()));
+
+            // The input is the plaintext message
+            java_buffer msgBuf = java_buffer::from_array(env, input, inputOffset, inputLen);
+
+            // We write the enc and the ciphertext to the output buffer
+            const auto encBufLen = EVP_HPKE_KEM_enc_len(kem);
+            const auto ctBufLen = inputLen + aead_overhead;
+            const auto outBufLen = encBufLen + ctBufLen;
+            java_buffer encBuf = java_buffer::from_array(env, output, outputOffset, encBufLen);
+            java_buffer ctBuf = java_buffer::from_array(env, output, outputOffset + encBufLen, ctBufLen);
+            size_t enc_len = 0;
+            size_t ct_len = 0;
+
+            {
+                jni_borrow msg(env, msgBuf, "input msg");
+                jni_borrow enc(env, encBuf, "output enc");
+                jni_borrow ct(env, ctBuf, "output ciphertext");
+
+                CHECK_OPENSSL(EVP_HPKE_seal(enc.data(), &enc_len, enc.size(), ct.data(), &ct_len, ct.size(), kem, kdf,
+                    aead, public_key_r.data(), public_key_r_len, info.data(), info.size(), msg.data(), msg.size(),
+                    ad.data(), ad.size()));
+                if (enc_len != encBufLen) {
+                    throw_java_ex(EX_RUNTIME_CRYPTO, "Unexpected error, enc buffer length is wrong!");
+                }
+                if (ct_len != ctBufLen) {
+                    throw_java_ex(EX_RUNTIME_CRYPTO, "Unexpected error, ciphertext buffer length is wrong!");
+                }
+                result = outBufLen;
+            }
+        } else if (javaCipherMode == 4 /* Unwrap */) {
+            // The input the enc and the ciphertext
+            const auto encBufLen = EVP_HPKE_KEM_enc_len(kem);
+            if (inputLen < (encBufLen + aead_overhead)) {
+                throw_java_ex(EX_RUNTIME_CRYPTO, "input too short to unwrap with HPKE");
+            }
+            const auto ctBufLen = inputLen - encBufLen;
+            java_buffer encBuf = java_buffer::from_array(env, input, inputOffset, encBufLen);
+            java_buffer ctBuf = java_buffer::from_array(env, input, inputOffset + encBufLen, ctBufLen);
+
+            // We write the plaintext message to the output buffer
+            java_buffer msgBuf = java_buffer::from_array(env, output, outputOffset);
+            size_t msg_len = 0;
+            {
+                jni_borrow msg(env, msgBuf, "output msg");
+                jni_borrow enc(env, encBuf, "input enc");
+                jni_borrow ct(env, ctBuf, "input ciphertext");
+
+                CHECK_OPENSSL(EVP_HPKE_open(msg.data(), &msg_len, msg.size(), key, kdf, aead, enc.data(), enc.size(),
+                    info.data(), info.size(), ct.data(), ct.size(), ad.data(), ad.size()))
+                result = msg_len;
+            }
+        } else {
+            throw_java_ex(EX_RUNTIME_CRYPTO, "Unsupported cipher mode");
+        }
+        return (jint)result;
+    } catch (java_ex& ex) {
+        ex.throw_to_java(pEnv);
+        return -1;
+    }
+}
+
+/*
+ * Class:     com_amazon_corretto_crypto_provider_HpkeCipher
+ * Method:    hpkeOutputSize
+ * Signature: (IIIII)I
+ */
+JNIEXPORT jint JNICALL Java_com_amazon_corretto_crypto_provider_HpkeCipher_hpkeOutputSize(
+    JNIEnv* pEnv, jclass, jint javaCipherMode, jint kemId, jint kdfId, jint aeadId, jint inputLen)
+{
+    const auto kem = EVP_HPKE_KEM_find_by_id(kemId);
+    const auto aead = EVP_HPKE_AEAD_find_by_id(aeadId);
+    const auto aead_overhead = EVP_AEAD_max_overhead(EVP_HPKE_AEAD_aead(aead));
+    const auto enc_len = EVP_HPKE_KEM_enc_len(kem);
+
+    try {
+        raii_env env(pEnv);
+
+        if (javaCipherMode == 3 /* Wrap */) {
+            // We write the enc and the ciphertext to the output buffer
+            return (inputLen + enc_len + aead_overhead);
+        } else if (javaCipherMode == 4 /* Unwrap */) {
+            // We write the plaintext to the output buffer
+            if (inputLen < (enc_len + aead_overhead)) {
+                throw_java_ex(EX_RUNTIME_CRYPTO, "input too short to unwrap with HPKE");
+            }
+            return (inputLen - enc_len - aead_overhead);
+        } else {
+            throw_java_ex(EX_RUNTIME_CRYPTO, "Unsupported cipher mode");
+        }
+    } catch (java_ex& ex) {
+        ex.throw_to_java(pEnv);
+        return -1;
+    }
+}

--- a/csrc/hpke_cipher.cpp
+++ b/csrc/hpke_cipher.cpp
@@ -151,18 +151,21 @@ JNIEXPORT jint JNICALL Java_com_amazon_corretto_crypto_provider_HpkeCipher_hpkeO
         }
         const size_t input_length = (size_t)inputLen;
 
+        size_t ret = -1;
+
         if ((javaCipherMode == 1 /* Encrypt */) || (javaCipherMode == 3 /* Wrap */)) {
             // We write the enc and the ciphertext to the output buffer
-            return (input_length + enc_len + aead_overhead);
+            ret = input_length + enc_len + aead_overhead;
         } else if ((javaCipherMode == 2 /* Decrypt */) || (javaCipherMode == 4 /* Unwrap */)) {
             // We write the plaintext to the output buffer
             if (input_length < (enc_len + aead_overhead)) {
                 throw_java_ex(EX_RUNTIME_CRYPTO, "input too short to unwrap with HPKE");
             }
-            return (input_length - enc_len - aead_overhead);
+            ret = (input_length - enc_len - aead_overhead);
         } else {
             throw_java_ex(EX_RUNTIME_CRYPTO, "Unsupported cipher mode");
         }
+        return (jint)ret;
     } catch (java_ex& ex) {
         ex.throw_to_java(pEnv);
         return -1;

--- a/csrc/hpke_gen.cpp
+++ b/csrc/hpke_gen.cpp
@@ -8,6 +8,7 @@
 #include "keyutils.h"
 #include "util.h"
 #include <openssl/evp.h>
+#include <openssl/hpke.h>
 #include <openssl/nid.h>
 
 using namespace AmazonCorrettoCryptoProvider;
@@ -24,7 +25,7 @@ JNIEXPORT jlong JNICALL Java_com_amazon_corretto_crypto_provider_HpkeGen_generat
     try {
         raii_env env(pEnv);
         key.set(EVP_HPKE_KEY_new());
-        const EVP_HPKE_KEM* kem = EVP_HPKE_KEM_find_kem_by_id(hpke_kem_id);
+        const EVP_HPKE_KEM* kem = EVP_HPKE_KEM_find_by_id(hpke_kem_id);
         CHECK_OPENSSL(EVP_HPKE_KEY_generate(key, kem));
         return reinterpret_cast<jlong>(key.take());
     } catch (java_ex& ex) {

--- a/csrc/hpke_gen.cpp
+++ b/csrc/hpke_gen.cpp
@@ -26,6 +26,7 @@ JNIEXPORT jlong JNICALL Java_com_amazon_corretto_crypto_provider_HpkeGen_generat
         raii_env env(pEnv);
         key.set(EVP_HPKE_KEY_new());
         const EVP_HPKE_KEM* kem = EVP_HPKE_KEM_find_by_id(hpke_kem_id);
+        CHECK_OPENSSL(kem != NULL);
         CHECK_OPENSSL(EVP_HPKE_KEY_generate(key, kem));
         return reinterpret_cast<jlong>(key.take());
     } catch (java_ex& ex) {

--- a/csrc/hpke_gen.cpp
+++ b/csrc/hpke_gen.cpp
@@ -1,0 +1,34 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+#include "auto_free.h"
+#include "bn.h"
+#include "buffer.h"
+#include "env.h"
+#include "generated-headers.h"
+#include "keyutils.h"
+#include "util.h"
+#include <openssl/evp.h>
+#include <openssl/nid.h>
+
+using namespace AmazonCorrettoCryptoProvider;
+
+/*
+ * Class:     com_amazon_corretto_crypto_provider_HpkeGen
+ * Method:    generateEvpHpkeKemKeyFromSpec
+ * Signature: (I)J
+ */
+JNIEXPORT jlong JNICALL Java_com_amazon_corretto_crypto_provider_HpkeGen_generateEvpHpkeKemKeyFromSpec(
+    JNIEnv* pEnv, jclass, jint hpke_kem_id)
+{
+    EVP_HPKE_KEY_auto key;
+    try {
+        raii_env env(pEnv);
+        key.set(EVP_HPKE_KEY_new());
+        const EVP_HPKE_KEM* kem = EVP_HPKE_KEM_find_kem_by_id(hpke_kem_id);
+        CHECK_OPENSSL(EVP_HPKE_KEY_generate(key, kem));
+        return reinterpret_cast<jlong>(key.take());
+    } catch (java_ex& ex) {
+        ex.throw_to_java(pEnv);
+        return 0;
+    }
+}

--- a/csrc/keyutils.cpp
+++ b/csrc/keyutils.cpp
@@ -170,25 +170,6 @@ const EVP_MD* digestFromJstring(raii_env& env, jstring digestName)
 
 RSA* new_private_RSA_key_with_no_e(BIGNUM const* n, BIGNUM const* d)
 {
-#ifdef FIPS_BUILD
-    // AWS-LC-FIPS doesn't have RSA_new_private_key_no_e method yet.
-    // The following implementation has been copied from AWS-LC:
-    // https://github.com/aws/aws-lc/blob/v1.30.1/crypto/fipsmodule/rsa/rsa.c#L147
-    RSA_auto rsa = RSA_auto::from(RSA_new());
-    if (rsa.get() == nullptr) {
-        throw_openssl("RSA_new failed");
-    }
-
-    // RSA struct is not opaque in FIPS mode.
-    rsa->flags |= RSA_FLAG_NO_BLINDING;
-
-    bn_dup_into(&rsa->n, n);
-    bn_dup_into(&rsa->d, d);
-
-    return rsa.take();
-
-#else
-
     RSA* result = RSA_new_private_key_no_e(n, d);
 
     if (result == nullptr) {
@@ -196,8 +177,6 @@ RSA* new_private_RSA_key_with_no_e(BIGNUM const* n, BIGNUM const* d)
     }
 
     return result;
-
-#endif
 }
 
 }

--- a/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
+++ b/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
@@ -156,7 +156,6 @@ public final class AmazonCorrettoCryptoProvider extends java.security.Provider {
   }
 
   private void addHPKE() {
-    // Support EVP_HPKE as a Cipher
     addService("KeyPairGenerator", "HPKE", "HpkeGen");
     addService("Cipher", "HPKE", "HpkeCipher");
   }

--- a/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
+++ b/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
@@ -158,8 +158,7 @@ public final class AmazonCorrettoCryptoProvider extends java.security.Provider {
   private void addHPKE() {
     // Support EVP_HPKE as a Cipher
     addService("KeyPairGenerator", "HPKE", "HpkeGen");
-    // FIXME(sanketh): add cipher implementation
-    // addService("Cipher", "HPKE", "HpkeCipher");
+    addService("Cipher", "HPKE", "HpkeCipher");
   }
 
   private void addSignatures() {

--- a/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
+++ b/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
@@ -152,6 +152,14 @@ public final class AmazonCorrettoCryptoProvider extends java.security.Provider {
     }
 
     addSignatures();
+    addHPKE();
+  }
+
+  private void addHPKE() {
+    // Support EVP_HPKE as a Cipher
+    addService("KeyPairGenerator", "HPKE", "HpkeGen");
+    // FIXME(sanketh): add cipher implementation
+    // addService("Cipher", "HPKE", "HpkeCipher");
   }
 
   private void addSignatures() {

--- a/src/com/amazon/corretto/crypto/provider/EvpHpkeKey.java
+++ b/src/com/amazon/corretto/crypto/provider/EvpHpkeKey.java
@@ -5,7 +5,14 @@ package com.amazon.corretto.crypto.provider;
 class EvpHpkeKey extends EvpKey {
   private static final long serialVersionUID = 1;
 
-  EvpHpkeKey(final InternalKey key, final boolean isPublicKey) {
+  final HpkeParameterSpec spec;
+
+  EvpHpkeKey(final InternalKey key, final boolean isPublicKey, HpkeParameterSpec spec) {
     super(key, EvpKeyType.HPKE, isPublicKey);
+    this.spec = spec;
+  }
+
+  public HpkeParameterSpec getSpec() {
+    return spec;
   }
 }

--- a/src/com/amazon/corretto/crypto/provider/EvpHpkeKey.java
+++ b/src/com/amazon/corretto/crypto/provider/EvpHpkeKey.java
@@ -1,0 +1,11 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package com.amazon.corretto.crypto.provider;
+
+class EvpHpkeKey extends EvpKey {
+  private static final long serialVersionUID = 1;
+
+  EvpHpkeKey(final InternalKey key, final boolean isPublicKey) {
+    super(key, EvpKeyType.HPKE, isPublicKey);
+  }
+}

--- a/src/com/amazon/corretto/crypto/provider/EvpHpkePrivateKey.java
+++ b/src/com/amazon/corretto/crypto/provider/EvpHpkePrivateKey.java
@@ -1,0 +1,30 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package com.amazon.corretto.crypto.provider;
+
+import com.amazon.corretto.crypto.provider.EvpKey.CanDerivePublicKey;
+import java.security.PrivateKey;
+
+public class EvpHpkePrivateKey extends EvpHpkeKey
+    implements PrivateKey, CanDerivePublicKey<EvpHpkePublicKey> {
+  private static final long serialVersionUID = 1;
+
+  EvpHpkePrivateKey(InternalKey key) {
+    super(key, false);
+  }
+
+  EvpHpkePrivateKey(final long ptr) {
+    this(new InternalKey(ptr));
+  }
+
+  // Copied from EvpEcPrivateKey
+  @Override
+  public EvpHpkePublicKey getPublicKey() {
+    // Once our internal key could be elsewhere, we can no longer safely release it when done
+    ephemeral = false;
+    sharedKey = true;
+    final EvpHpkePublicKey result = new EvpHpkePublicKey(internalKey);
+    result.sharedKey = true;
+    return result;
+  }
+}

--- a/src/com/amazon/corretto/crypto/provider/EvpHpkePrivateKey.java
+++ b/src/com/amazon/corretto/crypto/provider/EvpHpkePrivateKey.java
@@ -9,12 +9,12 @@ public class EvpHpkePrivateKey extends EvpHpkeKey
     implements PrivateKey, CanDerivePublicKey<EvpHpkePublicKey> {
   private static final long serialVersionUID = 1;
 
-  EvpHpkePrivateKey(InternalKey key) {
-    super(key, false);
+  EvpHpkePrivateKey(InternalKey key, HpkeParameterSpec spec) {
+    super(key, false, spec);
   }
 
-  EvpHpkePrivateKey(final long ptr) {
-    this(new InternalKey(ptr));
+  EvpHpkePrivateKey(final long ptr, HpkeParameterSpec spec) {
+    this(new InternalKey(ptr), spec);
   }
 
   // Copied from EvpEcPrivateKey
@@ -23,7 +23,7 @@ public class EvpHpkePrivateKey extends EvpHpkeKey
     // Once our internal key could be elsewhere, we can no longer safely release it when done
     ephemeral = false;
     sharedKey = true;
-    final EvpHpkePublicKey result = new EvpHpkePublicKey(internalKey);
+    final EvpHpkePublicKey result = new EvpHpkePublicKey(internalKey, spec);
     result.sharedKey = true;
     return result;
   }

--- a/src/com/amazon/corretto/crypto/provider/EvpHpkePrivateKey.java
+++ b/src/com/amazon/corretto/crypto/provider/EvpHpkePrivateKey.java
@@ -17,7 +17,6 @@ public class EvpHpkePrivateKey extends EvpHpkeKey
     this(new InternalKey(ptr), spec);
   }
 
-  // Copied from EvpEcPrivateKey
   @Override
   public EvpHpkePublicKey getPublicKey() {
     // Once our internal key could be elsewhere, we can no longer safely release it when done

--- a/src/com/amazon/corretto/crypto/provider/EvpHpkePublicKey.java
+++ b/src/com/amazon/corretto/crypto/provider/EvpHpkePublicKey.java
@@ -1,0 +1,13 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package com.amazon.corretto.crypto.provider;
+
+import java.security.PublicKey;
+
+public class EvpHpkePublicKey extends EvpHpkeKey implements PublicKey {
+  private static final long serialVersionUID = 1;
+
+  EvpHpkePublicKey(InternalKey key) {
+    super(key, true);
+  }
+}

--- a/src/com/amazon/corretto/crypto/provider/EvpHpkePublicKey.java
+++ b/src/com/amazon/corretto/crypto/provider/EvpHpkePublicKey.java
@@ -7,7 +7,7 @@ import java.security.PublicKey;
 public class EvpHpkePublicKey extends EvpHpkeKey implements PublicKey {
   private static final long serialVersionUID = 1;
 
-  EvpHpkePublicKey(InternalKey key) {
-    super(key, true);
+  EvpHpkePublicKey(InternalKey key, HpkeParameterSpec spec) {
+    super(key, true, spec);
   }
 }

--- a/src/com/amazon/corretto/crypto/provider/EvpKeyType.java
+++ b/src/com/amazon/corretto/crypto/provider/EvpKeyType.java
@@ -17,7 +17,8 @@ import java.util.Map;
 /** Corresponds to native constants in OpenSSL which represent keytypes. */
 enum EvpKeyType {
   RSA("RSA", 6, RSAPublicKey.class, RSAPrivateKey.class),
-  EC("EC", 408, ECPublicKey.class, ECPrivateKey.class);
+  EC("EC", 408, ECPublicKey.class, ECPrivateKey.class),
+  HPKE("HPKE", 991, EvpHpkePublicKey.class, EvpHpkePrivateKey.class);
 
   final String jceName;
   final int nativeValue;

--- a/src/com/amazon/corretto/crypto/provider/HpkeCipher.java
+++ b/src/com/amazon/corretto/crypto/provider/HpkeCipher.java
@@ -1,0 +1,309 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package com.amazon.corretto.crypto.provider;
+
+import java.security.AlgorithmParameters;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidKeyException;
+import java.security.Key;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.security.spec.AlgorithmParameterSpec;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.InvalidParameterSpecException;
+import javax.crypto.BadPaddingException;
+import javax.crypto.Cipher;
+import javax.crypto.CipherSpi;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.NoSuchPaddingException;
+import javax.crypto.ShortBufferException;
+
+public class HpkeCipher extends CipherSpi {
+
+  static {
+    Loader.load();
+  }
+
+  private final AmazonCorrettoCryptoProvider provider_;
+
+  private int javaCipherMode_ = 0;
+  private EvpHpkeKey key_;
+  private HpkeParameterSpec params_;
+
+  private final Object lock_ = new Object();
+
+  HpkeCipher(AmazonCorrettoCryptoProvider provider) {
+    Loader.checkNativeLibraryAvailability();
+    provider_ = provider;
+  }
+
+  // Core Native Methods
+  // -------------------
+
+  /**
+   * Performs single-shot HPKE encryption or decryption, as specified in Section 6.1 of RFC 9180.
+   *
+   * @return number of bytes written to output, and -1 if failed.
+   */
+  private static native int hpkeCipher(
+      long keyHandle,
+      int javaCipherMode,
+      int kemId,
+      int KdfId,
+      int aeadId,
+      byte[] input,
+      int inputOffset,
+      int inputLen,
+      byte[] output,
+      int outputOffset);
+
+  /**
+   * Computes the number of bytes the output buffer needs to be for wrapping and unwrapping.
+   *
+   * <p>For wrapping, the size is greater than the input buffer since the output buffer also needs
+   * to include an AEAD tag and KEM encapsulate.
+   *
+   * <p>For unwrapping, the size is smaller, since the output does not need the AEAD tag or the KEM
+   * encapsulate.
+   */
+  private static native int hpkeOutputSize(
+      int javaCipherMode, int kemId, int KdfId, int aeadId, int inputLen);
+
+  // Core Java Methods
+  // -----------------
+
+  @Override
+  protected void engineInit(int opmode, Key key, AlgorithmParameterSpec params, SecureRandom random)
+      throws InvalidKeyException, InvalidAlgorithmParameterException {
+    if ((opmode != Cipher.WRAP_MODE) && (opmode != Cipher.UNWRAP_MODE)) {
+      throw new IllegalStateException("HpkeCipher only supports WRAP_MODE and UNWRAP_MODE");
+    }
+    if (params == null) {
+      throw new InvalidAlgorithmParameterException(
+          "HpkeCipher does not support a null parameters.");
+    }
+    if (!(params instanceof HpkeParameterSpec)) {
+      throw new InvalidAlgorithmParameterException(
+          "HpkeCipher only supports HpkeParameterSpec parameters.");
+    }
+    if (!(key instanceof EvpHpkeKey)) {
+      throw new InvalidKeyException("HpkeCipher only supports EvpHpkeKey keys.");
+    }
+    if (((EvpHpkeKey) key).getSpec() != params) {
+      throw new InvalidKeyException("Spec of key does not match the params provided");
+    }
+    if ((opmode == Cipher.WRAP_MODE) && !(key instanceof EvpHpkePublicKey)) {
+      throw new IllegalStateException("Need PublicKey to wrap");
+    }
+    if ((opmode == Cipher.UNWRAP_MODE) && !(key instanceof EvpHpkePrivateKey)) {
+      throw new IllegalStateException("Need PrivateKey to unwrap");
+    }
+    synchronized (lock_) {
+      params_ = (HpkeParameterSpec) params;
+      javaCipherMode_ = opmode;
+      key_ = opmode == Cipher.WRAP_MODE ? (EvpHpkePublicKey) key : (EvpHpkePrivateKey) key;
+    }
+  }
+
+  /**
+   * Performs HPKE single-shot encryption, as specified in Section 6.1 of RFC 9180.
+   *
+   * @return concatenation of KEM encapsulated key and encrypted ciphertext
+   */
+  @Override
+  protected byte[] engineWrap(Key key) throws IllegalBlockSizeException, InvalidKeyException {
+    if (javaCipherMode_ != Cipher.WRAP_MODE) {
+      throw new IllegalStateException("Cipher must be in WRAP_MODE");
+    }
+    if ((key_ == null) || !(key_ instanceof EvpHpkePublicKey)) {
+      throw new IllegalStateException("PublicKey should be set before wrapping.");
+    }
+    try {
+      final byte[] encoded = Utils.encodeForWrapping(provider_, key);
+      return engineDoFinal(encoded, 0, encoded.length);
+    } catch (final BadPaddingException e) {
+      throw new InvalidKeyException("Failed to wrap key", e);
+    }
+  }
+
+  /**
+   * Performs HPKE single-shot decryption, as specified in Section 6.1 of RFC 9180.
+   *
+   * @return decrypted plaintext
+   */
+  @Override
+  protected Key engineUnwrap(byte[] wrappedKey, String wrappedKeyAlgorithm, int wrappedKeyType)
+      throws InvalidKeyException, NoSuchAlgorithmException {
+    if (javaCipherMode_ != Cipher.UNWRAP_MODE) {
+      throw new IllegalStateException("Cipher must be in UNWRAP_MODE");
+    }
+    if ((key_ == null) || !(key_ instanceof EvpHpkePrivateKey)) {
+      throw new IllegalStateException("PrivateKey should be set before unwrapping.");
+    }
+    try {
+      final byte[] unwrappedKey = engineDoFinal(wrappedKey, 0, wrappedKey.length);
+      return Utils.buildUnwrappedKey(provider_, unwrappedKey, wrappedKeyAlgorithm, wrappedKeyType);
+    } catch (final BadPaddingException | IllegalBlockSizeException | InvalidKeySpecException e) {
+      throw new InvalidKeyException("Failed to unwrap key", e);
+    }
+  }
+
+  /**
+   * Performs HPKE single-shot encryption or decryption, as specified in Section 6.1 of RFC 9180.
+   *
+   * @return number of bytes written to output
+   */
+  @Override
+  protected int engineDoFinal(
+      byte[] input, int inputOffset, int inputLen, byte[] output, int outputOffset)
+      throws ShortBufferException {
+
+    if (input == output) {
+      // TODO: is it okay if they are non-overlapping, support that case if necessary.
+      throw new IllegalStateException("input and output must be separate arrays");
+    }
+
+    synchronized (lock_) {
+      if (key_ == null) {
+        throw new IllegalStateException("key should be set before finalizing");
+      }
+      if ((javaCipherMode_ != Cipher.WRAP_MODE) && (javaCipherMode_ != Cipher.UNWRAP_MODE)) {
+        throw new IllegalStateException("HpkeCipher only supports WRAP_MODE and UNWRAP_MODE");
+      }
+      if ((javaCipherMode_ == Cipher.WRAP_MODE) && !(key_ instanceof EvpHpkePublicKey)) {
+        throw new IllegalStateException("PublicKey should be set before wrapping.");
+      }
+      if ((javaCipherMode_ == Cipher.UNWRAP_MODE) && !(key_ instanceof EvpHpkePrivateKey)) {
+        throw new IllegalStateException("PrivateKey should be set before wrapping.");
+      }
+
+      final int result;
+      result =
+          key_.use(
+              ptr ->
+                  hpkeCipher(
+                      ptr,
+                      javaCipherMode_,
+                      params_.getKemId(),
+                      params_.getKdfId(),
+                      params_.getAeadId(),
+                      input,
+                      inputOffset,
+                      inputLen,
+                      output,
+                      outputOffset));
+      return result;
+    }
+  }
+
+  @Override
+  protected int engineGetOutputSize(int inputLen) {
+    if (params_ == null) {
+      throw new IllegalStateException("params should be set before getOutputSize");
+    }
+    if ((javaCipherMode_ != Cipher.WRAP_MODE) && (javaCipherMode_ != Cipher.UNWRAP_MODE)) {
+      throw new IllegalStateException("cipher mode should be set before getOutputSize");
+    }
+    return hpkeOutputSize(
+        javaCipherMode_, params_.getKemId(), params_.getKdfId(), params_.getAeadId(), inputLen);
+  }
+
+  // Boilerplate Methods
+  // -------------------
+
+  @Override
+  protected AlgorithmParameters engineGetParameters() {
+    AlgorithmParameters params;
+    try {
+      params = AlgorithmParameters.getInstance("HPKE");
+      params.init(params_);
+      return params;
+    } catch (NoSuchAlgorithmException | InvalidParameterSpecException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  protected byte[] engineDoFinal(byte[] input, int inputOffset, int inputLen)
+      throws IllegalBlockSizeException, BadPaddingException {
+    byte[] output = new byte[engineGetOutputSize(inputLen)];
+    try {
+      int len = engineDoFinal(input, inputOffset, inputLen, output, 0);
+      if (len != output.length) {
+        throw new RuntimeCryptoException(
+            "HpkeCipher expected output of length " + output.length + ", got output of len " + len);
+      }
+      return output;
+    } catch (ShortBufferException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  protected void engineInit(int opmode, Key key, AlgorithmParameters params, SecureRandom random)
+      throws InvalidKeyException, InvalidAlgorithmParameterException {
+    if (params == null) {
+      throw new InvalidAlgorithmParameterException("cannot initialize HpkeCipher with null params");
+    }
+    try {
+      AlgorithmParameterSpec spec = params.getParameterSpec(HpkeParameterSpec.class);
+      engineInit(opmode, key, spec, random);
+    } catch (InvalidParameterSpecException e) {
+      throw new InvalidAlgorithmParameterException(e);
+    }
+  }
+
+  @Override
+  protected void engineInit(int opmode, Key key, SecureRandom random) throws InvalidKeyException {
+    if (key instanceof EvpHpkeKey) {
+      try {
+        engineInit(opmode, key, ((EvpHpkeKey) key).getSpec(), random);
+      } catch (InvalidAlgorithmParameterException e) {
+        throw new InvalidKeyException(e);
+      }
+    } else {
+      throw new InvalidKeyException("HpkeCipher can only be initialized with EvpHpkeKey.");
+    }
+  }
+
+  // Unsupported Methods
+  // -------------------
+
+  @Override
+  protected void engineUpdateAAD(byte[] src, int offset, int len) {
+    // TODO: implement AAD support
+    throw new IllegalStateException("HpkeCipher currently does not support AAD");
+  }
+
+  @Override
+  protected void engineSetMode(String mode) throws NoSuchAlgorithmException {
+    throw new NoSuchAlgorithmException("HpkeCipher does not support modes");
+  }
+
+  @Override
+  protected void engineSetPadding(String padding) throws NoSuchPaddingException {
+    throw new NoSuchPaddingException("HpkeCipher does not support padding");
+  }
+
+  @Override
+  protected int engineGetBlockSize() {
+    throw new IllegalStateException("HpkeCipher does not support block sizes");
+  }
+
+  @Override
+  protected byte[] engineGetIV() {
+    throw new IllegalStateException("HpkeCipher does not support IVs");
+  }
+
+  @Override
+  protected byte[] engineUpdate(byte[] input, int inputOffset, int inputLen) {
+    throw new IllegalStateException("HpkeCipher does not support updates");
+  }
+
+  @Override
+  protected int engineUpdate(
+      byte[] input, int inputOffset, int inputLen, byte[] output, int outputOffset)
+      throws ShortBufferException {
+    throw new IllegalStateException("HpkeCipher does not support updates");
+  }
+}

--- a/src/com/amazon/corretto/crypto/provider/HpkeCipher.java
+++ b/src/com/amazon/corretto/crypto/provider/HpkeCipher.java
@@ -128,7 +128,7 @@ public class HpkeCipher extends CipherSpi {
    *     for DECRYPT and UNWRAP
    * @param params the algorithm parameters, must be an instance of HpkeParameterSpec, and may not
    *     be null.
-   * @param random a source of randomness
+   * @param random a source of randomness, which we disregard, may be null.
    */
   @Override
   protected void engineInit(int opmode, Key key, AlgorithmParameterSpec params, SecureRandom random)

--- a/src/com/amazon/corretto/crypto/provider/HpkeGen.java
+++ b/src/com/amazon/corretto/crypto/provider/HpkeGen.java
@@ -42,7 +42,7 @@ public class HpkeGen extends KeyPairGeneratorSpi {
       throw new InvalidParameterException("Spec not initialized");
     }
     final EvpHpkePrivateKey privateKey =
-        new EvpHpkePrivateKey(generateEvpHpkeKemKeyFromSpec(spec.getKemId()));
+        new EvpHpkePrivateKey(generateEvpHpkeKemKeyFromSpec(spec.getKemId()), spec);
     final EvpHpkePublicKey publicKey = privateKey.getPublicKey();
     return new KeyPair(publicKey, privateKey);
   }

--- a/src/com/amazon/corretto/crypto/provider/HpkeGen.java
+++ b/src/com/amazon/corretto/crypto/provider/HpkeGen.java
@@ -1,0 +1,49 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package com.amazon.corretto.crypto.provider;
+
+import java.security.*;
+import java.security.spec.AlgorithmParameterSpec;
+
+public class HpkeGen extends KeyPairGeneratorSpi {
+  private final AmazonCorrettoCryptoProvider provider_;
+  private HpkeParameterSpec spec = null;
+
+  HpkeGen(AmazonCorrettoCryptoProvider provider) {
+    Loader.checkNativeLibraryAvailability();
+    provider_ = provider;
+  }
+
+  /** Generates a new HPKE key and returns a pointer to it. */
+  private static native long generateEvpHpkeKemKeyFromSpec(int hpke_kem_id);
+
+  @Override
+  public void initialize(final AlgorithmParameterSpec params, final SecureRandom rnd)
+      throws InvalidAlgorithmParameterException {
+    if (params instanceof HpkeParameterSpec) {
+      // TODO: do validation
+      spec = (HpkeParameterSpec) params;
+    } else {
+      throw new InvalidAlgorithmParameterException("Unsupported AlgorithmParameterSpec: " + spec);
+    }
+  }
+
+  @Override
+  public void initialize(final int keysize, final SecureRandom rnd)
+      throws InvalidParameterException {
+    throw new InvalidParameterException(
+        "Cannot initialize a KEM key with keysize, must use AlgorithmParameterSpec.");
+  }
+
+  @Override
+  public KeyPair generateKeyPair() {
+    if (spec == null) {
+      // TODO: support default spec?
+      throw new InvalidParameterException("Spec not initialized");
+    }
+    final EvpHpkePrivateKey privateKey =
+        new EvpHpkePrivateKey(generateEvpHpkeKemKeyFromSpec(spec.getKemId()));
+    final EvpHpkePublicKey publicKey = privateKey.getPublicKey();
+    return new KeyPair(publicKey, privateKey);
+  }
+}

--- a/src/com/amazon/corretto/crypto/provider/HpkeGen.java
+++ b/src/com/amazon/corretto/crypto/provider/HpkeGen.java
@@ -2,7 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.amazon.corretto.crypto.provider;
 
-import java.security.*;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidParameterException;
+import java.security.KeyPair;
+import java.security.KeyPairGeneratorSpi;
+import java.security.SecureRandom;
 import java.security.spec.AlgorithmParameterSpec;
 
 public class HpkeGen extends KeyPairGeneratorSpi {
@@ -38,7 +42,6 @@ public class HpkeGen extends KeyPairGeneratorSpi {
   @Override
   public KeyPair generateKeyPair() {
     if (spec == null) {
-      // TODO: support default spec?
       throw new InvalidParameterException("Spec not initialized");
     }
     final EvpHpkePrivateKey privateKey =

--- a/src/com/amazon/corretto/crypto/provider/HpkeGen.java
+++ b/src/com/amazon/corretto/crypto/provider/HpkeGen.java
@@ -18,7 +18,14 @@ public class HpkeGen extends KeyPairGeneratorSpi {
     provider_ = provider;
   }
 
-  /** Generates a new HPKE key and returns a pointer to it. */
+  /**
+   * Generates a new HPKE key and returns a pointer to it.
+   *
+   * @param hpke_kem_id HPKE KEM ID defined in Table 2 of RFC 9180
+   * @return native pointer to a newly allocated EVP_HPKE_KEY structure, does not need to be
+   *     explicitly freed when wrapped inside InternalKey (or EvpHpkeKey) which calls OPENSSL_free
+   *     when destroyed.
+   */
   private static native long generateEvpHpkeKemKeyFromSpec(int hpke_kem_id);
 
   @Override

--- a/src/com/amazon/corretto/crypto/provider/HpkeParameterSpec.java
+++ b/src/com/amazon/corretto/crypto/provider/HpkeParameterSpec.java
@@ -8,37 +8,47 @@ public class HpkeParameterSpec implements AlgorithmParameterSpec {
 
   // Selected ciphersuites from RFC 9180
 
+  private static final int mode_base = 0x00;
+
+  private static final int kem_x25519 = 0x0020;
+  private static final int kem_mlkem768 = 0xff01;
+  private static final int kem_mlkem1024 = 0xff02;
+  private static final int kem_pqt25519 = 0xff03;
+  private static final int kem_pqt256 = 0xff04;
+  private static final int kem_pqt384 = 0xff05;
+
+  private static final int kdf_hkdf_sha256 = 0x0001;
+  private static final int kdf_hkdf_sha384 = 0x0002;
+
+  private static final int aead_aes128_gcm = 0x0001;
+  private static final int aead_aes256_gcm = 0x0002;
+  private static final int aead_chacha20_poly1305 = 0x0003;
+
   /** Base mode, DHKEM-X25519, HKDF-SHA256, AES128-GCM */
   public static final HpkeParameterSpec X25519Sha256Aes128gcm =
-      new HpkeParameterSpec(0x00, 0x0020, 0x0001, 0x0001);
+      new HpkeParameterSpec(mode_base, kem_x25519, kdf_hkdf_sha256, aead_aes128_gcm);
   /** Base mode, DHKEM-X25519, HKDF-SHA256, ChaCha20/Poly1305 z */
   public static final HpkeParameterSpec X25519Sha256Chapoly =
-      new HpkeParameterSpec(0x00, 0x0020, 0x0001, 0x0003);
+      new HpkeParameterSpec(mode_base, kem_x25519, kdf_hkdf_sha256, aead_chacha20_poly1305);
 
   // Selected PQ and PQ/T ciphersuites (experimental)
 
-  /** Base mode, HPKE-MLKEM768, HKDF-SHA256, AES128-GCM */
-  public static final HpkeParameterSpec Mlkem768Sha256Aes128gcm =
-      new HpkeParameterSpec(0x00, 0xff01, 0x0001, 0x0001);
-  /** Base mode, HPKE-MLKEM768, HKDF-SHA256, ChaCha20/Poly1305 */
-  public static final HpkeParameterSpec Mlkem768Sha256Chapoly =
-      new HpkeParameterSpec(0x00, 0xff01, 0x0001, 0x0003);
+  /** Base mode, HPKE-MLKEM768, HKDF-SHA256, AES256-GCM */
+  public static final HpkeParameterSpec Mlkem768Sha256Aes256gcm =
+      new HpkeParameterSpec(mode_base, kem_mlkem768, kdf_hkdf_sha256, aead_aes256_gcm);
   /** Base mode, HPKE-MLKEM1024, HKDF-SHA384, AES256-GCM */
   public static final HpkeParameterSpec Mlkem1024Sha384Aes256gcm =
-      new HpkeParameterSpec(0x00, 0xff02, 0x0002, 0x0002);
+      new HpkeParameterSpec(mode_base, kem_mlkem1024, kdf_hkdf_sha384, aead_aes256_gcm);
 
-  /** Base mode, HPKE-PQT25519, HKDF-SHA256, AES128-GCM */
-  public static final HpkeParameterSpec Pqt25519Sha256Aes128gcm =
-      new HpkeParameterSpec(0x00, 0xff03, 0x0001, 0x0001);
-  /** Base mode, HPKE-PQT25519, HKDF-SHA256, ChaCha20/Poly1305 */
-  public static final HpkeParameterSpec Pqt25519768Sha256Chapoly =
-      new HpkeParameterSpec(0x00, 0xff03, 0x0001, 0x0003);
-  /** Base mode, HPKE-PQT256, HKDF-SHA256, AES128-GCM */
-  public static final HpkeParameterSpec Pqt256Sha256Aes128gcm =
-      new HpkeParameterSpec(0x00, 0xff04, 0x0001, 0x0001);
+  /** Base mode, HPKE-PQT25519, HKDF-SHA256, AES256-GCM */
+  public static final HpkeParameterSpec Pqt25519Sha256Aes256gcm =
+      new HpkeParameterSpec(mode_base, kem_pqt25519, kdf_hkdf_sha256, aead_aes256_gcm);
+  /** Base mode, HPKE-PQT256, HKDF-SHA256, AES256-GCM */
+  public static final HpkeParameterSpec Pqt256Sha256Aes256gcm =
+      new HpkeParameterSpec(mode_base, kem_pqt256, kdf_hkdf_sha256, aead_aes256_gcm);
   /** Base mode, HPKE-PQT384, HKDF-SHA384, AES256-GCM */
   public static final HpkeParameterSpec Pqt384Sha384Aes256gcm =
-      new HpkeParameterSpec(0x00, 0xff05, 0x0002, 0x0002);
+      new HpkeParameterSpec(mode_base, kem_pqt384, kdf_hkdf_sha384, aead_aes256_gcm);
 
   /** HPKE mode, defined in Table 1 of RFC 9180 */
   private final int mode;

--- a/src/com/amazon/corretto/crypto/provider/HpkeParameterSpec.java
+++ b/src/com/amazon/corretto/crypto/provider/HpkeParameterSpec.java
@@ -8,44 +8,48 @@ public class HpkeParameterSpec implements AlgorithmParameterSpec {
 
   // Selected ciphersuites from RFC 9180
 
-  // Base mode, DHKEM-X25519, HKDF-SHA256, AES128-GCM
+  /** Base mode, DHKEM-X25519, HKDF-SHA256, AES128-GCM */
   public static final HpkeParameterSpec X25519Sha256Aes128gcm =
       new HpkeParameterSpec(0x00, 0x0020, 0x0001, 0x0001);
-  // Base mode, DHKEM-X25519, HKDF-SHA256, ChaCha20/Poly1305
+  /** Base mode, DHKEM-X25519, HKDF-SHA256, ChaCha20/Poly1305 z */
   public static final HpkeParameterSpec X25519Sha256Chapoly =
       new HpkeParameterSpec(0x00, 0x0020, 0x0001, 0x0003);
 
   // Selected PQ and PQ/T ciphersuites (experimental)
 
-  // Base mode, HPKE-MLKEM768, HKDF-SHA256, AES128-GCM
+  /** Base mode, HPKE-MLKEM768, HKDF-SHA256, AES128-GCM */
   public static final HpkeParameterSpec Mlkem768Sha256Aes128gcm =
       new HpkeParameterSpec(0x00, 0xff01, 0x0001, 0x0001);
-  // Base mode, HPKE-MLKEM768, HKDF-SHA256, ChaCha20/Poly1305
+  /** Base mode, HPKE-MLKEM768, HKDF-SHA256, ChaCha20/Poly1305 */
   public static final HpkeParameterSpec Mlkem768Sha256Chapoly =
       new HpkeParameterSpec(0x00, 0xff01, 0x0001, 0x0003);
-  // Base mode, HPKE-MLKEM1024, HKDF-SHA384, AES256-GCM
+  /** Base mode, HPKE-MLKEM1024, HKDF-SHA384, AES256-GCM */
   public static final HpkeParameterSpec Mlkem1024Sha384Aes256gcm =
       new HpkeParameterSpec(0x00, 0xff02, 0x0002, 0x0002);
 
-  // Base mode, HPKE-PQT25519, HKDF-SHA256, AES128-GCM
+  /** Base mode, HPKE-PQT25519, HKDF-SHA256, AES128-GCM */
   public static final HpkeParameterSpec Pqt25519Sha256Aes128gcm =
       new HpkeParameterSpec(0x00, 0xff03, 0x0001, 0x0001);
-  // Base mode, HPKE-PQT25519, HKDF-SHA256, ChaCha20/Poly1305
+  /** Base mode, HPKE-PQT25519, HKDF-SHA256, ChaCha20/Poly1305 */
   public static final HpkeParameterSpec Pqt25519768Sha256Chapoly =
       new HpkeParameterSpec(0x00, 0xff03, 0x0001, 0x0003);
-  // Base mode, HPKE-PQT256, HKDF-SHA256, AES128-GCM
+  /** Base mode, HPKE-PQT256, HKDF-SHA256, AES128-GCM */
   public static final HpkeParameterSpec Pqt256Sha256Aes128gcm =
       new HpkeParameterSpec(0x00, 0xff04, 0x0001, 0x0001);
-  // Base mode, HPKE-PQT384, HKDF-SHA384, AES256-GCM
+  /** Base mode, HPKE-PQT384, HKDF-SHA384, AES256-GCM */
   public static final HpkeParameterSpec Pqt384Sha384Aes256gcm =
       new HpkeParameterSpec(0x00, 0xff05, 0x0002, 0x0002);
 
+  /** HPKE mode, defined in Table 1 of RFC 9180 */
   private final int mode;
+  /** HPKE KEM ID, defined in Table 2 of RFC 9180 */
   private final int kemId;
+  /** HPKE KDF ID, defined in Table 3 of RFC 9180 */
   private final int kdfId;
+  /** HPKE AEAD ID, defined in Table 5 of RFC 9180 */
   private final int aeadId;
 
-  public HpkeParameterSpec(int mode, int kemId, int kdfId, int aeadId) {
+  private HpkeParameterSpec(int mode, int kemId, int kdfId, int aeadId) {
     this.mode = mode;
     this.kemId = kemId;
     this.kdfId = kdfId;

--- a/src/com/amazon/corretto/crypto/provider/HpkeParameterSpec.java
+++ b/src/com/amazon/corretto/crypto/provider/HpkeParameterSpec.java
@@ -1,0 +1,70 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package com.amazon.corretto.crypto.provider;
+
+import java.security.spec.AlgorithmParameterSpec;
+
+public class HpkeParameterSpec implements AlgorithmParameterSpec {
+
+  // Selected ciphersuites from RFC 9180
+
+  // Base mode, DHKEM-X25519, HKDF-SHA256, AES128-GCM
+  public static final HpkeParameterSpec X25519Sha256Aes128gcm =
+      new HpkeParameterSpec(0x00, 0x0020, 0x0001, 0x0001);
+  // Base mode, DHKEM-X25519, HKDF-SHA256, ChaCha20/Poly1305
+  public static final HpkeParameterSpec X25519Sha256Chapoly =
+      new HpkeParameterSpec(0x00, 0x0020, 0x0001, 0x0003);
+
+  // Selected PQ and PQ/T ciphersuites (experimental)
+
+  // Base mode, HPKE-MLKEM768, HKDF-SHA256, AES128-GCM
+  public static final HpkeParameterSpec Mlkem768Sha256Aes128gcm =
+      new HpkeParameterSpec(0x00, 0xff01, 0x0001, 0x0001);
+  // Base mode, HPKE-MLKEM768, HKDF-SHA256, ChaCha20/Poly1305
+  public static final HpkeParameterSpec Mlkem768Sha256Chapoly =
+      new HpkeParameterSpec(0x00, 0xff01, 0x0001, 0x0003);
+  // Base mode, HPKE-MLKEM1024, HKDF-SHA384, AES256-GCM
+  public static final HpkeParameterSpec Mlkem1024Sha384Aes256gcm =
+      new HpkeParameterSpec(0x00, 0xff02, 0x0002, 0x0002);
+
+  // Base mode, HPKE-PQT25519, HKDF-SHA256, AES128-GCM
+  public static final HpkeParameterSpec Pqt25519Sha256Aes128gcm =
+      new HpkeParameterSpec(0x00, 0xff03, 0x0001, 0x0001);
+  // Base mode, HPKE-PQT25519, HKDF-SHA256, ChaCha20/Poly1305
+  public static final HpkeParameterSpec Pqt25519768Sha256Chapoly =
+      new HpkeParameterSpec(0x00, 0xff03, 0x0001, 0x0003);
+  // Base mode, HPKE-PQT256, HKDF-SHA256, AES128-GCM
+  public static final HpkeParameterSpec Pqt256Sha256Aes128gcm =
+      new HpkeParameterSpec(0x00, 0xff04, 0x0001, 0x0001);
+  // Base mode, HPKE-PQT384, HKDF-SHA384, AES256-GCM
+  public static final HpkeParameterSpec Pqt384Sha384Aes256gcm =
+      new HpkeParameterSpec(0x00, 0xff05, 0x0002, 0x0002);
+
+  private final int mode;
+  private final int kemId;
+  private final int kdfId;
+  private final int aeadId;
+
+  public HpkeParameterSpec(int mode, int kemId, int kdfId, int aeadId) {
+    this.mode = mode;
+    this.kemId = kemId;
+    this.kdfId = kdfId;
+    this.aeadId = aeadId;
+  }
+
+  public int getMode() {
+    return mode;
+  }
+
+  public int getKemId() {
+    return kemId;
+  }
+
+  public int getKdfId() {
+    return kdfId;
+  }
+
+  public int getAeadId() {
+    return aeadId;
+  }
+}

--- a/tst/com/amazon/corretto/crypto/provider/test/HpkeCipherTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/HpkeCipherTest.java
@@ -1,0 +1,104 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package com.amazon.corretto.crypto.provider.test;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import com.amazon.corretto.crypto.provider.HpkeParameterSpec;
+import java.security.*;
+import java.security.GeneralSecurityException;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.spec.ECGenParameterSpec;
+import javax.crypto.Cipher;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
+
+@ExtendWith(TestResultLogger.class)
+@Execution(ExecutionMode.CONCURRENT)
+@ResourceLock(value = TestUtil.RESOURCE_GLOBAL, mode = ResourceAccessMode.READ)
+public class HpkeCipherTest {
+  private KeyPairGenerator getGenerator() throws GeneralSecurityException {
+    return KeyPairGenerator.getInstance("HPKE", TestUtil.NATIVE_PROVIDER);
+  }
+
+  private static Cipher getCipher() throws GeneralSecurityException {
+    return Cipher.getInstance("HPKE", TestUtil.NATIVE_PROVIDER);
+  }
+
+  @Test
+  public void testWrapUnwrap() throws GeneralSecurityException {
+    final HpkeParameterSpec[] namedSpecs = {
+      HpkeParameterSpec.X25519Sha256Aes128gcm,
+      HpkeParameterSpec.X25519Sha256Chapoly,
+      HpkeParameterSpec.Mlkem768Sha256Aes128gcm,
+      HpkeParameterSpec.Mlkem768Sha256Chapoly,
+      HpkeParameterSpec.Mlkem1024Sha384Aes256gcm,
+      HpkeParameterSpec.Pqt25519Sha256Aes128gcm,
+      HpkeParameterSpec.Pqt25519768Sha256Chapoly,
+      HpkeParameterSpec.Pqt256Sha256Aes128gcm,
+      HpkeParameterSpec.Pqt384Sha384Aes256gcm
+    };
+    for (final HpkeParameterSpec spec : namedSpecs) {
+      final KeyPairGenerator generator = getGenerator();
+      final Cipher wrapCipher = getCipher();
+      final Cipher unwrapCipher = getCipher();
+
+      // Generate a key pair
+      generator.initialize(spec);
+      final KeyPair keyPair = generator.generateKeyPair();
+      assertNotNull(keyPair.getPublic());
+      assertNotNull(keyPair.getPrivate());
+
+      // Initialize ciphers
+      wrapCipher.init(Cipher.WRAP_MODE, keyPair.getPublic());
+      unwrapCipher.init(Cipher.UNWRAP_MODE, keyPair.getPrivate());
+
+      // Test wrapping AES key
+      final SecretKeySpec aesKey = new SecretKeySpec(TestUtil.getRandomBytes(16), "AES");
+      final SecretKey unwrappedSecretKey =
+          (SecretKey) unwrapCipher.unwrap(wrapCipher.wrap(aesKey), "AES", Cipher.SECRET_KEY);
+      assertEquals(aesKey.getAlgorithm(), unwrappedSecretKey.getAlgorithm());
+      assertArrayEquals(aesKey.getEncoded(), unwrappedSecretKey.getEncoded());
+
+      // Test wrapping RSA keys
+      final KeyPairGenerator rsaGenerator = KeyPairGenerator.getInstance("RSA");
+      rsaGenerator.initialize(4096);
+      final KeyPair rsaKeyPair = rsaGenerator.generateKeyPair();
+      final PublicKey rsaPublicKey = rsaKeyPair.getPublic();
+      final PublicKey unwrappedRsaPublicKey =
+          (PublicKey) unwrapCipher.unwrap(wrapCipher.wrap(rsaPublicKey), "RSA", Cipher.PUBLIC_KEY);
+      assertEquals(rsaPublicKey.getAlgorithm(), unwrappedRsaPublicKey.getAlgorithm());
+      assertArrayEquals(rsaPublicKey.getEncoded(), unwrappedRsaPublicKey.getEncoded());
+      final PrivateKey rsaPrivateKey = rsaKeyPair.getPrivate();
+      final PrivateKey unwrappedRsaPrivateKey =
+          (PrivateKey)
+              unwrapCipher.unwrap(wrapCipher.wrap(rsaPrivateKey), "RSA", Cipher.PRIVATE_KEY);
+      assertEquals(rsaPrivateKey.getAlgorithm(), unwrappedRsaPrivateKey.getAlgorithm());
+      assertArrayEquals(rsaPrivateKey.getEncoded(), unwrappedRsaPrivateKey.getEncoded());
+
+      // Test wrapping EC keys
+      final KeyPairGenerator ecGenerator = KeyPairGenerator.getInstance("EC");
+      ecGenerator.initialize(new ECGenParameterSpec("NIST P-384"));
+      final KeyPair ecKeyPair = ecGenerator.generateKeyPair();
+      final PublicKey ecPublicKey = ecKeyPair.getPublic();
+      final PublicKey unwrappedEcPublicKey =
+          (PublicKey) unwrapCipher.unwrap(wrapCipher.wrap(ecPublicKey), "EC", Cipher.PUBLIC_KEY);
+      assertEquals(ecPublicKey.getAlgorithm(), unwrappedEcPublicKey.getAlgorithm());
+      assertArrayEquals(ecPublicKey.getEncoded(), unwrappedEcPublicKey.getEncoded());
+      final PrivateKey ecPrivateKey = ecKeyPair.getPrivate();
+      final PrivateKey unwrappedEcPrivateKey =
+          (PrivateKey) unwrapCipher.unwrap(wrapCipher.wrap(ecPrivateKey), "EC", Cipher.PRIVATE_KEY);
+      assertEquals(ecPrivateKey.getAlgorithm(), unwrappedEcPrivateKey.getAlgorithm());
+      assertArrayEquals(ecPrivateKey.getEncoded(), unwrappedEcPrivateKey.getEncoded());
+    }
+  }
+}

--- a/tst/com/amazon/corretto/crypto/provider/test/HpkeCipherTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/HpkeCipherTest.java
@@ -35,12 +35,10 @@ public class HpkeCipherTest {
     return Arrays.asList(
         HpkeParameterSpec.X25519Sha256Aes128gcm,
         HpkeParameterSpec.X25519Sha256Chapoly,
-        HpkeParameterSpec.Mlkem768Sha256Aes128gcm,
-        HpkeParameterSpec.Mlkem768Sha256Chapoly,
+        HpkeParameterSpec.Mlkem768Sha256Aes256gcm,
         HpkeParameterSpec.Mlkem1024Sha384Aes256gcm,
-        HpkeParameterSpec.Pqt25519Sha256Aes128gcm,
-        HpkeParameterSpec.Pqt25519768Sha256Chapoly,
-        HpkeParameterSpec.Pqt256Sha256Aes128gcm,
+        HpkeParameterSpec.Pqt25519Sha256Aes256gcm,
+        HpkeParameterSpec.Pqt256Sha256Aes256gcm,
         HpkeParameterSpec.Pqt384Sha384Aes256gcm);
   }
 
@@ -134,7 +132,7 @@ public class HpkeCipherTest {
 
   @Test
   public void invalidUses() throws GeneralSecurityException {
-    final HpkeParameterSpec spec = HpkeParameterSpec.Mlkem768Sha256Chapoly;
+    final HpkeParameterSpec spec = HpkeParameterSpec.Mlkem768Sha256Aes256gcm;
     final KeyPair keyPair = getKeyPair(spec);
     final byte[] input = TestUtil.arrayOf((byte) 0x42, 42);
 

--- a/tst/com/amazon/corretto/crypto/provider/test/HpkeGenTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/HpkeGenTest.java
@@ -4,8 +4,6 @@ package com.amazon.corretto.crypto.provider.test;
 
 import static org.junit.Assert.assertNotNull;
 
-import com.amazon.corretto.crypto.provider.EvpHpkePrivateKey;
-import com.amazon.corretto.crypto.provider.EvpHpkePublicKey;
 import com.amazon.corretto.crypto.provider.HpkeParameterSpec;
 import java.security.GeneralSecurityException;
 import java.security.KeyPair;
@@ -42,12 +40,8 @@ public class HpkeGenTest {
       final KeyPairGenerator generator = getGenerator();
       generator.initialize(spec);
       final KeyPair keyPair = generator.generateKeyPair();
-      final EvpHpkePublicKey pubKey = (EvpHpkePublicKey) keyPair.getPublic();
-      final EvpHpkePrivateKey privKey = (EvpHpkePrivateKey) keyPair.getPrivate();
-
-      assertNotNull(pubKey);
-      assertNotNull(privKey);
-      // TODO: do more checks
+      assertNotNull(keyPair.getPublic());
+      assertNotNull(keyPair.getPrivate());
     }
   }
 }

--- a/tst/com/amazon/corretto/crypto/provider/test/HpkeGenTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/HpkeGenTest.java
@@ -1,0 +1,53 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package com.amazon.corretto.crypto.provider.test;
+
+import static org.junit.Assert.assertNotNull;
+
+import com.amazon.corretto.crypto.provider.EvpHpkePrivateKey;
+import com.amazon.corretto.crypto.provider.EvpHpkePublicKey;
+import com.amazon.corretto.crypto.provider.HpkeParameterSpec;
+import java.security.GeneralSecurityException;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
+
+@ExtendWith(TestResultLogger.class)
+@Execution(ExecutionMode.CONCURRENT)
+@ResourceLock(value = TestUtil.RESOURCE_GLOBAL, mode = ResourceAccessMode.READ)
+public class HpkeGenTest {
+  private KeyPairGenerator getGenerator() throws GeneralSecurityException {
+    return KeyPairGenerator.getInstance("HPKE", TestUtil.NATIVE_PROVIDER);
+  }
+
+  @Test
+  public void testNamedSpecs() throws GeneralSecurityException {
+    final HpkeParameterSpec[] namedSpecs = {
+      HpkeParameterSpec.X25519Sha256Aes128gcm,
+      HpkeParameterSpec.X25519Sha256Chapoly,
+      HpkeParameterSpec.Mlkem768Sha256Aes128gcm,
+      HpkeParameterSpec.Mlkem768Sha256Chapoly,
+      HpkeParameterSpec.Mlkem1024Sha384Aes256gcm,
+      HpkeParameterSpec.Pqt25519Sha256Aes128gcm,
+      HpkeParameterSpec.Pqt25519768Sha256Chapoly,
+      HpkeParameterSpec.Pqt256Sha256Aes128gcm,
+      HpkeParameterSpec.Pqt384Sha384Aes256gcm
+    };
+    for (final HpkeParameterSpec spec : namedSpecs) {
+      final KeyPairGenerator generator = getGenerator();
+      generator.initialize(spec);
+      final KeyPair keyPair = generator.generateKeyPair();
+      final EvpHpkePublicKey pubKey = (EvpHpkePublicKey) keyPair.getPublic();
+      final EvpHpkePrivateKey privKey = (EvpHpkePrivateKey) keyPair.getPrivate();
+
+      assertNotNull(pubKey);
+      assertNotNull(privKey);
+      // TODO: do more checks
+    }
+  }
+}

--- a/tst/com/amazon/corretto/crypto/provider/test/HpkeGenTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/HpkeGenTest.java
@@ -2,46 +2,48 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.amazon.corretto.crypto.provider.test;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.amazon.corretto.crypto.provider.HpkeParameterSpec;
 import java.security.GeneralSecurityException;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
-import org.junit.jupiter.api.Test;
+import java.util.Arrays;
+import java.util.List;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.api.parallel.ResourceAccessMode;
 import org.junit.jupiter.api.parallel.ResourceLock;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 @ExtendWith(TestResultLogger.class)
 @Execution(ExecutionMode.CONCURRENT)
 @ResourceLock(value = TestUtil.RESOURCE_GLOBAL, mode = ResourceAccessMode.READ)
 public class HpkeGenTest {
+  static List<HpkeParameterSpec> namedSpecs() {
+    return Arrays.asList(
+        HpkeParameterSpec.X25519Sha256Aes128gcm,
+        HpkeParameterSpec.X25519Sha256Chapoly,
+        HpkeParameterSpec.Mlkem768Sha256Aes256gcm,
+        HpkeParameterSpec.Mlkem1024Sha384Aes256gcm,
+        HpkeParameterSpec.Pqt25519Sha256Aes256gcm,
+        HpkeParameterSpec.Pqt256Sha256Aes256gcm,
+        HpkeParameterSpec.Pqt384Sha384Aes256gcm);
+  }
+
   private KeyPairGenerator getGenerator() throws GeneralSecurityException {
     return KeyPairGenerator.getInstance("HPKE", TestUtil.NATIVE_PROVIDER);
   }
 
-  @Test
-  public void testNamedSpecs() throws GeneralSecurityException {
-    final HpkeParameterSpec[] namedSpecs = {
-      HpkeParameterSpec.X25519Sha256Aes128gcm,
-      HpkeParameterSpec.X25519Sha256Chapoly,
-      HpkeParameterSpec.Mlkem768Sha256Aes128gcm,
-      HpkeParameterSpec.Mlkem768Sha256Chapoly,
-      HpkeParameterSpec.Mlkem1024Sha384Aes256gcm,
-      HpkeParameterSpec.Pqt25519Sha256Aes128gcm,
-      HpkeParameterSpec.Pqt25519768Sha256Chapoly,
-      HpkeParameterSpec.Pqt256Sha256Aes128gcm,
-      HpkeParameterSpec.Pqt384Sha384Aes256gcm
-    };
-    for (final HpkeParameterSpec spec : namedSpecs) {
-      final KeyPairGenerator generator = getGenerator();
-      generator.initialize(spec);
-      final KeyPair keyPair = generator.generateKeyPair();
-      assertNotNull(keyPair.getPublic());
-      assertNotNull(keyPair.getPrivate());
-    }
+  @ParameterizedTest
+  @MethodSource("namedSpecs")
+  public void basicKeygen(HpkeParameterSpec spec) throws GeneralSecurityException {
+    final KeyPairGenerator generator = getGenerator();
+    generator.initialize(spec);
+    final KeyPair keyPair = generator.generateKeyPair();
+    assertNotNull(keyPair.getPublic());
+    assertNotNull(keyPair.getPrivate());
   }
 }


### PR DESCRIPTION
### Description of changes:

Add experimental support for using AWS-LC HPKE as a `Cipher` using AWS-LC's `hpke.h`:
- update to building with an experimental branch of aws-lc
- add new `AlgorithmParameterSpec` `HpkeParameterSpec`
- add new `EvpKey` `EvpHpkeKey`
- add new `PublicKey` `EvpHpkePublicKey` and new `PrivateKey` `EvpHpkePrivateKey`
- add new `KeyPairGenerator` `HpkeGen` which generates a HPKE key, backed by the native `hpke_gen.cpp`
- add new `Cipher``HpkeCipher`, which performs single-shot HPKE encryption and decryption, backed by the native`hpke_cipher.cpp`.

### Call-outs:

- lines 40-209 in `HpkeCipher.java` contain the core java implementation
- native files `hpke_gen.cpp` and `hpke_cipher.cpp` contain the main cpp wrappers
- general code organization into classes and methods
- there are some outstanding TODO that will be addressed in a later revision

### Testing:

Added `HpkeGenTest` and `HpkeCipherTest` to test basic correctness.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.