### PR TITLE
Bump AWS-LC version to 1.42.0 and AWS-LC-FIPS version to 3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 * [PR 397:](https://github.com/corretto/amazon-corretto-crypto-provider/pull/397) Support for Concatenation KDFs
 * [PR 399:](https://github.com/corretto/amazon-corretto-crypto-provider/pull/399) Support for Counter KDFs
 * [PR 394:](https://github.com/corretto/amazon-corretto-crypto-provider/pull/394) Support for Ed25519 DSA
+* Use AWS-LC [v1.42.0](https://github.com/aws/aws-lc/releases/tag/v1.42.0) for ACCP
+* Use AWS-LC [AWS-LC-FIPS-3.0.0](https://github.com/aws/aws-lc/releases/tag/AWS-LC-FIPS-3.0.0) for ACCP-FIPS
 
 ## 2.4.1
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -261,6 +261,8 @@ set(C_SRC
     csrc/agreement.cpp
     csrc/bn.cpp
     csrc/buffer.cpp
+    csrc/concatenation_kdf.cpp
+    csrc/counter_kdf.cpp
     csrc/ec_gen.cpp
     csrc/ec_utils.cpp
     csrc/ed_gen.cpp
@@ -290,14 +292,6 @@ if(FIPS)
     set(TEST_FIPS_PROPERTY "-DFIPS=true")
 else()
     set(TEST_FIPS_PROPERTY "-DFIPS=false")
-endif()
-
-# The source files under this guard should be removed and added to all builds, including FIPS,
-# once the corresponding algorithms are added to a FIPS branch of AWS-LC consumable by ACCP.
-if(EXPERIMENTAL_FIPS OR (NOT FIPS))
-    set(C_SRC ${C_SRC}
-        csrc/concatenation_kdf.cpp
-        csrc/counter_kdf.cpp)
 endif()
 
 add_library(amazonCorrettoCryptoProvider SHARED ${C_SRC})

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ ACCP did not track a FIPS branch/release version of AWS-LC until ACCP v2.3.0. Be
 | 2.3.3               | 1.17.0         | 2.0.2               |
 | 2.4.0               | 1.30.1         | 2.0.13              |
 | 2.4.1               | 1.30.1         | 2.0.13              |
-
+| 2.5.0               | 1.42.0         | 3.0.0               |
 
 Notable differences between ACCP and ACCP-FIPS:
 * ACCP uses [the latest release of AWS-LC](https://github.com/aws/aws-lc/releases), whereas, ACCP-FIPS uses [the fips-2022-11-02 branch of AWS-LC](https://github.com/aws/aws-lc/tree/fips-2022-11-02).

--- a/build.gradle
+++ b/build.gradle
@@ -21,11 +21,10 @@ if (ext.isExperimentalFips) {
     ext.isFips = Boolean.getBoolean('FIPS')
 }
 
-if (ext.isExperimentalFips || !ext.isFips) {
-    // Experimental FIPS uses the same AWS-LC version as non-FIPS builds.
-    ext.awsLcGitVersionId = 'v1.36.0'
+if (!ext.isFips) {
+    ext.awsLcGitVersionId = 'v1.42.0'
 } else {
-    ext.awsLcGitVersionId = 'AWS-LC-FIPS-2.0.15'
+    ext.awsLcGitVersionId = 'AWS-LC-FIPS-3.0.0'
 }
 
 // Check for user inputted git version ID.

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,8 @@ if (ext.isExperimentalFips) {
     ext.isFips = Boolean.getBoolean('FIPS')
 }
 
-if (!ext.isFips) {
+if (ext.isExperimentalFips || !ext.isFips) {
+    // Experimental FIPS uses the same AWS-LC version as non-FIPS builds.
     ext.awsLcGitVersionId = 'v1.42.0'
 } else {
     ext.awsLcGitVersionId = 'AWS-LC-FIPS-3.0.0'

--- a/csrc/keyutils.cpp
+++ b/csrc/keyutils.cpp
@@ -170,25 +170,6 @@ const EVP_MD* digestFromJstring(raii_env& env, jstring digestName)
 
 RSA* new_private_RSA_key_with_no_e(BIGNUM const* n, BIGNUM const* d)
 {
-#if defined FIPS_BUILD && !defined EXPERIMENTAL_FIPS_BUILD
-    // AWS-LC-FIPS doesn't have RSA_new_private_key_no_e method yet.
-    // The following implementation has been copied from AWS-LC:
-    // https://github.com/aws/aws-lc/blob/v1.30.1/crypto/fipsmodule/rsa/rsa.c#L147
-    RSA_auto rsa = RSA_auto::from(RSA_new());
-    if (rsa.get() == nullptr) {
-        throw_openssl("RSA_new failed");
-    }
-
-    // RSA struct is not opaque in FIPS mode.
-    rsa->flags |= RSA_FLAG_NO_BLINDING;
-
-    bn_dup_into(&rsa->n, n);
-    bn_dup_into(&rsa->d, d);
-
-    return rsa.take();
-
-#else
-
     RSA* result = ::RSA_new_private_key_no_e(n, d);
 
     if (result == nullptr) {
@@ -196,8 +177,6 @@ RSA* new_private_RSA_key_with_no_e(BIGNUM const* n, BIGNUM const* d)
     }
 
     return result;
-
-#endif
 }
 
 }

--- a/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
+++ b/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
@@ -112,20 +112,17 @@ public final class AmazonCorrettoCryptoProvider extends java.security.Provider {
     addService("SecretKeyFactory", HKDF_WITH_SHA384, hkdfSpi, false);
     addService("SecretKeyFactory", HKDF_WITH_SHA512, hkdfSpi, false);
 
-    // Once these KDFs are added to a FIPS branch of AWS-LC, we can remove this check.
-    if (!Loader.FIPS_BUILD || Loader.EXPERIMENTAL_FIPS_BUILD) {
-      final String concatenationKdfSpi = "ConcatenationKdfSpi";
-      addService("SecretKeyFactory", CKDF_WITH_SHA256, concatenationKdfSpi, false);
-      addService("SecretKeyFactory", CKDF_WITH_SHA384, concatenationKdfSpi, false);
-      addService("SecretKeyFactory", CKDF_WITH_SHA512, concatenationKdfSpi, false);
-      addService("SecretKeyFactory", CKDF_WITH_HMAC_SHA256, concatenationKdfSpi, false);
-      addService("SecretKeyFactory", CKDF_WITH_HMAC_SHA512, concatenationKdfSpi, false);
+    final String concatenationKdfSpi = "ConcatenationKdfSpi";
+    addService("SecretKeyFactory", CKDF_WITH_SHA256, concatenationKdfSpi, false);
+    addService("SecretKeyFactory", CKDF_WITH_SHA384, concatenationKdfSpi, false);
+    addService("SecretKeyFactory", CKDF_WITH_SHA512, concatenationKdfSpi, false);
+    addService("SecretKeyFactory", CKDF_WITH_HMAC_SHA256, concatenationKdfSpi, false);
+    addService("SecretKeyFactory", CKDF_WITH_HMAC_SHA512, concatenationKdfSpi, false);
 
-      final String counterKdfSpi = "CounterKdfSpi";
-      addService("SecretKeyFactory", CTR_KDF_WITH_HMAC_SHA256, counterKdfSpi, false);
-      addService("SecretKeyFactory", CTR_KDF_WITH_HMAC_SHA384, counterKdfSpi, false);
-      addService("SecretKeyFactory", CTR_KDF_WITH_HMAC_SHA512, counterKdfSpi, false);
-    }
+    final String counterKdfSpi = "CounterKdfSpi";
+    addService("SecretKeyFactory", CTR_KDF_WITH_HMAC_SHA256, counterKdfSpi, false);
+    addService("SecretKeyFactory", CTR_KDF_WITH_HMAC_SHA384, counterKdfSpi, false);
+    addService("SecretKeyFactory", CTR_KDF_WITH_HMAC_SHA512, counterKdfSpi, false);
 
     addService("KeyPairGenerator", "RSA", "RsaGen");
     addService("KeyPairGenerator", "EC", "EcGen");

--- a/tst/com/amazon/corretto/crypto/provider/test/ConcatenationKdfTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/ConcatenationKdfTest.java
@@ -6,12 +6,9 @@ import static com.amazon.corretto.crypto.provider.test.TestUtil.bcDigest;
 import static com.amazon.corretto.crypto.provider.test.TestUtil.getEntriesFromFile;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import com.amazon.corretto.crypto.provider.ConcatenationKdfSpec;
 import java.security.NoSuchAlgorithmException;
@@ -36,7 +33,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 public class ConcatenationKdfTest {
 
   @Test
-  public void concatenationKdfsAreNotAvailableInFipsMode() {
+  public void concatenationKdfsAreAvailable() {
     Stream.of(
             "ConcatenationKdfWithSHA256",
             "ConcatenationKdfWithSHA384",
@@ -47,9 +44,8 @@ public class ConcatenationKdfTest {
             alg -> {
               try {
                 assertNotNull(SecretKeyFactory.getInstance(alg, TestUtil.NATIVE_PROVIDER));
-                assertTrue(TestUtil.supportsExtraKdfs());
               } catch (final NoSuchAlgorithmException e) {
-                assertFalse(TestUtil.supportsExtraKdfs());
+                throw new RuntimeException(e);
               }
             });
   }
@@ -71,7 +67,6 @@ public class ConcatenationKdfTest {
   // The rest of the tests are only available in non-FIPS mode, or in experimental FIPS mode.
   @Test
   public void concatenationKdfExpectsConcatenationKdfSpecAsKeySpec() throws Exception {
-    assumeTrue(TestUtil.supportsExtraKdfs());
     final SecretKeyFactory skf =
         SecretKeyFactory.getInstance("ConcatenationKdfWithSha256", TestUtil.NATIVE_PROVIDER);
     assertThrows(
@@ -80,7 +75,6 @@ public class ConcatenationKdfTest {
 
   @Test
   public void concatenationKdfWithEmptyInfoIsFine() throws Exception {
-    assumeTrue(TestUtil.supportsExtraKdfs());
     final SecretKeyFactory skf =
         SecretKeyFactory.getInstance("ConcatenationKdfWithSha256", TestUtil.NATIVE_PROVIDER);
     final ConcatenationKdfSpec spec = new ConcatenationKdfSpec(new byte[1], 10, "name");
@@ -90,7 +84,6 @@ public class ConcatenationKdfTest {
 
   @Test
   public void concatenationKdfHmacWithEmptySaltIsFine() throws Exception {
-    assumeTrue(TestUtil.supportsExtraKdfs());
     final SecretKeyFactory skf =
         SecretKeyFactory.getInstance("ConcatenationKdfWithHmacSha256", TestUtil.NATIVE_PROVIDER);
     final ConcatenationKdfSpec spec1 = new ConcatenationKdfSpec(new byte[1], 10, "name");
@@ -108,7 +101,6 @@ public class ConcatenationKdfTest {
   @ParameterizedTest(name = "{0}")
   @MethodSource("sskdfKatTests")
   public void concatenationKdfKatTests(final RspTestEntry entry) throws Exception {
-    assumeTrue(TestUtil.supportsExtraKdfs());
     final String digest = jceDigestName(entry.getInstance("HASH"));
     assumeFalse("SHA1".equals(digest) || "SHA224".equals(digest));
     final boolean digestPrf = entry.getInstance("VARIANT").equals("DIGEST");

--- a/tst/com/amazon/corretto/crypto/provider/test/TestUtil.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/TestUtil.java
@@ -98,10 +98,6 @@ public class TestUtil {
     return NATIVE_PROVIDER.isExperimentalFips();
   }
 
-  public static boolean supportsExtraKdfs() {
-    return isExperimentalFips() || !isFips();
-  }
-
   public static byte[] intArrayToByteArray(final int[] array) {
     final byte[] result = new byte[array.length];
     for (int i = 0; i != array.length; i++) {


### PR DESCRIPTION
*Issue #, if available:* t/P189144242

*Description of changes:*

We also remove some now-unnecessary guards around `RSA_new_private_key_no_e`, CounterKDF, and ConcatenationKDF.

With these changes, the `EXPERIMENTAL_FIPS` flag doesn't guard anything, but we leave it in place for future use as feature development will inevitably get ahead of our 3.0.0 snapshot of AWS-LC-FIPS.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
