### PR TITLE
Remove CPP coverage target from default coverage target

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -601,7 +601,7 @@ task coverage_cpp_report {
 }
 
 task coverage {
-    dependsOn coverage_java_report, coverage_cpp_report
+    dependsOn coverage_java_report
 }
 
 task release {


### PR DESCRIPTION
*Issue #, if available:*
ACCP-120 

*Description of changes:*
Mainly, we want to remove this to unblock our CI. This task is currently
breaking all Mac CI dimensions (and possibly others). The root cause
seems related to some mismatches in the related software dependencies
used to create the coverage report.

More broadly, this coverage report is not in a state of good health and
should not bere-introduced to the CI until we take the time addressing
these issues: Redundant unit test execution due to dependency hierarchy,
ignored errors in the coverage report resulting in poor coverage of the
coverage data, surfacing the coverage reporting in a useful manner.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
