### PR TITLE
Use ACCP for ML-DSA in EvpKeyFactoryTest (for now)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 * [PR 394:](https://github.com/corretto/amazon-corretto-crypto-provider/pull/394) Support for Ed25519 DSA
 * [PR 421:](https://github.com/corretto/amazon-corretto-crypto-provider/pull/421) Bump AWS-LC version to 1.42.0 and AWS-LC-FIPS version to 3.0.0
 * [PR 422:](https://github.com/corretto/amazon-corretto-crypto-provider/pull/422) Support "pure" ML-DSA, Bump AWS-LC version to 1.43.0
+* [PR 423:](https://github.com/corretto/amazon-corretto-crypto-provider/pull/423) Support "External Mu" ML-DSA
+* [PR 424:](https://github.com/corretto/amazon-corretto-crypto-provider/pull/424) Use ACCP for ML-DSA in EvpKeyFactoryTest (for now)
 
 ## 2.4.1
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ ACCP did not track a FIPS branch/release version of AWS-LC until ACCP v2.3.0. Be
 | 2.3.3               | 1.17.0         | 2.0.2               |
 | 2.4.0               | 1.30.1         | 2.0.13              |
 | 2.4.1               | 1.30.1         | 2.0.13              |
-| 2.5.0               | 1.43.0         | 3.0.0               |
+| 2.5.0               | 1.44.0         | 3.0.0               |
 
 Notable differences between ACCP and ACCP-FIPS:
 * ACCP uses [the latest release of AWS-LC](https://github.com/aws/aws-lc/releases), whereas, ACCP-FIPS uses [the fips-2022-11-02 branch of AWS-LC](https://github.com/aws/aws-lc/tree/fips-2022-11-02).

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ if (ext.isExperimentalFips) {
 
 if (ext.isExperimentalFips || !ext.isFips) {
     // Experimental FIPS uses the same AWS-LC version as non-FIPS builds.
-    ext.awsLcGitVersionId = 'v1.43.0'
+    ext.awsLcGitVersionId = 'v1.44.0'
 } else {
     ext.awsLcGitVersionId = 'AWS-LC-FIPS-3.0.0'
 }

--- a/tst/com/amazon/corretto/crypto/provider/test/EvpKeyFactoryTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/EvpKeyFactoryTest.java
@@ -88,8 +88,10 @@ public class EvpKeyFactoryTest {
     for (String algorithm : ALGORITHMS) {
       KeyPairGenerator kpg;
       if (algorithm.startsWith("ML-DSA")) {
-        // JCE doesn't support ML-DSA until JDK24, so use BouncyCastle until then
-        kpg = KeyPairGenerator.getInstance(algorithm, TestUtil.BC_PROVIDER);
+        // JCE doesn't support ML-DSA until JDK24, and BouncyCastle currently
+        // serializes ML-DSA private keys via seeds. TODO: switch to
+        // BouncyCastle once we support deserializing private keys from seed.
+        kpg = KeyPairGenerator.getInstance(algorithm, NATIVE_PROVIDER);
       } else {
         kpg = KeyPairGenerator.getInstance(algorithm);
       }
@@ -234,8 +236,10 @@ public class EvpKeyFactoryTest {
     final KeyFactory nativeFactory = KeyFactory.getInstance(algorithm, NATIVE_PROVIDER);
     final KeyFactory jceFactory;
     if (algorithm.startsWith("ML-DSA")) {
-      // JCE doesn't support ML-DSA until JDK24, so use BouncyCastle until then
-      jceFactory = KeyFactory.getInstance(algorithm, TestUtil.BC_PROVIDER);
+      // JCE doesn't support ML-DSA until JDK24, and BouncyCastle currently
+      // serializes ML-DSA private keys via seeds. TODO: switch to
+      // BouncyCastle once we support deserializing private keys from seed.
+      jceFactory = KeyFactory.getInstance(algorithm, NATIVE_PROVIDER);
     } else {
       jceFactory = KeyFactory.getInstance(algorithm);
     }
@@ -309,8 +313,10 @@ public class EvpKeyFactoryTest {
     final KeyFactory nativeFactory = KeyFactory.getInstance(algorithm, NATIVE_PROVIDER);
     final KeyFactory jceFactory;
     if (algorithm.startsWith("ML-DSA")) {
-      // JCE doesn't support ML-DSA until JDK24, so use BouncyCastle until then
-      jceFactory = KeyFactory.getInstance(algorithm, TestUtil.BC_PROVIDER);
+      // JCE doesn't support ML-DSA until JDK24, and BouncyCastle currently
+      // serializes ML-DSA private keys via seeds. TODO: switch to
+      // BouncyCastle once we support deserializing private keys from seed.
+      jceFactory = KeyFactory.getInstance(algorithm, NATIVE_PROVIDER);
     } else {
       jceFactory = KeyFactory.getInstance(algorithm);
     }

--- a/tst/com/amazon/corretto/crypto/provider/test/MLDSATest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/MLDSATest.java
@@ -236,18 +236,16 @@ public class MLDSATest {
     assertThrows(
         InvalidKeyException.class, () -> bcSignature.initSign(finalNativePair.getPrivate()));
 
-    // ACCP can't effectively use BouncyCastle private keys due to seed/expanded encoding difference
-    Signature nativeSignature = Signature.getInstance("ML-DSA", NATIVE_PROVIDER);
-    nativeSignature.initSign(bcPair.getPrivate());
-    byte[] sigBytes = nativeSignature.sign();
-    assertNotNull(sigBytes);
-    nativeSignature.initVerify(bcPair.getPublic());
-    assertFalse(nativeSignature.verify(sigBytes));
+    // ACCP can't use BouncyCastle private keys due to seed/expanded encoding difference
+    Signature finalNativeSignature = Signature.getInstance("ML-DSA", NATIVE_PROVIDER);
+    final KeyPair finalBcPair = bcPair;
+    assertThrows(
+        InvalidKeyException.class, () -> finalNativeSignature.initSign(finalBcPair.getPrivate()));
 
     // However, ACCP can use BouncyCastle public keys
-    nativeSignature = Signature.getInstance("ML-DSA", NATIVE_PROVIDER);
+    Signature nativeSignature = Signature.getInstance("ML-DSA", NATIVE_PROVIDER);
     nativeSignature.initSign(nativePair.getPrivate());
-    sigBytes = nativeSignature.sign();
+    byte[] sigBytes = nativeSignature.sign();
     assertNotNull(sigBytes);
     PublicKey bcPub =
         KeyFactory.getInstance("ML-DSA", TestUtil.BC_PROVIDER)


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*

A [recent AWS-LC change][1], coupled with [ACCP's recent ML-DSA support][2],
induces [failures][3] in AWS-LC's tip-of-ACCP-main integration test.

This is ultimately due to ACCP's current lack of support for deserializing
BouncyCastle's ML-DSA private key encoding; ACCP expects the full key while
BouncyCastle encodes only the 32 bytes seed. We're actively working on
supporting both formats, but until that lands we modify `EvpKeyFactoryTest` to
use ACCP for all ML-DSA keypairs.

This was caught upstream in AWS-LC instead of ACCP's CI because:

1. ACCP pins AWS-LC version and doesn't currently test against AWS-LC
   tip-of-main
2. ACCP's EvpKeyFactoryTest cases for ML-DSA previously succeeded only because
   the de/serialized keys were never used. We were "successfully" deserializing
   BouncyCastle "keys" represented as a 32-byte seed, but never used them
   cryptographically in EvpKeyFactoryTest. Doing so results in verification
   failures as documented [here][4].  With AWS-LC's [recent change][1], the
   cryptographic properties of raw private key material are exercised and thus
   deserialization of seeds fails.

We also bump AWS-LC tracking version to include above in tests.

[1]: https://github.com/aws/aws-lc/commit/695c3a05e2ac2a4cf39556ba143632da20ac3f6f
[2]: https://github.com/corretto/amazon-corretto-crypto-provider/pull/422
[3]: https://github.com/aws/aws-lc/actions/runs/13084244974/job/36513185053
[4]: https://github.com/corretto/amazon-corretto-crypto-provider/blob/aa9bfd2acc1c3539e2fe21630685b704930b9f74/tst/com/amazon/corretto/crypto/provider/test/MLDSATest.java#L239-L245

---

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.