### PR TITLE
Add null check to AesCbcSpi

### DIFF
--- a/src/com/amazon/corretto/crypto/provider/AesCbcSpi.java
+++ b/src/com/amazon/corretto/crypto/provider/AesCbcSpi.java
@@ -277,8 +277,12 @@ class AesCbcSpi extends CipherSpi {
   private static byte[] checkAesCbcIv(final AlgorithmParameterSpec params)
       throws InvalidAlgorithmParameterException {
     if (!(params instanceof IvParameterSpec)) {
-      throw new InvalidAlgorithmParameterException(
-          "Unknown AlgorithmParameterSpec: " + params.getClass());
+      if (params == null) {
+        throw new InvalidAlgorithmParameterException("AlgorithmParameterSpec cannot be null.");
+      } else {
+        throw new InvalidAlgorithmParameterException(
+            "Unknown AlgorithmParameterSpec: " + params.getClass());
+      }
     }
 
     final IvParameterSpec ivParameterSpec = (IvParameterSpec) params;

--- a/tst/com/amazon/corretto/crypto/provider/test/AesCbcTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/AesCbcTest.java
@@ -1268,4 +1268,14 @@ public class AesCbcTest {
     assertTrue(
         Arrays.equals(encryptShiftedSlices(buffer, key, iv, isPaddingEnabled), expectedOutput));
   }
+
+  @Test
+  public void testNullParamSpec() {
+    Cipher cipher = accpAesCbcCipher(false);
+    SecretKeySpec key = genAesKey(1, 128);
+    AlgorithmParameterSpec nullParam = null;
+    TestUtil.assertThrows(
+        InvalidAlgorithmParameterException.class,
+        () -> cipher.init(Cipher.ENCRYPT_MODE, key, nullParam));
+  }
 }


### PR DESCRIPTION
*Issue #, if available:*
V1600360624

*Description of changes:*
This guards against an NPE and throws the
InvalidAlgorithmParameterException as expected.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
