### PR TITLE
Support "pure" ML-DSA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@
 * [PR 397:](https://github.com/corretto/amazon-corretto-crypto-provider/pull/397) Support for Concatenation KDFs
 * [PR 399:](https://github.com/corretto/amazon-corretto-crypto-provider/pull/399) Support for Counter KDFs
 * [PR 394:](https://github.com/corretto/amazon-corretto-crypto-provider/pull/394) Support for Ed25519 DSA
-* Use AWS-LC [v1.42.0](https://github.com/aws/aws-lc/releases/tag/v1.42.0) for ACCP
-* Use AWS-LC [AWS-LC-FIPS-3.0.0](https://github.com/aws/aws-lc/releases/tag/AWS-LC-FIPS-3.0.0) for ACCP-FIPS
+* [PR 421:](https://github.com/corretto/amazon-corretto-crypto-provider/pull/421) Bump AWS-LC version to 1.42.0 and AWS-LC-FIPS version to 3.0.0
+* [PR 422:](https://github.com/corretto/amazon-corretto-crypto-provider/pull/422) Support "pure" ML-DSA, Bump AWS-LC version to 1.43.0
 
 ## 2.4.1
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -274,6 +274,7 @@ set(C_SRC
     csrc/libcrypto_rng.cpp
     csrc/loader.cpp
     csrc/md5.cpp
+    csrc/mldsa_gen.cpp
     csrc/rsa_cipher.cpp
     csrc/rsa_gen.cpp
     csrc/sha1.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -274,7 +274,6 @@ set(C_SRC
     csrc/libcrypto_rng.cpp
     csrc/loader.cpp
     csrc/md5.cpp
-    csrc/mldsa_gen.cpp
     csrc/rsa_cipher.cpp
     csrc/rsa_gen.cpp
     csrc/sha1.cpp
@@ -293,6 +292,12 @@ if(FIPS)
     set(TEST_FIPS_PROPERTY "-DFIPS=true")
 else()
     set(TEST_FIPS_PROPERTY "-DFIPS=false")
+endif()
+
+# The source files under this guard should be removed and added to all builds, including FIPS,
+# once the corresponding algorithms are added to a FIPS branch of AWS-LC consumable by ACCP.
+if(EXPERIMENTAL_FIPS OR (NOT FIPS))
+    set(C_SRC ${C_SRC} csrc/mldsa_gen.cpp)
 endif()
 
 add_library(amazonCorrettoCryptoProvider SHARED ${C_SRC})

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ ACCP did not track a FIPS branch/release version of AWS-LC until ACCP v2.3.0. Be
 | 2.3.3               | 1.17.0         | 2.0.2               |
 | 2.4.0               | 1.30.1         | 2.0.13              |
 | 2.4.1               | 1.30.1         | 2.0.13              |
-| 2.5.0               | 1.42.0         | 3.0.0               |
+| 2.5.0               | 1.43.0         | 3.0.0               |
 
 Notable differences between ACCP and ACCP-FIPS:
 * ACCP uses [the latest release of AWS-LC](https://github.com/aws/aws-lc/releases), whereas, ACCP-FIPS uses [the fips-2022-11-02 branch of AWS-LC](https://github.com/aws/aws-lc/tree/fips-2022-11-02).

--- a/benchmarks/lib/src/jmh/java/com/amazon/corretto/crypto/provider/benchmarks/KeyGenMLDSA.java
+++ b/benchmarks/lib/src/jmh/java/com/amazon/corretto/crypto/provider/benchmarks/KeyGenMLDSA.java
@@ -2,6 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.amazon.corretto.crypto.provider.benchmarks;
 
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+
 import com.amazon.corretto.crypto.provider.AmazonCorrettoCryptoProvider;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Param;
@@ -10,25 +13,24 @@ import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 
 @State(Scope.Benchmark)
-public class SignatureMlDSA extends SignatureBase {
+public class KeyGenMLDSA {
+
     @Param({AmazonCorrettoCryptoProvider.PROVIDER_NAME, "BC"})
     public String provider;
 
     @Param({"ML-DSA-44", "ML-DSA-65", "ML-DSA-87"})
-    public String algo;
+    public String algorithm;
+
+    private KeyPairGenerator kpg;
 
     @Setup
     public void setup() throws Exception {
-        super.setup(provider, algo, null, "ML-DSA", null);
+        BenchmarkUtils.setupProvider(provider);
+        kpg = KeyPairGenerator.getInstance(algorithm, provider);
     }
 
     @Benchmark
-    public byte[] sign() throws Exception {
-        return super.sign();
-    }
-
-    @Benchmark
-    public boolean verify() throws Exception {
-        return super.verify();
+    public KeyPair generate() {
+        return kpg.generateKeyPair();
     }
 }

--- a/benchmarks/lib/src/jmh/java/com/amazon/corretto/crypto/provider/benchmarks/KeyGenMlDSA.java
+++ b/benchmarks/lib/src/jmh/java/com/amazon/corretto/crypto/provider/benchmarks/KeyGenMlDSA.java
@@ -1,0 +1,36 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package com.amazon.corretto.crypto.provider.benchmarks;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+
+import com.amazon.corretto.crypto.provider.AmazonCorrettoCryptoProvider;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+@State(Scope.Benchmark)
+public class KeyGenMlDSA {
+
+    @Param({AmazonCorrettoCryptoProvider.PROVIDER_NAME, "BC"})
+    public String provider;
+
+    @Param({"ML-DSA-44", "ML-DSA-65", "ML-DSA-87"})
+    public String algo;
+
+    private KeyPairGenerator kpg;
+
+    @Setup
+    public void setup() throws Exception {
+        BenchmarkUtils.setupProvider(provider);
+        kpg = KeyPairGenerator.getInstance(algo, provider);
+    }
+
+    @Benchmark
+    public KeyPair generate() {
+        return kpg.generateKeyPair();
+    }
+}

--- a/benchmarks/lib/src/jmh/java/com/amazon/corretto/crypto/provider/benchmarks/SignatureBase.java
+++ b/benchmarks/lib/src/jmh/java/com/amazon/corretto/crypto/provider/benchmarks/SignatureBase.java
@@ -25,7 +25,7 @@ public class SignatureBase {
     BenchmarkUtils.setupProvider(provider);
     final KeyPairGenerator kpg = KeyPairGenerator.getInstance(keyAlg, provider);
     // Ed25519 in ACCP doesn't currently support initialization
-    if (!keyAlg.equals("Ed25519")) {
+    if (!keyAlg.equals("Ed25519") && !keyAlg.startsWith("ML-DSA")) {
       kpg.initialize(keyParams);
     }
     keyPair = kpg.generateKeyPair();

--- a/benchmarks/lib/src/jmh/java/com/amazon/corretto/crypto/provider/benchmarks/SignatureMLDSA.java
+++ b/benchmarks/lib/src/jmh/java/com/amazon/corretto/crypto/provider/benchmarks/SignatureMLDSA.java
@@ -2,9 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.amazon.corretto.crypto.provider.benchmarks;
 
-import java.security.KeyPair;
-import java.security.KeyPairGenerator;
-
 import com.amazon.corretto.crypto.provider.AmazonCorrettoCryptoProvider;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Param;
@@ -13,24 +10,25 @@ import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 
 @State(Scope.Benchmark)
-public class KeyGenMlDSA {
-
+public class SignatureMLDSA extends SignatureBase {
     @Param({AmazonCorrettoCryptoProvider.PROVIDER_NAME, "BC"})
     public String provider;
 
     @Param({"ML-DSA-44", "ML-DSA-65", "ML-DSA-87"})
-    public String algo;
-
-    private KeyPairGenerator kpg;
+    public String algorithm;
 
     @Setup
     public void setup() throws Exception {
-        BenchmarkUtils.setupProvider(provider);
-        kpg = KeyPairGenerator.getInstance(algo, provider);
+        super.setup(provider, algorithm, null, "ML-DSA", null);
     }
 
     @Benchmark
-    public KeyPair generate() {
-        return kpg.generateKeyPair();
+    public byte[] sign() throws Exception {
+        return super.sign();
+    }
+
+    @Benchmark
+    public boolean verify() throws Exception {
+        return super.verify();
     }
 }

--- a/benchmarks/lib/src/jmh/java/com/amazon/corretto/crypto/provider/benchmarks/SignatureMlDSA.java
+++ b/benchmarks/lib/src/jmh/java/com/amazon/corretto/crypto/provider/benchmarks/SignatureMlDSA.java
@@ -1,0 +1,34 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package com.amazon.corretto.crypto.provider.benchmarks;
+
+import com.amazon.corretto.crypto.provider.AmazonCorrettoCryptoProvider;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+@State(Scope.Benchmark)
+public class SignatureMlDSA extends SignatureBase {
+    @Param({AmazonCorrettoCryptoProvider.PROVIDER_NAME, "BC"})
+    public String provider;
+
+    @Param({"ML-DSA-44", "ML-DSA-65", "ML-DSA-87"})
+    public String algo;
+
+    @Setup
+    public void setup() throws Exception {
+        super.setup(provider, algo, null, "ML-DSA", null);
+    }
+
+    @Benchmark
+    public byte[] sign() throws Exception {
+        return super.sign();
+    }
+
+    @Benchmark
+    public boolean verify() throws Exception {
+        return super.verify();
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -25,9 +25,7 @@ if (ext.isExperimentalFips || !ext.isFips) {
     // Experimental FIPS uses the same AWS-LC version as non-FIPS builds.
     ext.awsLcGitVersionId = 'v1.43.0'
 } else {
-    // TODO [childw] put this under "experimental FIPS"...
-    //ext.awsLcGitVersionId = 'AWS-LC-FIPS-3.0.0'
-    ext.awsLcGitVersionId = 'v1.43.0'
+    ext.awsLcGitVersionId = 'AWS-LC-FIPS-3.0.0'
 }
 
 // Check for user inputted git version ID.

--- a/build.gradle
+++ b/build.gradle
@@ -23,9 +23,11 @@ if (ext.isExperimentalFips) {
 
 if (ext.isExperimentalFips || !ext.isFips) {
     // Experimental FIPS uses the same AWS-LC version as non-FIPS builds.
-    ext.awsLcGitVersionId = 'v1.42.0'
+    ext.awsLcGitVersionId = 'v1.43.0'
 } else {
-    ext.awsLcGitVersionId = 'AWS-LC-FIPS-3.0.0'
+    // TODO [childw] put this under "experimental FIPS"...
+    //ext.awsLcGitVersionId = 'AWS-LC-FIPS-3.0.0'
+    ext.awsLcGitVersionId = 'v1.43.0'
 }
 
 // Check for user inputted git version ID.
@@ -181,8 +183,8 @@ dependencies {
     testDep 'org.apiguardian:apiguardian-api:1.1.2'
     testDep 'org.junit.jupiter:junit-jupiter:5.8.2'
     testDep 'org.junit.vintage:junit-vintage-engine:5.8.2'
-    testDep 'org.bouncycastle:bcprov-debug-jdk15on:1.69'
-    testDep 'org.bouncycastle:bcpkix-jdk15on:1.69'
+    testDep 'org.bouncycastle:bcpkix-jdk18on:1.80'
+    testDep 'org.bouncycastle:bcprov-jdk18on:1.80'
     testDep 'commons-codec:commons-codec:1.12'
     testDep 'org.hamcrest:hamcrest:2.1'
     testDep 'org.jacoco:org.jacoco.core:0.8.3'

--- a/csrc/mldsa_gen.cpp
+++ b/csrc/mldsa_gen.cpp
@@ -1,0 +1,42 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+#include "auto_free.h"
+#include "env.h"
+#include "generated-headers.h"
+
+#include <openssl/evp.h>
+#include <openssl/nid.h>
+
+using namespace AmazonCorrettoCryptoProvider;
+
+JNIEXPORT jlong JNICALL Java_com_amazon_corretto_crypto_provider_MlDsaGen_generateEvpMlDsaKey(
+    JNIEnv* pEnv, jclass, jint level)
+{
+    try {
+        raii_env env(pEnv);
+        EVP_PKEY_auto key;
+        EVP_PKEY_CTX_auto ctx = EVP_PKEY_CTX_auto::from(EVP_PKEY_CTX_new_id(EVP_PKEY_PQDSA, NULL));
+        CHECK_OPENSSL(ctx.isInitialized());
+        int nid;
+        switch (level) {
+        case 2:
+            nid = NID_MLDSA44;
+            break;
+        case 3:
+            nid = NID_MLDSA65;
+            break;
+        case 5:
+            nid = NID_MLDSA87;
+            break;
+        default:
+            throw java_ex(EX_ILLEGAL_ARGUMENT, "Invalid level");
+        }
+        CHECK_OPENSSL(EVP_PKEY_CTX_pqdsa_set_params(ctx, nid));
+        CHECK_OPENSSL(EVP_PKEY_keygen_init(ctx) == 1);
+        CHECK_OPENSSL(EVP_PKEY_keygen(ctx, key.getAddressOfPtr()));
+        return reinterpret_cast<jlong>(key.take());
+    } catch (java_ex& ex) {
+        ex.throw_to_java(pEnv);
+    }
+    return 0;
+}

--- a/csrc/sign.cpp
+++ b/csrc/sign.cpp
@@ -66,7 +66,7 @@ bool initializeContext(raii_env& env,
     EVP_PKEY_up_ref(pKey);
     ctx->setKey(pKey);
 
-    if (md != nullptr || EVP_PKEY_id(pKey) == EVP_PKEY_ED25519) {
+    if (md != nullptr || EVP_PKEY_id(pKey) == EVP_PKEY_ED25519 || EVP_PKEY_id(pKey) == EVP_PKEY_PQDSA) {
         if (!ctx->setDigestCtx(EVP_MD_CTX_create())) {
             throw_openssl("Unable to create MD_CTX");
         }
@@ -456,7 +456,7 @@ JNIEXPORT jbyteArray JNICALL Java_com_amazon_corretto_crypto_provider_EvpSignatu
 
         int keyType = EVP_PKEY_id(reinterpret_cast<EVP_PKEY*>(pKey));
 
-        if (keyType == EVP_PKEY_ED25519) {
+        if (keyType == EVP_PKEY_ED25519 || keyType == EVP_PKEY_PQDSA) {
             jni_borrow message(env, messageBuf, "message");
 
             if (!EVP_DigestSign(ctx.getDigestCtx(), NULL, &sigLength, message.data(), message.len())) {
@@ -526,7 +526,7 @@ JNIEXPORT jboolean JNICALL Java_com_amazon_corretto_crypto_provider_EvpSignature
 
         int ret;
         int keyType = EVP_PKEY_id(reinterpret_cast<EVP_PKEY*>(pKey));
-        if (keyType == EVP_PKEY_ED25519) {
+        if (keyType == EVP_PKEY_ED25519 || keyType == EVP_PKEY_PQDSA) {
             ret = EVP_DigestVerify(
                 ctx.getDigestCtx(), signature.data(), signature.len(), message.data(), message.len());
         } else {

--- a/csrc/sign.cpp
+++ b/csrc/sign.cpp
@@ -66,7 +66,11 @@ bool initializeContext(raii_env& env,
     EVP_PKEY_up_ref(pKey);
     ctx->setKey(pKey);
 
+#if defined(FIPS_BUILD) && !defined(EXPERIMENTAL_FIPS_BUILD)
+    if (md != nullptr || EVP_PKEY_id(pKey) == EVP_PKEY_ED25519) {
+#else
     if (md != nullptr || EVP_PKEY_id(pKey) == EVP_PKEY_ED25519 || EVP_PKEY_id(pKey) == EVP_PKEY_PQDSA) {
+#endif
         if (!ctx->setDigestCtx(EVP_MD_CTX_create())) {
             throw_openssl("Unable to create MD_CTX");
         }
@@ -456,7 +460,11 @@ JNIEXPORT jbyteArray JNICALL Java_com_amazon_corretto_crypto_provider_EvpSignatu
 
         int keyType = EVP_PKEY_id(reinterpret_cast<EVP_PKEY*>(pKey));
 
+#if defined(FIPS_BUILD) && !defined(EXPERIMENTAL_FIPS_BUILD)
+        if (keyType == EVP_PKEY_ED25519) {
+#else
         if (keyType == EVP_PKEY_ED25519 || keyType == EVP_PKEY_PQDSA) {
+#endif
             jni_borrow message(env, messageBuf, "message");
 
             if (!EVP_DigestSign(ctx.getDigestCtx(), NULL, &sigLength, message.data(), message.len())) {
@@ -526,7 +534,11 @@ JNIEXPORT jboolean JNICALL Java_com_amazon_corretto_crypto_provider_EvpSignature
 
         int ret;
         int keyType = EVP_PKEY_id(reinterpret_cast<EVP_PKEY*>(pKey));
+#if defined(FIPS_BUILD) && !defined(EXPERIMENTAL_FIPS_BUILD)
+        if (keyType == EVP_PKEY_ED25519) {
+#else
         if (keyType == EVP_PKEY_ED25519 || keyType == EVP_PKEY_PQDSA) {
+#endif
             ret = EVP_DigestVerify(
                 ctx.getDigestCtx(), signature.data(), signature.len(), message.data(), message.len());
         } else {

--- a/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
+++ b/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
@@ -93,7 +93,6 @@ public final class AmazonCorrettoCryptoProvider extends java.security.Provider {
     addService("KeyFactory", "RSA", "EvpKeyFactory$RSA");
     addService("KeyFactory", "EC", "EvpKeyFactory$EC");
 
-
     if (shouldRegisterMLDSA) {
       addService("KeyFactory", "ML-DSA", "EvpKeyFactory$MLDSA");
       addService("KeyFactory", "ML-DSA-44", "EvpKeyFactory$MLDSA");

--- a/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
+++ b/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
@@ -91,10 +91,13 @@ public final class AmazonCorrettoCryptoProvider extends java.security.Provider {
 
     addService("KeyFactory", "RSA", "EvpKeyFactory$RSA");
     addService("KeyFactory", "EC", "EvpKeyFactory$EC");
-    addService("KeyFactory", "ML-DSA", "EvpKeyFactory$MlDSA");
-    addService("KeyFactory", "ML-DSA-44", "EvpKeyFactory$MlDSA");
-    addService("KeyFactory", "ML-DSA-65", "EvpKeyFactory$MlDSA");
-    addService("KeyFactory", "ML-DSA-87", "EvpKeyFactory$MlDSA");
+
+    if (!isFips() || isExperimentalFips()) {
+      addService("KeyFactory", "ML-DSA", "EvpKeyFactory$MlDSA");
+      addService("KeyFactory", "ML-DSA-44", "EvpKeyFactory$MlDSA");
+      addService("KeyFactory", "ML-DSA-65", "EvpKeyFactory$MlDSA");
+      addService("KeyFactory", "ML-DSA-87", "EvpKeyFactory$MlDSA");
+    }
 
     if (shouldRegisterEdDSA) {
       // KeyFactories are used to convert key encodings to Java Key objects. ACCP's KeyFactory for
@@ -131,10 +134,12 @@ public final class AmazonCorrettoCryptoProvider extends java.security.Provider {
     addService("KeyPairGenerator", "RSA", "RsaGen");
     addService("KeyPairGenerator", "EC", "EcGen");
 
-    addService("KeyPairGenerator", "ML-DSA", "MlDsaGen$MlDsaGen44");
-    addService("KeyPairGenerator", "ML-DSA-44", "MlDsaGen$MlDsaGen44");
-    addService("KeyPairGenerator", "ML-DSA-65", "MlDsaGen$MlDsaGen65");
-    addService("KeyPairGenerator", "ML-DSA-87", "MlDsaGen$MlDsaGen87");
+    if (!isFips() || isExperimentalFips()) {
+      addService("KeyPairGenerator", "ML-DSA", "MlDsaGen$MlDsaGen44");
+      addService("KeyPairGenerator", "ML-DSA-44", "MlDsaGen$MlDsaGen44");
+      addService("KeyPairGenerator", "ML-DSA-65", "MlDsaGen$MlDsaGen65");
+      addService("KeyPairGenerator", "ML-DSA-87", "MlDsaGen$MlDsaGen87");
+    }
 
     addService("KeyGenerator", "AES", "keygeneratorspi.SecretKeyGenerator", false);
 
@@ -222,7 +227,10 @@ public final class AmazonCorrettoCryptoProvider extends java.security.Provider {
       addService("Signature", "EdDSA", "EvpSignatureRaw$Ed25519");
       addService("Signature", "Ed25519", "EvpSignatureRaw$Ed25519");
     }
-    addService("Signature", "ML-DSA", "EvpSignatureRaw$MlDSA");
+
+    if (!isFips() || isExperimentalFips()) {
+      addService("Signature", "ML-DSA", "EvpSignatureRaw$MlDSA");
+    }
   }
 
   private ACCPService addService(

--- a/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
+++ b/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
@@ -91,6 +91,10 @@ public final class AmazonCorrettoCryptoProvider extends java.security.Provider {
 
     addService("KeyFactory", "RSA", "EvpKeyFactory$RSA");
     addService("KeyFactory", "EC", "EvpKeyFactory$EC");
+    addService("KeyFactory", "ML-DSA", "EvpKeyFactory$MlDSA");
+    addService("KeyFactory", "ML-DSA-44", "EvpKeyFactory$MlDSA");
+    addService("KeyFactory", "ML-DSA-65", "EvpKeyFactory$MlDSA");
+    addService("KeyFactory", "ML-DSA-87", "EvpKeyFactory$MlDSA");
 
     if (shouldRegisterEdDSA) {
       // KeyFactories are used to convert key encodings to Java Key objects. ACCP's KeyFactory for
@@ -126,6 +130,11 @@ public final class AmazonCorrettoCryptoProvider extends java.security.Provider {
 
     addService("KeyPairGenerator", "RSA", "RsaGen");
     addService("KeyPairGenerator", "EC", "EcGen");
+
+    addService("KeyPairGenerator", "ML-DSA", "MlDsaGen$MlDsaGen44");
+    addService("KeyPairGenerator", "ML-DSA-44", "MlDsaGen$MlDsaGen44");
+    addService("KeyPairGenerator", "ML-DSA-65", "MlDsaGen$MlDsaGen65");
+    addService("KeyPairGenerator", "ML-DSA-87", "MlDsaGen$MlDsaGen87");
 
     addService("KeyGenerator", "AES", "keygeneratorspi.SecretKeyGenerator", false);
 
@@ -213,6 +222,7 @@ public final class AmazonCorrettoCryptoProvider extends java.security.Provider {
       addService("Signature", "EdDSA", "EvpSignatureRaw$Ed25519");
       addService("Signature", "Ed25519", "EvpSignatureRaw$Ed25519");
     }
+    addService("Signature", "ML-DSA", "EvpSignatureRaw$MlDSA");
   }
 
   private ACCPService addService(
@@ -714,6 +724,7 @@ public final class AmazonCorrettoCryptoProvider extends java.security.Provider {
   private transient volatile KeyFactory rsaFactory;
   private transient volatile KeyFactory ecFactory;
   private transient volatile KeyFactory edFactory;
+  private transient volatile KeyFactory mlDsaFactory;
 
   KeyFactory getKeyFactory(EvpKeyType keyType) {
     try {
@@ -733,8 +744,13 @@ public final class AmazonCorrettoCryptoProvider extends java.security.Provider {
             edFactory = new EdKeyFactory(this);
           }
           return edFactory;
+        case MlDSA:
+          if (mlDsaFactory == null) {
+            mlDsaFactory = KeyFactory.getInstance(keyType.jceName, this);
+          }
+          return mlDsaFactory;
         default:
-          throw new AssertionError("Unsupported key type");
+          throw new AssertionError(String.format("Unsupported key type: %s", keyType.jceName));
       }
     } catch (final NoSuchAlgorithmException ex) {
       throw new AssertionError(ex);

--- a/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
+++ b/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
@@ -63,6 +63,7 @@ public final class AmazonCorrettoCryptoProvider extends java.security.Provider {
   private final boolean shouldRegisterSecureRandom;
   private final boolean shouldRegisterEdDSA;
   private final boolean shouldRegisterEdKeyFactory;
+  private final boolean shouldRegisterMLDSA;
   private final Utils.NativeContextReleaseStrategy nativeContextReleaseStrategy;
 
   private transient SelfTestSuite selfTestSuite = new SelfTestSuite();
@@ -92,11 +93,12 @@ public final class AmazonCorrettoCryptoProvider extends java.security.Provider {
     addService("KeyFactory", "RSA", "EvpKeyFactory$RSA");
     addService("KeyFactory", "EC", "EvpKeyFactory$EC");
 
-    if (!isFips() || isExperimentalFips()) {
-      addService("KeyFactory", "ML-DSA", "EvpKeyFactory$MlDSA");
-      addService("KeyFactory", "ML-DSA-44", "EvpKeyFactory$MlDSA");
-      addService("KeyFactory", "ML-DSA-65", "EvpKeyFactory$MlDSA");
-      addService("KeyFactory", "ML-DSA-87", "EvpKeyFactory$MlDSA");
+
+    if (shouldRegisterMLDSA) {
+      addService("KeyFactory", "ML-DSA", "EvpKeyFactory$MLDSA");
+      addService("KeyFactory", "ML-DSA-44", "EvpKeyFactory$MLDSA");
+      addService("KeyFactory", "ML-DSA-65", "EvpKeyFactory$MLDSA");
+      addService("KeyFactory", "ML-DSA-87", "EvpKeyFactory$MLDSA");
     }
 
     if (shouldRegisterEdDSA) {
@@ -134,7 +136,7 @@ public final class AmazonCorrettoCryptoProvider extends java.security.Provider {
     addService("KeyPairGenerator", "RSA", "RsaGen");
     addService("KeyPairGenerator", "EC", "EcGen");
 
-    if (!isFips() || isExperimentalFips()) {
+    if (shouldRegisterMLDSA) {
       addService("KeyPairGenerator", "ML-DSA", "MlDsaGen$MlDsaGen44");
       addService("KeyPairGenerator", "ML-DSA-44", "MlDsaGen$MlDsaGen44");
       addService("KeyPairGenerator", "ML-DSA-65", "MlDsaGen$MlDsaGen65");
@@ -228,8 +230,8 @@ public final class AmazonCorrettoCryptoProvider extends java.security.Provider {
       addService("Signature", "Ed25519", "EvpSignatureRaw$Ed25519");
     }
 
-    if (!isFips() || isExperimentalFips()) {
-      addService("Signature", "ML-DSA", "EvpSignatureRaw$MlDSA");
+    if (shouldRegisterMLDSA) {
+      addService("Signature", "ML-DSA", "EvpSignatureRaw$MLDSA");
     }
   }
 
@@ -519,6 +521,8 @@ public final class AmazonCorrettoCryptoProvider extends java.security.Provider {
     this.shouldRegisterEdKeyFactory =
         Utils.getBooleanProperty(PROPERTY_REGISTER_ED_KEYFACTORY, false);
 
+    this.shouldRegisterMLDSA = (!isFips() || isExperimentalFips());
+
     this.nativeContextReleaseStrategy = Utils.getNativeContextReleaseStrategyProperty();
 
     Utils.optionsFromProperty(ExtraCheck.class, extraChecks, "extrachecks");
@@ -752,7 +756,7 @@ public final class AmazonCorrettoCryptoProvider extends java.security.Provider {
             edFactory = new EdKeyFactory(this);
           }
           return edFactory;
-        case MlDSA:
+        case MLDSA:
           if (mlDsaFactory == null) {
             mlDsaFactory = KeyFactory.getInstance(keyType.jceName, this);
           }

--- a/src/com/amazon/corretto/crypto/provider/EvpKeyFactory.java
+++ b/src/com/amazon/corretto/crypto/provider/EvpKeyFactory.java
@@ -333,9 +333,9 @@ abstract class EvpKeyFactory extends KeyFactorySpi {
     }
   }
 
-  static class MlDSA extends StandardEvpKeyFactory {
-    MlDSA(AmazonCorrettoCryptoProvider provider) {
-      super(EvpKeyType.MlDSA, provider);
+  static class MLDSA extends StandardEvpKeyFactory {
+    MLDSA(AmazonCorrettoCryptoProvider provider) {
+      super(EvpKeyType.MLDSA, provider);
     }
   }
 }

--- a/src/com/amazon/corretto/crypto/provider/EvpKeyFactory.java
+++ b/src/com/amazon/corretto/crypto/provider/EvpKeyFactory.java
@@ -128,8 +128,9 @@ abstract class EvpKeyFactory extends KeyFactorySpi {
   }
 
   protected boolean keyNeedsConversion(Key key) throws InvalidKeyException {
-    if (!type.jceName.equalsIgnoreCase(key.getAlgorithm())) {
-      throw new InvalidKeyException("Incorrect key algorithm: " + key.getAlgorithm());
+    if (key.getAlgorithm() == null || !key.getAlgorithm().startsWith(type.jceName)) {
+      throw new InvalidKeyException(
+          "Incorrect key algorithm: " + key.getAlgorithm() + ". Expected: " + type.jceName);
     }
     return !(key instanceof EvpKey);
   }
@@ -303,10 +304,9 @@ abstract class EvpKeyFactory extends KeyFactorySpi {
     }
   }
 
-  static class EdDSA extends EvpKeyFactory {
-
-    EdDSA(AmazonCorrettoCryptoProvider provider) {
-      super(EvpKeyType.EdDSA, provider);
+  private abstract static class StandardEvpKeyFactory extends EvpKeyFactory {
+    StandardEvpKeyFactory(EvpKeyType type, AmazonCorrettoCryptoProvider provider) {
+      super(type, provider);
     }
 
     @Override
@@ -324,6 +324,18 @@ abstract class EvpKeyFactory extends KeyFactorySpi {
     protected <T extends KeySpec> T engineGetKeySpec(final Key key, final Class<T> keySpec)
         throws InvalidKeySpecException {
       return super.engineGetKeySpec(key, keySpec);
+    }
+  }
+
+  static class EdDSA extends StandardEvpKeyFactory {
+    EdDSA(AmazonCorrettoCryptoProvider provider) {
+      super(EvpKeyType.EdDSA, provider);
+    }
+  }
+
+  static class MlDSA extends StandardEvpKeyFactory {
+    MlDSA(AmazonCorrettoCryptoProvider provider) {
+      super(EvpKeyType.MlDSA, provider);
     }
   }
 }

--- a/src/com/amazon/corretto/crypto/provider/EvpKeyType.java
+++ b/src/com/amazon/corretto/crypto/provider/EvpKeyType.java
@@ -19,7 +19,7 @@ enum EvpKeyType {
   RSA("RSA", 6, RSAPublicKey.class, RSAPrivateKey.class),
   EC("EC", 408, ECPublicKey.class, ECPrivateKey.class),
   EdDSA("EdDSA", 949, PublicKey.class, PrivateKey.class),
-  MlDSA("ML-DSA", 993, PublicKey.class, PrivateKey.class);
+  MLDSA("ML-DSA", 993, PublicKey.class, PrivateKey.class);
 
   final String jceName;
   final int nativeValue;
@@ -59,7 +59,7 @@ enum EvpKeyType {
         return new EvpEcPrivateKey(fn.applyAsLong(der.getEncoded(), nativeValue));
       case EdDSA:
         return new EvpEdPrivateKey(fn.applyAsLong(der.getEncoded(), nativeValue));
-      case MlDSA:
+      case MLDSA:
         return new EvpMlDsaPrivateKey(fn.applyAsLong(der.getEncoded(), nativeValue));
       default:
         throw new AssertionError("Unsupported key type");
@@ -76,7 +76,7 @@ enum EvpKeyType {
         return new EvpEcPublicKey(fn.applyAsLong(der.getEncoded(), nativeValue));
       case EdDSA:
         return new EvpEdPublicKey(fn.applyAsLong(der.getEncoded(), nativeValue));
-      case MlDSA:
+      case MLDSA:
         return new EvpMlDsaPublicKey(fn.applyAsLong(der.getEncoded(), nativeValue));
       default:
         throw new AssertionError("Unsupported key type");

--- a/src/com/amazon/corretto/crypto/provider/EvpKeyType.java
+++ b/src/com/amazon/corretto/crypto/provider/EvpKeyType.java
@@ -18,7 +18,8 @@ import java.util.Map;
 enum EvpKeyType {
   RSA("RSA", 6, RSAPublicKey.class, RSAPrivateKey.class),
   EC("EC", 408, ECPublicKey.class, ECPrivateKey.class),
-  EdDSA("EdDSA", 949, PublicKey.class, PrivateKey.class);
+  EdDSA("EdDSA", 949, PublicKey.class, PrivateKey.class),
+  MlDSA("ML-DSA", 993, PublicKey.class, PrivateKey.class);
 
   final String jceName;
   final int nativeValue;
@@ -58,6 +59,8 @@ enum EvpKeyType {
         return new EvpEcPrivateKey(fn.applyAsLong(der.getEncoded(), nativeValue));
       case EdDSA:
         return new EvpEdPrivateKey(fn.applyAsLong(der.getEncoded(), nativeValue));
+      case MlDSA:
+        return new EvpMlDsaPrivateKey(fn.applyAsLong(der.getEncoded(), nativeValue));
       default:
         throw new AssertionError("Unsupported key type");
     }
@@ -73,6 +76,8 @@ enum EvpKeyType {
         return new EvpEcPublicKey(fn.applyAsLong(der.getEncoded(), nativeValue));
       case EdDSA:
         return new EvpEdPublicKey(fn.applyAsLong(der.getEncoded(), nativeValue));
+      case MlDSA:
+        return new EvpMlDsaPublicKey(fn.applyAsLong(der.getEncoded(), nativeValue));
       default:
         throw new AssertionError("Unsupported key type");
     }

--- a/src/com/amazon/corretto/crypto/provider/EvpMlDsaKey.java
+++ b/src/com/amazon/corretto/crypto/provider/EvpMlDsaKey.java
@@ -1,0 +1,11 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package com.amazon.corretto.crypto.provider;
+
+abstract class EvpMlDsaKey extends EvpKey {
+  private static final long serialVersionUID = 1;
+
+  EvpMlDsaKey(InternalKey key, final boolean isPublicKey) {
+    super(key, EvpKeyType.MlDSA, isPublicKey);
+  }
+}

--- a/src/com/amazon/corretto/crypto/provider/EvpMlDsaKey.java
+++ b/src/com/amazon/corretto/crypto/provider/EvpMlDsaKey.java
@@ -6,6 +6,6 @@ abstract class EvpMlDsaKey extends EvpKey {
   private static final long serialVersionUID = 1;
 
   EvpMlDsaKey(InternalKey key, final boolean isPublicKey) {
-    super(key, EvpKeyType.MlDSA, isPublicKey);
+    super(key, EvpKeyType.MLDSA, isPublicKey);
   }
 }

--- a/src/com/amazon/corretto/crypto/provider/EvpMlDsaPrivateKey.java
+++ b/src/com/amazon/corretto/crypto/provider/EvpMlDsaPrivateKey.java
@@ -1,0 +1,25 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package com.amazon.corretto.crypto.provider;
+
+import java.security.PrivateKey;
+
+class EvpMlDsaPrivateKey extends EvpMlDsaKey implements PrivateKey {
+  private static final long serialVersionUID = 1;
+
+  EvpMlDsaPrivateKey(final long ptr) {
+    this(new InternalKey(ptr));
+  }
+
+  EvpMlDsaPrivateKey(final InternalKey key) {
+    super(key, false);
+  }
+
+  public EvpMlDsaPublicKey getPublicKey() {
+    this.ephemeral = false;
+    this.sharedKey = true;
+    final EvpMlDsaPublicKey result = new EvpMlDsaPublicKey(internalKey);
+    result.sharedKey = true;
+    return result;
+  }
+}

--- a/src/com/amazon/corretto/crypto/provider/EvpMlDsaPublicKey.java
+++ b/src/com/amazon/corretto/crypto/provider/EvpMlDsaPublicKey.java
@@ -4,14 +4,14 @@ package com.amazon.corretto.crypto.provider;
 
 import java.security.PublicKey;
 
-class EvpEdPublicKey extends EvpEdKey implements PublicKey {
+class EvpMlDsaPublicKey extends EvpMlDsaKey implements PublicKey {
   private static final long serialVersionUID = 1;
 
-  EvpEdPublicKey(final long ptr) {
+  EvpMlDsaPublicKey(final long ptr) {
     this(new InternalKey(ptr));
   }
 
-  EvpEdPublicKey(final InternalKey key) {
+  EvpMlDsaPublicKey(final InternalKey key) {
     super(key, true);
   }
 }

--- a/src/com/amazon/corretto/crypto/provider/EvpSignatureBase.java
+++ b/src/com/amazon/corretto/crypto/provider/EvpSignatureBase.java
@@ -103,8 +103,11 @@ abstract class EvpSignatureBase extends SignatureSpi {
     }
 
     if (untranslatedKey_ != privateKey) {
-      if (!keyType_.jceName.equalsIgnoreCase(privateKey.getAlgorithm())) {
-        throw new InvalidKeyException();
+      if (!keyType_.jceName.equalsIgnoreCase(privateKey.getAlgorithm())
+          && !privateKey.getAlgorithm().startsWith(keyType_.jceName)) {
+        throw new InvalidKeyException(
+            String.format(
+                "Invalid algorithm: %s, expected %s", privateKey.getAlgorithm(), keyType_.jceName));
       }
       keyUsageCount_ = 0;
       untranslatedKey_ = privateKey;
@@ -125,7 +128,8 @@ abstract class EvpSignatureBase extends SignatureSpi {
     }
 
     if (untranslatedKey_ != publicKey) {
-      if (!keyType_.jceName.equalsIgnoreCase(publicKey.getAlgorithm())) {
+      if (!keyType_.jceName.equalsIgnoreCase(publicKey.getAlgorithm())
+          && !publicKey.getAlgorithm().startsWith(keyType_.jceName)) {
         throw new InvalidKeyException();
       }
       keyUsageCount_ = 0;

--- a/src/com/amazon/corretto/crypto/provider/EvpSignatureRaw.java
+++ b/src/com/amazon/corretto/crypto/provider/EvpSignatureRaw.java
@@ -114,4 +114,10 @@ class EvpSignatureRaw extends EvpSignatureBase {
       super(provider, EvpKeyType.EdDSA, 0);
     }
   }
+
+  static final class MlDSA extends EvpSignatureRaw {
+    MlDSA(final AmazonCorrettoCryptoProvider provider) {
+      super(provider, EvpKeyType.MlDSA, 0);
+    }
+  }
 }

--- a/src/com/amazon/corretto/crypto/provider/EvpSignatureRaw.java
+++ b/src/com/amazon/corretto/crypto/provider/EvpSignatureRaw.java
@@ -115,9 +115,9 @@ class EvpSignatureRaw extends EvpSignatureBase {
     }
   }
 
-  static final class MlDSA extends EvpSignatureRaw {
-    MlDSA(final AmazonCorrettoCryptoProvider provider) {
-      super(provider, EvpKeyType.MlDSA, 0);
+  static final class MLDSA extends EvpSignatureRaw {
+    MLDSA(final AmazonCorrettoCryptoProvider provider) {
+      super(provider, EvpKeyType.MLDSA, 0);
     }
   }
 }

--- a/src/com/amazon/corretto/crypto/provider/MlDsaGen.java
+++ b/src/com/amazon/corretto/crypto/provider/MlDsaGen.java
@@ -1,0 +1,63 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package com.amazon.corretto.crypto.provider;
+
+import java.security.KeyPair;
+import java.security.KeyPairGeneratorSpi;
+import java.security.SecureRandom;
+import java.security.spec.AlgorithmParameterSpec;
+
+class MlDsaGen extends KeyPairGeneratorSpi {
+  /** Generates a new ML-DSA key and returns a pointer to it. */
+  private static native long generateEvpMlDsaKey(int nid);
+
+  private final AmazonCorrettoCryptoProvider provider_;
+  private int type_ = -1;
+
+  private MlDsaGen(AmazonCorrettoCryptoProvider provider, Integer type) {
+    Loader.checkNativeLibraryAvailability();
+    provider_ = provider;
+    type_ = type;
+  }
+
+  MlDsaGen(AmazonCorrettoCryptoProvider provider) {
+    this(provider, null);
+  }
+
+  public void initialize(AlgorithmParameterSpec params, final SecureRandom random) {
+    throw new UnsupportedOperationException();
+  }
+
+  public void initialize(final int keysize, final SecureRandom random) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public KeyPair generateKeyPair() {
+    if (type_ < 0) {
+      throw new IllegalStateException("Key type not set");
+    }
+    long pkey_ptr = generateEvpMlDsaKey(type_);
+    final EvpMlDsaPrivateKey privateKey = new EvpMlDsaPrivateKey(pkey_ptr);
+    final EvpMlDsaPublicKey publicKey = privateKey.getPublicKey();
+    return new KeyPair(publicKey, privateKey);
+  }
+
+  public static final class MlDsaGen44 extends MlDsaGen {
+    public MlDsaGen44(AmazonCorrettoCryptoProvider provider) {
+      super(provider, 2);
+    }
+  }
+
+  public static final class MlDsaGen65 extends MlDsaGen {
+    public MlDsaGen65(AmazonCorrettoCryptoProvider provider) {
+      super(provider, 3);
+    }
+  }
+
+  public static final class MlDsaGen87 extends MlDsaGen {
+    public MlDsaGen87(AmazonCorrettoCryptoProvider provider) {
+      super(provider, 5);
+    }
+  }
+}

--- a/src/com/amazon/corretto/crypto/provider/MlDsaGen.java
+++ b/src/com/amazon/corretto/crypto/provider/MlDsaGen.java
@@ -9,15 +9,19 @@ import java.security.spec.AlgorithmParameterSpec;
 
 class MlDsaGen extends KeyPairGeneratorSpi {
   /** Generates a new ML-DSA key and returns a pointer to it. */
-  private static native long generateEvpMlDsaKey(int nid);
+  private static native long generateEvpMlDsaKey(int level);
 
   private final AmazonCorrettoCryptoProvider provider_;
-  private int type_ = -1;
+  /**
+   * level_ corresponds to the purported NIST security level for each ML-DSA variant. It uniquely
+   * determines which NID is used to request an ML-DSA key. -1 indicates it is uninitialized.
+   */
+  private int level_ = -1;
 
-  private MlDsaGen(AmazonCorrettoCryptoProvider provider, Integer type) {
+  private MlDsaGen(AmazonCorrettoCryptoProvider provider, Integer level) {
     Loader.checkNativeLibraryAvailability();
     provider_ = provider;
-    type_ = type;
+    level_ = level;
   }
 
   MlDsaGen(AmazonCorrettoCryptoProvider provider) {
@@ -34,10 +38,10 @@ class MlDsaGen extends KeyPairGeneratorSpi {
 
   @Override
   public KeyPair generateKeyPair() {
-    if (type_ < 0) {
+    if (level_ < 0) {
       throw new IllegalStateException("Key type not set");
     }
-    long pkey_ptr = generateEvpMlDsaKey(type_);
+    long pkey_ptr = generateEvpMlDsaKey(level_);
     final EvpMlDsaPrivateKey privateKey = new EvpMlDsaPrivateKey(pkey_ptr);
     final EvpMlDsaPublicKey publicKey = privateKey.getPublicKey();
     return new KeyPair(publicKey, privateKey);

--- a/tst/com/amazon/corretto/crypto/provider/test/EvpKeyFactoryTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/EvpKeyFactoryTest.java
@@ -86,7 +86,13 @@ public class EvpKeyFactoryTest {
     }
 
     for (String algorithm : ALGORITHMS) {
-      KeyPairGenerator kpg = KeyPairGenerator.getInstance(algorithm);
+      KeyPairGenerator kpg;
+      if (algorithm.startsWith("ML-DSA")) {
+        // JCE doesn't support ML-DSA until JDK24, so use BouncyCastle until then
+        kpg = KeyPairGenerator.getInstance(algorithm, TestUtil.BC_PROVIDER);
+      } else {
+        kpg = KeyPairGenerator.getInstance(algorithm);
+      }
       List<Arguments> keys = new ArrayList<>();
       if (algorithm.equals("EC")) {
         // Different curves can excercise different areas of ASN.1/DER and so should all be tested.
@@ -226,7 +232,13 @@ public class EvpKeyFactoryTest {
     final String algorithm = pubKey.getAlgorithm();
 
     final KeyFactory nativeFactory = KeyFactory.getInstance(algorithm, NATIVE_PROVIDER);
-    final KeyFactory jceFactory = KeyFactory.getInstance(algorithm);
+    final KeyFactory jceFactory;
+    if (algorithm.startsWith("ML-DSA")) {
+      // JCE doesn't support ML-DSA until JDK24, so use BouncyCastle until then
+      jceFactory = KeyFactory.getInstance(algorithm, TestUtil.BC_PROVIDER);
+    } else {
+      jceFactory = KeyFactory.getInstance(algorithm);
+    }
 
     final X509EncodedKeySpec nativeSpec =
         nativeFactory.getKeySpec(pubKey, X509EncodedKeySpec.class);
@@ -295,7 +307,13 @@ public class EvpKeyFactoryTest {
     final String algorithm = privKey.getAlgorithm();
 
     final KeyFactory nativeFactory = KeyFactory.getInstance(algorithm, NATIVE_PROVIDER);
-    final KeyFactory jceFactory = KeyFactory.getInstance(algorithm);
+    final KeyFactory jceFactory;
+    if (algorithm.startsWith("ML-DSA")) {
+      // JCE doesn't support ML-DSA until JDK24, so use BouncyCastle until then
+      jceFactory = KeyFactory.getInstance(algorithm, TestUtil.BC_PROVIDER);
+    } else {
+      jceFactory = KeyFactory.getInstance(algorithm);
+    }
 
     final PKCS8EncodedKeySpec nativeSpec =
         nativeFactory.getKeySpec(privKey, PKCS8EncodedKeySpec.class);

--- a/tst/com/amazon/corretto/crypto/provider/test/EvpSignatureSpecificTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/EvpSignatureSpecificTest.java
@@ -659,8 +659,8 @@ public final class EvpSignatureSpecificTest {
       if (!service.getType().equals("Signature") || "RSASSA-PSS".equals(algorithm)) {
         continue;
       }
-      if (algorithm.equals("Ed25519") || algorithm.equals("EdDSA")) {
-        return;
+      if (algorithm.equals("Ed25519") || algorithm.equals("EdDSA") || algorithm.equals("ML-DSA")) {
+        continue;
       }
       String bcAlgorithm = algorithm;
       AlgorithmParameterSpec keyGenSpec = null;

--- a/tst/com/amazon/corretto/crypto/provider/test/MLDSATest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/MLDSATest.java
@@ -34,11 +34,11 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
-@DisabledIf("com.amazon.corretto.crypto.provider.test.MlDSATest#isDisabled")
+@DisabledIf("com.amazon.corretto.crypto.provider.test.MLDSATest#isDisabled")
 @Execution(ExecutionMode.CONCURRENT)
 @ExtendWith(TestResultLogger.class)
 @ResourceLock(value = TestUtil.RESOURCE_GLOBAL, mode = ResourceAccessMode.READ)
-public class MlDSATest {
+public class MLDSATest {
   private static final Provider NATIVE_PROVIDER = AmazonCorrettoCryptoProvider.INSTANCE;
   private static final int[] MESSAGE_LENGTHS = new int[] {0, 1, 16, 32, 2047, 2048, 2049, 4100};
 

--- a/tst/com/amazon/corretto/crypto/provider/test/MlDSATest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/MlDSATest.java
@@ -1,0 +1,198 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package com.amazon.corretto.crypto.provider.test;
+
+import static com.amazon.corretto.crypto.provider.test.TestUtil.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.amazon.corretto.crypto.provider.AmazonCorrettoCryptoProvider;
+import java.security.InvalidKeyException;
+import java.security.KeyFactory;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.PrivateKey;
+import java.security.Provider;
+import java.security.PublicKey;
+import java.security.Signature;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.security.spec.X509EncodedKeySpec;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+@Execution(ExecutionMode.CONCURRENT)
+@ExtendWith(TestResultLogger.class)
+@ResourceLock(value = TestUtil.RESOURCE_GLOBAL, mode = ResourceAccessMode.READ)
+public class MlDSATest {
+  private static final Provider NATIVE_PROVIDER = AmazonCorrettoCryptoProvider.INSTANCE;
+  private static final int[] MESSAGE_LENGTHS = new int[] {0, 1, 16, 32, 2047, 2048, 2049, 4100};
+
+  private static class TestParams {
+    private final Provider signerProv;
+    private final Provider verifierProv;
+    private final PrivateKey priv;
+    private final PublicKey pub;
+    private final byte[] message;
+
+    public TestParams(
+        Provider signerProv,
+        Provider verifierProv,
+        PrivateKey priv,
+        PublicKey pub,
+        byte[] message) {
+      this.signerProv = signerProv;
+      this.verifierProv = verifierProv;
+      this.priv = priv;
+      this.pub = pub;
+      this.message = message;
+    }
+
+    public String toString() {
+      return String.format(
+          "signer: %s, verifier: %s, message size: %d",
+          signerProv.getName(), verifierProv.getName(), message.length);
+    }
+  }
+
+  private static List<TestParams> getParams() throws Exception {
+    List<TestParams> params = new ArrayList<TestParams>();
+    for (String algo : new String[] {"ML-DSA-44", "ML-DSA-65", "ML-DSA-87"}) {
+      for (int messageSize : MESSAGE_LENGTHS) {
+        KeyPair keyPair = KeyPairGenerator.getInstance(algo, NATIVE_PROVIDER).generateKeyPair();
+        PublicKey nativePub = keyPair.getPublic();
+        PrivateKey nativePriv = keyPair.getPrivate();
+
+        // Convert ACCP native key to BouncyCastle key, as BouncyCastle ML-DSA Signatures don't
+        // support non-Bouncy-Castle keys.
+        KeyFactory bcKf = KeyFactory.getInstance("ML-DSA", TestUtil.BC_PROVIDER);
+        PublicKey bcPub = bcKf.generatePublic(new X509EncodedKeySpec(nativePub.getEncoded()));
+        PrivateKey bcPriv = bcKf.generatePrivate(new PKCS8EncodedKeySpec(nativePriv.getEncoded()));
+
+        Provider nativeProv = NATIVE_PROVIDER;
+        Provider bcProv = TestUtil.BC_PROVIDER;
+
+        byte[] message = new byte[messageSize];
+        Arrays.fill(message, (byte) 'A');
+
+        params.add(new TestParams(nativeProv, nativeProv, nativePriv, nativePub, message));
+        params.add(new TestParams(nativeProv, bcProv, nativePriv, bcPub, message));
+        params.add(new TestParams(bcProv, nativeProv, bcPriv, nativePub, message));
+        params.add(new TestParams(bcProv, bcProv, bcPriv, bcPub, message));
+      }
+    }
+    return params;
+  }
+
+  @ParameterizedTest
+  @MethodSource("getParams")
+  public void testInteropRoundTrips(TestParams params) throws Exception {
+    Signature signer = Signature.getInstance("ML-DSA", params.signerProv);
+    Signature verifier = Signature.getInstance("ML-DSA", params.verifierProv);
+    PrivateKey priv = params.priv;
+    PublicKey pub = params.pub;
+    byte[] message = Arrays.copyOf(params.message, params.message.length);
+
+    signer.initSign(priv);
+    signer.update(message);
+    byte[] signatureBytes = signer.sign();
+    verifier.initVerify(pub);
+    verifier.update(message);
+    assertTrue(verifier.verify(signatureBytes));
+
+    // Because ACCP's ML-DSA uses per-signature randomness, its signatures over identical inputs
+    // should be unique.
+    if (signer.getProvider() == NATIVE_PROVIDER) {
+      signer.initSign(priv);
+      signer.update(message);
+      byte[] secondSignatureBytes = signer.sign();
+      assertFalse(Arrays.equals(signatureBytes, secondSignatureBytes));
+    }
+
+    // Verifying a different message should result in verification failure
+    if (message.length > 0) {
+      signer.initSign(priv);
+      signer.update(message);
+      signatureBytes = signer.sign();
+      verifier.initVerify(pub);
+      byte[] otherMessage = Arrays.copyOf(message, message.length);
+      otherMessage[0] ^= 0xff; // flip all bits in the first byte
+      verifier.update(otherMessage);
+      assertFalse(verifier.verify(signatureBytes));
+    }
+
+    // Corrupting the signature should result in verification failure
+    signer.initSign(priv);
+    signer.update(message);
+    signatureBytes = signer.sign();
+    verifier.initVerify(pub);
+    verifier.update(message);
+    signatureBytes[0] ^= 0xff; // flip all bits in the first byte
+    assertFalse(verifier.verify(signatureBytes));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"ML-DSA-44", "ML-DSA-65", "ML-DSA-87"})
+  public void testKeyGeneration(String algo) throws Exception {
+    KeyPairGenerator keyGen = KeyPairGenerator.getInstance(algo, NATIVE_PROVIDER);
+    KeyPair keyPair = keyGen.generateKeyPair();
+
+    assertNotNull(keyPair);
+    assertNotNull(keyPair.getPrivate());
+    assertNotNull(keyPair.getPublic());
+    assertEquals("ML-DSA", keyPair.getPrivate().getAlgorithm());
+    assertEquals("ML-DSA", keyPair.getPublic().getAlgorithm());
+  }
+
+  @Test
+  public void testKeyFactorySelfConversion() throws Exception {
+    KeyPairGenerator keyGen = KeyPairGenerator.getInstance("ML-DSA", NATIVE_PROVIDER);
+    KeyPair originalKeyPair = keyGen.generateKeyPair();
+
+    KeyFactory keyFactory = KeyFactory.getInstance("ML-DSA", NATIVE_PROVIDER);
+
+    byte[] publicKeyEncoded = originalKeyPair.getPublic().getEncoded();
+    PublicKey publicKey = keyFactory.generatePublic(new X509EncodedKeySpec(publicKeyEncoded));
+    assertArrayEquals(publicKeyEncoded, publicKey.getEncoded());
+
+    byte[] privateKeyEncoded = originalKeyPair.getPrivate().getEncoded();
+    PrivateKey privateKey = keyFactory.generatePrivate(new PKCS8EncodedKeySpec(privateKeyEncoded));
+    assertArrayEquals(privateKeyEncoded, privateKey.getEncoded());
+  }
+
+  @Test
+  public void testInvalidKeyInitialization() {
+    assertThrows(
+        InvalidKeyException.class,
+        () -> {
+          KeyPair rsaKeys = KeyPairGenerator.getInstance("RSA").generateKeyPair();
+          Signature sig = Signature.getInstance("ML-DSA", NATIVE_PROVIDER);
+          sig.initSign(rsaKeys.getPrivate());
+        });
+
+    assertThrows(
+        InvalidKeyException.class,
+        () -> {
+          KeyPair rsaKeys = KeyPairGenerator.getInstance("RSA").generateKeyPair();
+          Signature sig = Signature.getInstance("ML-DSA", NATIVE_PROVIDER);
+          sig.initVerify(rsaKeys.getPublic());
+        });
+  }
+
+  @Test
+  public void codifyBcDifferences() {
+    // TODO [childw] hard-coded test to document de/serialization tests between ACCP and BC
+  }
+}

--- a/tst/com/amazon/corretto/crypto/provider/test/MlDSATest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/MlDSATest.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIf;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
@@ -33,12 +34,19 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
+@DisabledIf("com.amazon.corretto.crypto.provider.test.MlDSATest#isDisabled")
 @Execution(ExecutionMode.CONCURRENT)
 @ExtendWith(TestResultLogger.class)
 @ResourceLock(value = TestUtil.RESOURCE_GLOBAL, mode = ResourceAccessMode.READ)
 public class MlDSATest {
   private static final Provider NATIVE_PROVIDER = AmazonCorrettoCryptoProvider.INSTANCE;
   private static final int[] MESSAGE_LENGTHS = new int[] {0, 1, 16, 32, 2047, 2048, 2049, 4100};
+
+  // TODO: remove this disablement when ACCP consumes an AWS-LC-FIPS release with ML-DSA
+  public static boolean isDisabled() {
+    return AmazonCorrettoCryptoProvider.INSTANCE.isFips()
+        && !AmazonCorrettoCryptoProvider.INSTANCE.isExperimentalFips();
+  }
 
   private static class TestParams {
     private final Provider signerProv;


### PR DESCRIPTION
*Issue #, if available:* i/ACCP-100

*Description of changes:*

# Overview

This PR exposes ML-DSA functionality through the Signature, KeyPairGenerator, and KeyFactory JCA interfaces. The implementation closely follows [our Ed25519 implementation](https://github.com/corretto/amazon-corretto-crypto-provider/commit/0bfd4f278f07a7ee4f1b82070b650af5c0958279#diff-797ef5bd8c859f6e598eb60150c9cf5aae1b21f02b968288beb4be766f0b28aaR344), as both algorithms are currently used through AWS-LC's `EVP_DigestSign` API initialized with a `NULL` message digest (these newer algorithms use a fixed, non-parameterizable digest function per spec).

We also provide benchmarks for key generation, signing, and verifying.

# Interoperability

This change has been written to be interoperable and forwards-compatible with other JCA provider ML-DSA implementations, such as [BouncyCastle's](https://github.com/bcgit/bc-java/tree/8b813e11536eddea8a2efc370ee7db0ddadcd97c/prov/src/main/java/org/bouncycastle/jcajce/provider/asymmetric/mldsa) and OpenJDK's [JEP 497](https://openjdk.org/jeps/497).

This means that ACCP callers cannot use JDK's [NamedParameterSpec classes](https://github.com/openjdk/jdk/blob/master/src/java.base/share/classes/java/security/spec/NamedParameterSpec.java#L72-L94) or BouncyCastle's [MLDSAParameterSpec](https://github.com/bcgit/bc-java/blob/main/prov/src/main/java/org/bouncycastle/jcajce/spec/MLDSAParameterSpec.java), but allows ACCP to provide ML-DSA on supported LTS JDK versions, independent of other providers. Instead of using ParameterSpec classes, callers can request a specific security level via the algorithm name passed into `KeyPairGenerator.getInstance` (if no level is specified, `"ML-DSA-44"` is the default):

```
KeyPairGenerator g = KeyPairGenerator.getInstance("ML-DSA-87");
KeyPair kp = g.generateKeyPair(); // an ML-DSA-87 key pair

g = KeyPairGenerator.getInstance("ML-DSA");
kp = g.generateKeyPair(); // an ML-DSA-44 key pair
```

We also update our BouncyCastle test dependency to 1.80, allowing us to pefrorm interoperability tests with BouncyCastle's ML-DSA implementation.

## Limitations

As mentioned above, ACCP does not currently support [ParameterSpec-based initialization](https://docs.oracle.com/javase/8/docs/api/java/security/KeyPairGenerator.html#initialize-java.security.spec.AlgorithmParameterSpec-java.security.SecureRandom-) on `KeyPairGenerator` instances. We also don't support `keysize`-based initialization as it is somewhat ambiguous for ML-DSA. These limitations may change in the future.

ACCP's ML-DSA keys cannot be used directly with BouncyCastle [KeyFactory](https://github.com/bcgit/bc-java/blob/8b813e11536eddea8a2efc370ee7db0ddadcd97c/prov/src/main/java/org/bouncycastle/jcajce/provider/asymmetric/mldsa/MLDSAKeyFactorySpi.java#L112) or [Signature](https://github.com/bcgit/bc-java/blob/8b813e11536eddea8a2efc370ee7db0ddadcd97c/prov/src/main/java/org/bouncycastle/jcajce/provider/asymmetric/mldsa/SignatureSpi.java#L83) instances, as BouncyCastle only supports its own keys today. To use ACCP keys with BouncyCastle, callers will need to serialize them into `X509EncodedKeySpec` or `PKCS8EncodedKeySpec` instances and pass those to BouncyCastle's `KeyFactory` for conversion.

Finally, ACCP cannot yet deserialize ML-DSA private keys serialized by BouncyCastle. BouncyCastle currently encodes the private key's 32 byte seed upon serialization, while ACCP expects the fully expanded private key material.

# Future Work

- Migrate to streaming APIs in AWS-LC (we currently buffer entire message in memory)
- Support deserializing private key seeds (e.g. from BouncyCastle) and expanding them (this will require AWS-LC supporting ibid., we're actively working on this)
- Add ML-DSA to EvpSignatureTest suite (unblocked once we can parse BouncyCastle keys per above)
- Interoperability tests with JDK 24 (once we support that version)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
