### PR TITLE
Add provider info string

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 tests/ci/cdk/.idea
 tests/ci/cdk/venv
 coverage/
+/classes

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,7 @@ set(PROVIDER_VERSION_STRING "" CACHE STRING "X.Y.Z formatted version of the prov
 set(EXPERIMENTAL_FIPS NO CACHE BOOL "Determines if this build is for FIPS mode with extra features from a non-FIPS branch of AWS-LC.")
 set(FIPS NO CACHE BOOL "Determine if this build is for FIPS mode")
 set(ALWAYS_ALLOW_EXTERNAL_LIB NO CACHE BOOL "Always permit tests to load ACCP shared objects from the library path")
+set(AWS_LC_VERSION_STRING "" CACHE STRING "Git version of AWS-LC used in this build")
 
 if (EXPERIMENTAL_FIPS)
     set(FIPS ON)
@@ -139,7 +140,12 @@ set(VERSION_PROPERTIES_FILE ${GENERATED_JAVA_DIR}/version.properties)
 add_custom_command(
     OUTPUT ${VERSION_PROPERTIES_FILE}
     COMMAND ${CMAKE_COMMAND} -E echo versionStr=${PROVIDER_VERSION_STRING} > ${VERSION_PROPERTIES_FILE}
-    COMMENT "Generation version properties file"
+    COMMAND if [ EXPERIMENTAL_FIPS || ! FIPS ]\; then
+        ${CMAKE_COMMAND} -E echo awsLcVersionStr=AWS-LC ${AWS_LC_VERSION_STRING} >> ${VERSION_PROPERTIES_FILE} \;
+    else
+        ${CMAKE_COMMAND} -E echo awsLcVersionStr=${AWS_LC_VERSION_STRING} >> ${VERSION_PROPERTIES_FILE} \;
+    fi
+    COMMENT "Generated version.properties file"
 )
 
 add_custom_command(

--- a/build.gradle
+++ b/build.gradle
@@ -15,11 +15,7 @@ plugins {
 group = 'software.amazon.cryptools'
 version = '2.5.0'
 ext.isExperimentalFips = Boolean.getBoolean('EXPERIMENTAL_FIPS')
-if (ext.isExperimentalFips) {
-    ext.isFips = true
-} else {
-    ext.isFips = Boolean.getBoolean('FIPS')
-}
+ext.isFips = ext.isExperimentalFips || Boolean.getBoolean('FIPS')
 
 if (ext.isExperimentalFips || !ext.isFips) {
     // Experimental FIPS uses the same AWS-LC version as non-FIPS builds.
@@ -336,6 +332,7 @@ task executeCmake(type: Exec) {
     args "-DOPENSSL_ROOT_DIR=${buildDir}/awslc/bin", '-DCMAKE_BUILD_TYPE=Release', '-DPROVIDER_VERSION_STRING=' + version
     args "-DTEST_RUNNER_JAR=${configurations.testRunner.singleFile}"
     args "-DCMAKE_VERBOSE_MAKEFILE:BOOL=ON"
+    args "-DAWS_LC_VERSION_STRING=" + awsLcGitVersionId
     if (isFips) {
         args "-DFIPS=ON"
     }
@@ -486,6 +483,12 @@ task single_test(type: Exec) {
     commandLine 'make', 'check-junit-single'
 }
 
+task test_install_via_properties(type: Exec) {
+    dependsOn executeCmake
+    workingDir "${buildDir}/cmake"
+    commandLine 'make', 'check-install-via-properties'
+}
+
 task test_integration_exec(type: Exec) {
     dependsOn executeCmake
     workingDir "${buildDir}/cmake"
@@ -531,6 +534,7 @@ task coverage_cmake(type: Exec) {
     args '-DPROVIDER_VERSION_STRING=' + version, projectDir
     args "-DTEST_RUNNER_JAR=${configurations.testRunner.singleFile}"
     args "-DCMAKE_VERBOSE_MAKEFILE:BOOL=ON"
+    args "-DAWS_LC_VERSION_STRING=" + awsLcGitVersionId
     if (isLegacyBuild) {
         args "-DLEGACY_BUILD=ON"
     }
@@ -883,11 +887,6 @@ task generateEclipseClasspath {
                     }
                 }
                 classpathentry('kind': 'src', 'output': 'build/eclipse/src', 'path': 'build/cmake/generated-java') {
-                    attributes {
-                        attribute('name': 'optional', 'value': 'true')
-                    }
-                }
-                classpathentry('kind': 'src', 'output': 'build/eclipse/src', 'path': 'build/coverage-cmake/generated-java') {
                     attributes {
                         attribute('name': 'optional', 'value': 'true')
                     }

--- a/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
+++ b/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
@@ -510,14 +510,13 @@ public final class AmazonCorrettoCryptoProvider extends java.security.Provider {
     super(
         PROVIDER_NAME,
         PROVIDER_VERSION,
-        PROVIDER_NAME
-            + ' '
-            + PROVIDER_VERSION_STR
-            + (FIPS_BUILD ? "+FIPS" : "")
-            + (EXPERIMENTAL_FIPS_BUILD ? "+EXP" : "")
-            + " ("
-            + AWS_LC_VERSION_STR
-            + ")");
+        String.format(
+            "%s %s%s%s (%s)",
+            PROVIDER_NAME,
+            PROVIDER_VERSION_STR,
+            FIPS_BUILD ? "+FIPS" : "",
+            EXPERIMENTAL_FIPS_BUILD ? "+EXP" : "",
+            AWS_LC_VERSION_STR));
     this.relyOnCachedSelfTestResults =
         Utils.getBooleanProperty(PROPERTY_CACHE_SELF_TEST_RESULTS, true);
     this.shouldRegisterEcParams = Utils.getBooleanProperty(PROPERTY_REGISTER_EC_PARAMS, false);

--- a/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
+++ b/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
@@ -17,6 +17,8 @@ import static com.amazon.corretto.crypto.provider.HkdfSecretKeyFactorySpi.HKDF_W
 import static com.amazon.corretto.crypto.provider.HkdfSecretKeyFactorySpi.HKDF_WITH_SHA256;
 import static com.amazon.corretto.crypto.provider.HkdfSecretKeyFactorySpi.HKDF_WITH_SHA384;
 import static com.amazon.corretto.crypto.provider.HkdfSecretKeyFactorySpi.HKDF_WITH_SHA512;
+import static com.amazon.corretto.crypto.provider.Loader.AWS_LC_VERSION_STR;
+import static com.amazon.corretto.crypto.provider.Loader.EXPERIMENTAL_FIPS_BUILD;
 import static com.amazon.corretto.crypto.provider.Loader.FIPS_BUILD;
 import static com.amazon.corretto.crypto.provider.Loader.PROVIDER_VERSION;
 import static com.amazon.corretto.crypto.provider.Loader.PROVIDER_VERSION_STR;
@@ -508,7 +510,14 @@ public final class AmazonCorrettoCryptoProvider extends java.security.Provider {
     super(
         PROVIDER_NAME,
         PROVIDER_VERSION,
-        PROVIDER_NAME + ' ' + PROVIDER_VERSION_STR + (FIPS_BUILD ? "-FIPS" : ""));
+        PROVIDER_NAME
+            + ' '
+            + PROVIDER_VERSION_STR
+            + (FIPS_BUILD ? "+FIPS" : "")
+            + (EXPERIMENTAL_FIPS_BUILD ? "+EXP" : "")
+            + " ("
+            + AWS_LC_VERSION_STR
+            + ")");
     this.relyOnCachedSelfTestResults =
         Utils.getBooleanProperty(PROPERTY_CACHE_SELF_TEST_RESULTS, true);
     this.shouldRegisterEcParams = Utils.getBooleanProperty(PROPERTY_REGISTER_EC_PARAMS, false);
@@ -576,6 +585,10 @@ public final class AmazonCorrettoCryptoProvider extends java.security.Provider {
   // Override annotation omitted so that it works/compiles in Java8
   public String getVersionStr() {
     return PROVIDER_VERSION_STR;
+  }
+
+  public String getAwsLcVersionStr() {
+    return AWS_LC_VERSION_STR;
   }
 
   /**

--- a/src/com/amazon/corretto/crypto/provider/Loader.java
+++ b/src/com/amazon/corretto/crypto/provider/Loader.java
@@ -186,7 +186,8 @@ final class Loader {
    * Loads a properties file and reads the value for the given key. If file is unavailable, falls
    * back to {@link System#getProperty(String)}.
    */
-  private static String readProperty(String propertyFile, String propertyKey) throws PrivilegedActionException {
+  private static String readProperty(String propertyFile, String propertyKey)
+      throws PrivilegedActionException {
     return AccessController.doPrivileged(
         (PrivilegedExceptionAction<String>)
             () -> {

--- a/src/com/amazon/corretto/crypto/provider/Loader.java
+++ b/src/com/amazon/corretto/crypto/provider/Loader.java
@@ -15,6 +15,7 @@ import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -47,6 +48,7 @@ final class Loader {
   static final String PROPERTY_BASE = "com.amazon.corretto.crypto.provider.";
   private static final String TEMP_DIR_PREFIX = "amazonCorrettoCryptoProviderNativeLibraries.";
   private static final String JNI_LIBRARY_NAME = "amazonCorrettoCryptoProvider";
+  private static final String VERSION_PROPERTY_FILE = "version.properties";
   private static final String PROPERTY_VERSION_STR = "versionStr";
   private static final String PROPERTY_AWS_LC_VERSION_STR = "awsLcVersionStr";
 
@@ -124,25 +126,15 @@ final class Loader {
     double oldVersion = 0;
 
     try {
-      versionStr =
-          AccessController.doPrivileged(
-              (PrivilegedExceptionAction<String>)
-                  () -> {
-                    try (InputStream is = Loader.class.getResourceAsStream("version.properties")) {
-                      if (is == null) {
-                        return System.getProperty(PROPERTY_VERSION_STR);
-                      }
-                      Properties p = new Properties();
-                      p.load(is);
-                      return p.getProperty(PROPERTY_VERSION_STR);
-                    }
-                  });
+      versionStr = readProperty(VERSION_PROPERTY_FILE, PROPERTY_VERSION_STR);
 
       Matcher m = OLD_VERSION_PATTERN.matcher(versionStr);
       if (!m.matches()) {
         throw new AssertionError("Version string has wrong form: " + versionStr);
       }
       oldVersion = Double.parseDouble(m.group(1));
+
+      awsLcVersionStr = readProperty(VERSION_PROPERTY_FILE, PROPERTY_AWS_LC_VERSION_STR);
 
       available =
           AccessController.doPrivileged(
@@ -157,19 +149,6 @@ final class Loader {
                     return true;
                   });
 
-      awsLcVersionStr =
-          AccessController.doPrivileged(
-              (PrivilegedExceptionAction<String>)
-                  () -> {
-                    try (InputStream is = Loader.class.getResourceAsStream("version.properties")) {
-                      if (is == null) {
-                        return System.getProperty(PROPERTY_AWS_LC_VERSION_STR);
-                      }
-                      Properties p = new Properties();
-                      p.load(is);
-                      return p.getProperty(PROPERTY_AWS_LC_VERSION_STR);
-                    }
-                  });
     } catch (final Throwable t) {
       available = false;
       error = t;
@@ -201,6 +180,25 @@ final class Loader {
 
     // Finally start up a cleaning thread if necessary
     RESOURCE_JANITOR = new Janitor();
+  }
+
+  /**
+   * Loads a properties file and reads the value for the given key. If file is unavailable, falls
+   * back to {@link System#getProperty(String)}.
+   */
+  private static String readProperty(String propertyFile, String propertyKey) throws PrivilegedActionException {
+    return AccessController.doPrivileged(
+        (PrivilegedExceptionAction<String>)
+            () -> {
+              try (InputStream is = Loader.class.getResourceAsStream(propertyFile)) {
+                if (is == null) {
+                  return System.getProperty(propertyKey);
+                }
+                Properties p = new Properties();
+                p.load(is);
+                return p.getProperty(propertyKey);
+              }
+            });
   }
 
   private static void tryLoadLibraryFromJar() throws IOException {

--- a/tst/com/amazon/corretto/crypto/provider/test/SecurityPropertyTester.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/SecurityPropertyTester.java
@@ -4,7 +4,6 @@ package com.amazon.corretto.crypto.provider.test;
 
 import static com.amazon.corretto.crypto.provider.test.TestUtil.NATIVE_PROVIDER;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import java.security.AlgorithmParameters;
@@ -31,22 +30,9 @@ public final class SecurityPropertyTester {
 
     String infoStr = NATIVE_PROVIDER.getInfo();
     System.out.println("Security Provider : " + infoStr);
-    String[] tokens = infoStr.split("[()]");
-    String[] semver = tokens[0].split("[\\s+-]");
-    String[] addInfo = tokens[1].split(",");
-    assertEquals(NATIVE_PROVIDER.getName(), semver[0]);
-    assertEquals(NATIVE_PROVIDER.getVersionStr(), semver[1]);
-    if (NATIVE_PROVIDER.isFips()) {
-      assertEquals("FIPS", semver[2]);
-    } else {
-      assertFalse(infoStr.contains("FIPS"));
-    }
-    if (NATIVE_PROVIDER.isExperimentalFips()) {
-      assertEquals("EXP", semver[3]);
-    } else {
-      assertFalse(infoStr.contains("EXP"));
-    }
-    assertEquals(NATIVE_PROVIDER.getAwsLcVersionStr(), addInfo[0]);
+    String[] tokens = infoStr.split("[\\s+-]");
+    assertEquals(NATIVE_PROVIDER.getName(), tokens[0]);
+    assertEquals(NATIVE_PROVIDER.getVersionStr(), tokens[1]);
 
     final Provider provider = Security.getProviders()[0];
     assertEquals(NATIVE_PROVIDER.getName(), provider.getName());

--- a/tst/com/amazon/corretto/crypto/provider/test/SecurityPropertyTester.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/SecurityPropertyTester.java
@@ -4,8 +4,8 @@ package com.amazon.corretto.crypto.provider.test;
 
 import static com.amazon.corretto.crypto.provider.test.TestUtil.NATIVE_PROVIDER;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.security.AlgorithmParameters;
 import java.security.KeyPairGenerator;
@@ -31,12 +31,22 @@ public final class SecurityPropertyTester {
 
     String infoStr = NATIVE_PROVIDER.getInfo();
     System.out.println("Security Provider : " + infoStr);
-    assertTrue(infoStr.startsWith(NATIVE_PROVIDER.getName()));
+    String[] tokens = infoStr.split("[()]");
+    String[] semver = tokens[0].split("[\\s+-]");
+    String[] addInfo = tokens[1].split(",");
+    assertEquals(NATIVE_PROVIDER.getName(), semver[0]);
+    assertEquals(NATIVE_PROVIDER.getVersionStr(), semver[1]);
     if (NATIVE_PROVIDER.isFips()) {
-      assertTrue(infoStr.endsWith(NATIVE_PROVIDER.getVersionStr() + "-FIPS"));
+      assertEquals("FIPS", semver[2]);
     } else {
-      assertTrue(infoStr.endsWith(NATIVE_PROVIDER.getVersionStr()));
+      assertFalse(infoStr.contains("FIPS"));
     }
+    if (NATIVE_PROVIDER.isExperimentalFips()) {
+      assertEquals("EXP", semver[3]);
+    } else {
+      assertFalse(infoStr.contains("EXP"));
+    }
+    assertEquals(NATIVE_PROVIDER.getAwsLcVersionStr(), addInfo[0]);
 
     final Provider provider = Security.getProviders()[0];
     assertEquals(NATIVE_PROVIDER.getName(), provider.getName());

--- a/tst/com/amazon/corretto/crypto/provider/test/SecurityPropertyTester.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/SecurityPropertyTester.java
@@ -5,6 +5,7 @@ package com.amazon.corretto.crypto.provider.test;
 import static com.amazon.corretto.crypto.provider.test.TestUtil.NATIVE_PROVIDER;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.security.AlgorithmParameters;
 import java.security.KeyPairGenerator;
@@ -27,6 +28,15 @@ public final class SecurityPropertyTester {
     final boolean fipsMode = Boolean.getBoolean("FIPS");
     System.out.println("FIPS? " + NATIVE_PROVIDER.isFips());
     assertEquals(fipsMode, NATIVE_PROVIDER.isFips());
+
+    String infoStr = NATIVE_PROVIDER.getInfo();
+    System.out.println("Security Provider : " + infoStr);
+    assertTrue(infoStr.startsWith(NATIVE_PROVIDER.getName()));
+    if (NATIVE_PROVIDER.isFips()) {
+      assertTrue(infoStr.endsWith(NATIVE_PROVIDER.getVersionStr() + "-FIPS"));
+    } else {
+      assertTrue(infoStr.endsWith(NATIVE_PROVIDER.getVersionStr()));
+    }
 
     final Provider provider = Security.getProviders()[0];
     assertEquals(NATIVE_PROVIDER.getName(), provider.getName());


### PR DESCRIPTION
*Issue #* [377](https://github.com/corretto/amazon-corretto-crypto-provider/issues/377)

*Description of changes:*
Adding a provider info string to AmazonCorrettoCryptoProvider using [Semantic Versioning](https://semver.org) format, with additional info on the underlying AWS-LC version.

Example output for the provider info string

* **AmazonCorrettoCryptoProvider 2.5.0 (AWS-LC v1.44.0)**
Normal build with a 'main' branch version of AWS-LC

* **AmazonCorrettoCryptoProvider 2.5.0+FIPS (AWS-LC-FIPS-3.0.0)**
Built in FIPS mode with `AWS-LC-FIPS-x.y.z` version of AWS-LC

* **AmazonCorrettoCryptoProvider 2.5.0+FIPS+EXP (AWS-LC v1.44.0)**
Built in FIPS mode with a 'main' branch version of AWS-LC (ie: with EXPERIMENTAL_FIPS flag)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
