### PR TITLE
Add missing JMH parameters and naming changes

### DIFF
--- a/benchmarks/lib/src/jmh/java/com/amazon/corretto/crypto/provider/benchmarks/Hashes.java
+++ b/benchmarks/lib/src/jmh/java/com/amazon/corretto/crypto/provider/benchmarks/Hashes.java
@@ -13,7 +13,7 @@ import org.openjdk.jmh.annotations.State;
 
 @State(Scope.Benchmark)
 public class Hashes {
-  @Param({"SHA-256", "SHA-384", "SHA-512"})
+  @Param({"SHA-256", "SHA-384", "SHA-512", "SHA-1", "MD5"})
   public String algorithm;
 
   @Param({AmazonCorrettoCryptoProvider.PROVIDER_NAME, "BC", "SUN"})

--- a/benchmarks/lib/src/jmh/java/com/amazon/corretto/crypto/provider/benchmarks/RsaCipherOneShot.java
+++ b/benchmarks/lib/src/jmh/java/com/amazon/corretto/crypto/provider/benchmarks/RsaCipherOneShot.java
@@ -22,7 +22,7 @@ public class RsaCipherOneShot {
   @Param({AmazonCorrettoCryptoProvider.PROVIDER_NAME, "BC", "SunJCE"})
   public String provider;
 
-  @Param({"Pkcs1Padding", "OAEPWithSHA-1AndMGF1Padding"})
+  @Param({"NoPadding", "Pkcs1Padding", "OAEPPadding", "OAEPWithSHA-1AndMGF1Padding"})
   public String padding;
 
   protected KeyPair keyPair;

--- a/benchmarks/lib/src/jmh/java/com/amazon/corretto/crypto/provider/benchmarks/SignatureRsassaPss.java
+++ b/benchmarks/lib/src/jmh/java/com/amazon/corretto/crypto/provider/benchmarks/SignatureRsassaPss.java
@@ -13,7 +13,7 @@ import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 
 @State(Scope.Benchmark)
-public class SignatureRsa extends SignatureBase {
+public class SignatureRsassaPss extends SignatureBase {
   @Param({"SHA-1"})
   public String hash;
 


### PR DESCRIPTION
*Issue #, if available:*
ACCP-118

*Description of changes:*
- Added some parameters to quickly increase our algorithm coverage.
- Renamed SignatureRsa to SignatureRsassaPss to more closely match the
  specific algorithm being tested. (there exists a separate RSA
  signature algorithm within ACCP)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
