### PR TITLE
Avoid unnecessary array copy in singlePass

### DIFF
--- a/csrc/hash_template.cpp.template
+++ b/csrc/hash_template.cpp.template
@@ -130,7 +130,7 @@ JNIEXPORT void JNICALL JNI_NAME(updateNativeByteBuffer)(
 }
 
 JNIEXPORT void JNICALL JNI_NAME(fastDigest)(
-    JNIEnv* pEnv, jclass, jbyteArray digestArray, jbyteArray dataArray, jint dataLength)
+    JNIEnv* pEnv, jclass, jbyteArray digestArray, jbyteArray dataArray, jint bufOffset, jint dataLength)
 {
     // As this method needs to be extremely high speed, we are omitting use of java_buffer
     // to avoid the extra JNI calls it requires. Instead we are trusting that dataLength
@@ -147,14 +147,14 @@ JNIEXPORT void JNICALL JNI_NAME(fastDigest)(
         }
 
         if (static_cast<size_t>(dataLength) > scratchSize) {
-            java_buffer dataBuffer = java_buffer::from_array(env, dataArray, 0, dataLength);
+            java_buffer dataBuffer = java_buffer::from_array(env, dataArray, bufOffset, dataLength);
             jni_borrow dataBorrow(env, dataBuffer, "data");
             if (unlikely(!OP(Update)(ctx, dataBorrow.data(), dataBorrow.len()))) {
                 throw java_ex::from_openssl(EX_RUNTIME_CRYPTO, "Unable to update context");
             }
         } else {
             SecureBuffer<uint8_t, scratchSize> scratch;
-            env->GetByteArrayRegion(dataArray, 0, dataLength, reinterpret_cast<jbyte*>(scratch.buf));
+            env->GetByteArrayRegion(dataArray, bufOffset, dataLength, reinterpret_cast<jbyte*>(scratch.buf));
             if (unlikely(!OP(Update)(ctx, scratch, dataLength))) {
                 throw java_ex::from_openssl(EX_RUNTIME_CRYPTO, "Unable to update context");
             }

--- a/template-src/com/amazon/corretto/crypto/provider/TemplateHashSpi.java
+++ b/template-src/com/amazon/corretto/crypto/provider/TemplateHashSpi.java
@@ -45,7 +45,7 @@ public final class TemplateHashSpi extends MessageDigestSpi implements Cloneable
      * @param buf Input buffer
      */
     // NOTE: This method trusts that all of the array lengths and bufLen are sane.
-    static native void fastDigest(byte[] digest, byte[] buf, int bufLen);
+    static native void fastDigest(byte[] digest, byte[] buf, int bufOffset, int bufLen);
 
     /**
      * @return The size of result hashes for this hash function
@@ -123,12 +123,8 @@ public final class TemplateHashSpi extends MessageDigestSpi implements Cloneable
     }
 
     private static byte[] singlePass(byte[] src, int offset, int length) {
-        if (offset != 0 || length != src.length) {
-            src = Arrays.copyOf(src, length);
-            offset = 0;
-        }
         final byte[] result = new byte[HASH_SIZE];
-        fastDigest(result, src, src.length);
+        fastDigest(result, src, offset, src.length);
         return result;
     }
 

--- a/template-src/com/amazon/corretto/crypto/provider/TemplateHashSpi.java
+++ b/template-src/com/amazon/corretto/crypto/provider/TemplateHashSpi.java
@@ -124,7 +124,7 @@ public final class TemplateHashSpi extends MessageDigestSpi implements Cloneable
 
     private static byte[] singlePass(byte[] src, int offset, int length) {
         final byte[] result = new byte[HASH_SIZE];
-        fastDigest(result, src, offset, src.length);
+        fastDigest(result, src, offset, length);
         return result;
     }
 


### PR DESCRIPTION
*Issue #, if available:* 407

*Description of changes:*

Both java_buffer::from_array and GetByteArrayRegion support consuming a slice of the array by passing offset and length, the change adds a `bufOffset` arguments to `fastDigest` to avoid unnecessary array copy in singlePass which needs to invoke `fastDigest` method.

We have tested the fix with JMH:

```
    private static ThreadLocal<MessageDigest> messageDigest = new ThreadLocal<MessageDigest>() {
        protected synchronized MessageDigest initialValue() {
            MessageDigest md = null;
            try {
                md = MessageDigest.getInstance("md5");
            } catch (NoSuchAlgorithmException e) {
                throw new RuntimeException("cannot find md5 algorithm", e);
            }
            return md;
        }
    };

    public static byte[][] inputs = new byte[][]{
            "1234567890123456789012345678901212345678901234567890123456789012".getBytes(), // 64 bytes
            "12345678901234567890123456789012".getBytes(),
            "12345678901234567890123456789012".getBytes(),
            "12345678901234567890123456789012".getBytes(),
            "12345678901234567890123456789012".getBytes(),
            "12345678901234567890123456789012".getBytes(),
            "12345678901234567890123456789012".getBytes(),
            "12345678901234567890123456789012".getBytes()
    };

    @Benchmark
    public static void test() {
        MessageDigest md = messageDigest.get();
        for(byte[] input : inputs) {
            md.digest(input);
        }
    }
```

JMH result:
W/o fix:
```
Benchmark                                  Mode  Cnt     Score    Error   Units
ACCPMD5Benchmark.test                      avgt    5  1630.452 ± 97.567   ns/op
ACCPMD5Benchmark.test:·gc.alloc.rate       avgt    5   346.316 ± 20.570  MB/sec
ACCPMD5Benchmark.test:·gc.alloc.rate.norm  avgt    5   592.000 ±  0.001    B/op
ACCPMD5Benchmark.test:·gc.count            avgt    5    11.000           counts
ACCPMD5Benchmark.test:·gc.time             avgt    5    11.000               ms

```

W/ fix:
```
Benchmark                                  Mode  Cnt     Score    Error   Units
ACCPMD5Benchmark.test                      avgt    5  1583.675 ± 94.346   ns/op
ACCPMD5Benchmark.test:·gc.alloc.rate       avgt    5   154.179 ±  9.225  MB/sec
ACCPMD5Benchmark.test:·gc.alloc.rate.norm  avgt    5   256.000 ±  0.001    B/op
ACCPMD5Benchmark.test:·gc.count            avgt    5     4.000           counts
ACCPMD5Benchmark.test:·gc.time             avgt    5     4.000               ms
```



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
