### PR TITLE
JMH Benchmarking Fixups

### DIFF
--- a/benchmarks/lib/build.gradle.kts
+++ b/benchmarks/lib/build.gradle.kts
@@ -17,7 +17,7 @@ repositories {
 
 dependencies {
     jmh("org.projectlombok:lombok:1.18.28")
-    jmh("org.bouncycastle:bcprov-jdk15on:1.70")
+    jmh("org.bouncycastle:bcprov-jdk18on:1.79")
 
     val accpArtifactId =
     if (project.hasProperty("fips"))

--- a/benchmarks/lib/src/jmh/java/com/amazon/corretto/crypto/provider/benchmarks/AesXtsBenchmark.java
+++ b/benchmarks/lib/src/jmh/java/com/amazon/corretto/crypto/provider/benchmarks/AesXtsBenchmark.java
@@ -75,7 +75,6 @@ public class AesXtsBenchmark {
 
   @Benchmark
   @BenchmarkMode(Mode.Throughput)
-  @OutputTimeUnit(TimeUnit.MILLISECONDS)
   public final void xtsSameBuffer(BenchmarkState state, Blackhole blackhole) throws Exception {
     final byte[] cipherText = enc(state.key, state.tweak, state.data);
     final byte[] plaintext = dec(state.key, state.tweak, cipherText);
@@ -98,7 +97,6 @@ public class AesXtsBenchmark {
 
   @Benchmark
   @BenchmarkMode(Mode.Throughput)
-  @OutputTimeUnit(TimeUnit.MILLISECONDS)
   public final void xtsDiffBuffer(BenchmarkState state, Blackhole blackhole) throws Exception {
     final byte[] cipherText = encFresh(state.key, state.tweak, state.data);
     final byte[] plaintext = decFresh(state.key, state.tweak, cipherText);

--- a/benchmarks/lib/src/jmh/java/com/amazon/corretto/crypto/provider/benchmarks/Hashes.java
+++ b/benchmarks/lib/src/jmh/java/com/amazon/corretto/crypto/provider/benchmarks/Hashes.java
@@ -44,7 +44,7 @@ public class Hashes {
   }
 
   @Benchmark
-  public byte[] oneShotMedium_64KiB() {
+  public byte[] oneShotLarge_64KiB() {
     return digest.digest(data_64KiB);
   }
 }

--- a/benchmarks/lib/src/jmh/java/com/amazon/corretto/crypto/provider/benchmarks/Hmac.java
+++ b/benchmarks/lib/src/jmh/java/com/amazon/corretto/crypto/provider/benchmarks/Hmac.java
@@ -47,7 +47,7 @@ public class Hmac {
   }
 
   @Benchmark
-  public byte[] oneShotMedium_64KiB() {
+  public byte[] oneShotLarge_64KiB() {
     return mac.doFinal(data_64KiB);
   }
 }

--- a/benchmarks/lib/src/jmh/java/com/amazon/corretto/crypto/provider/benchmarks/Random.java
+++ b/benchmarks/lib/src/jmh/java/com/amazon/corretto/crypto/provider/benchmarks/Random.java
@@ -25,7 +25,7 @@ import org.openjdk.jmh.annotations.Threads;
  * mode (ops/s), because the throughput mode sums the number of operations over all the threads
  */
 @BenchmarkMode(Mode.AverageTime)
-@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
 public class Random {
   @State(Scope.Thread)
   public static class ThreadState {


### PR DESCRIPTION
*Issue #, if available:*
ACCP-118

*Description of changes:*
These changes intend to improve the consistency and freshness of the JMH
benchmarks to support better reporting.

- Upgrade the BouncyCastle dependency to the latest `jdk18on` artifact.
  The artifact we were previously using has not seen an update in 3
  years.
- Remove the ms TimeUnit override for AES-XTS. This is the only
  benchmark that does this and breaks uniformity across the suite.
- Update Random's TimeUnit to microseconds. Nanosecond precision is not
  supported by CloudWatch and the ns precision is not strictly
  necessary.
- Fix some misnamed benchmark names.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

