### PR TITLE
Update RSA key generation unit test

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ if (ext.isExperimentalFips) {
 
 if (ext.isExperimentalFips || !ext.isFips) {
     // Experimental FIPS uses the same AWS-LC version as non-FIPS builds.
-    ext.awsLcGitVersionId = 'v1.34.2'
+    ext.awsLcGitVersionId = 'v1.36.0'
 } else {
     ext.awsLcGitVersionId = 'AWS-LC-FIPS-2.0.15'
 }

--- a/tst/com/amazon/corretto/crypto/provider/test/RsaGenTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/RsaGenTest.java
@@ -168,15 +168,18 @@ public class RsaGenTest {
   public void test5120() throws GeneralSecurityException {
     final KeyPairGenerator generator = getGenerator();
     generator.initialize(5120);
-    if (TestUtil.isFips()) {
-      assertThrows(RuntimeCryptoException.class, () -> generator.generateKeyPair());
-    } else {
+    try {
       final KeyPair keyPair = generator.generateKeyPair();
       final RSAPublicKey pubKey = (RSAPublicKey) keyPair.getPublic();
       final RSAPrivateCrtKey privKey = (RSAPrivateCrtKey) keyPair.getPrivate();
       assertEquals(5120, pubKey.getModulus().bitLength());
       assertEquals(RSAKeyGenParameterSpec.F4, pubKey.getPublicExponent());
       assertConsistency(pubKey, privKey);
+    } catch (final RuntimeCryptoException e) {
+      // Starting from version v1.35.1, AWS-LC built in FIPS mode allows key sizes larger than 4096.
+      // This exception could happen if ACCP is built with a version of AWS-LC in FIPS mode that
+      // does not support key sizes larger than 4096.
+      assertTrue(TestUtil.isFips());
     }
   }
 


### PR DESCRIPTION
*Description of changes:*

+ Future releases of AWS-LC FIPS support RSA key sizes larger than 4096.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
