### PR TITLE
Refactor Cipher/AES/CBC Service Registration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -480,9 +480,17 @@ task unit_tests(type: Copy) {
 }
 test.dependsOn unit_tests
 
-task single_test(type: Exec) {
+task singleTest(type: Exec) {
+    group 'Verification'
+    description 'Pass in the test class using -DSINGLE_TEST=${fully_qualified_test_class}'
     dependsOn executeCmake
     workingDir "${buildDir}/cmake"
+    // Our cmake doesn't properly react java source changes, but it will rebuild them if the jars are missing
+    doFirst {
+        delete fileTree("${buildDir}/cmake").matching {
+            include '*.jar'
+        }
+    }
     commandLine 'make', 'check-junit-single'
 }
 

--- a/src/com/amazon/corretto/crypto/provider/AesCbcSpi.java
+++ b/src/com/amazon/corretto/crypto/provider/AesCbcSpi.java
@@ -16,6 +16,7 @@ import java.security.spec.AlgorithmParameterSpec;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.InvalidParameterSpecException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Predicate;
@@ -55,30 +56,39 @@ class AesCbcSpi extends CipherSpi {
 
   static {
     Loader.load();
-    AES_CBC_NO_PADDING_NAMES = new HashSet<>();
-    AES_CBC_NO_PADDING_NAMES.add("AES/CBC/NoPadding".toLowerCase());
-    AES_CBC_NO_PADDING_NAMES.add("AES_128/CBC/NoPadding".toLowerCase());
-    AES_CBC_NO_PADDING_NAMES.add("AES_192/CBC/NoPadding".toLowerCase());
-    AES_CBC_NO_PADDING_NAMES.add("AES_256/CBC/NoPadding".toLowerCase());
+    AES_CBC_NO_PADDING_NAMES =
+        Collections.unmodifiableSet(
+            new HashSet<>(
+                Arrays.asList(
+                    "AES/CBC/NoPadding".toLowerCase(),
+                    "AES_128/CBC/NoPadding".toLowerCase(),
+                    "AES_192/CBC/NoPadding".toLowerCase(),
+                    "AES_256/CBC/NoPadding".toLowerCase())));
 
-    AES_CBC_PKCS7_PADDING_NAMES = new HashSet<>();
-    AES_CBC_PKCS7_PADDING_NAMES.add("AES/CBC/PKCS7Padding".toLowerCase());
-    AES_CBC_PKCS7_PADDING_NAMES.add("AES_128/CBC/PKCS7Padding".toLowerCase());
-    AES_CBC_PKCS7_PADDING_NAMES.add("AES_192/CBC/PKCS7Padding".toLowerCase());
-    AES_CBC_PKCS7_PADDING_NAMES.add("AES_256/CBC/PKCS7Padding".toLowerCase());
     // PKCS5Padding with AES/CBC must be treated as PKCS7Padding. PKCS7Padding name is not
     // recognized by SunJCE, but BouncyCastle supports PKCS7Padding as a valid name for the same
     // padding.
-    AES_CBC_PKCS7_PADDING_NAMES.add("AES/CBC/PKCS5Padding".toLowerCase());
-    AES_CBC_PKCS7_PADDING_NAMES.add("AES_128/CBC/PKCS5Padding".toLowerCase());
-    AES_CBC_PKCS7_PADDING_NAMES.add("AES_192/CBC/PKCS5Padding".toLowerCase());
-    AES_CBC_PKCS7_PADDING_NAMES.add("AES_256/CBC/PKCS5Padding".toLowerCase());
+    AES_CBC_PKCS7_PADDING_NAMES =
+        Collections.unmodifiableSet(
+            new HashSet<>(
+                Arrays.asList(
+                    "AES/CBC/PKCS7Padding".toLowerCase(),
+                    "AES_128/CBC/PKCS7Padding".toLowerCase(),
+                    "AES_192/CBC/PKCS7Padding".toLowerCase(),
+                    "AES_256/CBC/PKCS7Padding".toLowerCase(),
+                    "AES/CBC/PKCS5Padding".toLowerCase(),
+                    "AES_128/CBC/PKCS5Padding".toLowerCase(),
+                    "AES_192/CBC/PKCS5Padding".toLowerCase(),
+                    "AES_256/CBC/PKCS5Padding".toLowerCase())));
 
-    AES_CBC_ISO10126_PADDING_NAMES = new HashSet<>();
-    AES_CBC_ISO10126_PADDING_NAMES.add("AES/CBC/ISO10126Padding".toLowerCase());
-    AES_CBC_ISO10126_PADDING_NAMES.add("AES_128/CBC/ISO10126Padding".toLowerCase());
-    AES_CBC_ISO10126_PADDING_NAMES.add("AES_192/CBC/ISO10126Padding".toLowerCase());
-    AES_CBC_ISO10126_PADDING_NAMES.add("AES_256/CBC/ISO10126Padding".toLowerCase());
+    AES_CBC_ISO10126_PADDING_NAMES =
+        Collections.unmodifiableSet(
+            new HashSet<>(
+                Arrays.asList(
+                    "AES/CBC/ISO10126Padding".toLowerCase(),
+                    "AES_128/CBC/ISO10126Padding".toLowerCase(),
+                    "AES_192/CBC/ISO10126Padding".toLowerCase(),
+                    "AES_256/CBC/ISO10126Padding".toLowerCase())));
   }
 
   private static final byte[] EMPTY_ARRAY = new byte[0];

--- a/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
+++ b/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
@@ -3,7 +3,6 @@
 package com.amazon.corretto.crypto.provider;
 
 import static com.amazon.corretto.crypto.provider.AesCbcSpi.AES_CBC_ISO10126_PADDING_NAMES;
-import static com.amazon.corretto.crypto.provider.AesCbcSpi.AES_CBC_NO_PADDING_NAMES;
 import static com.amazon.corretto.crypto.provider.AesCbcSpi.AES_CBC_PKCS7_PADDING_NAMES;
 import static com.amazon.corretto.crypto.provider.ConcatenationKdfSpi.CKDF_WITH_HMAC_SHA256;
 import static com.amazon.corretto.crypto.provider.ConcatenationKdfSpi.CKDF_WITH_HMAC_SHA512;
@@ -41,6 +40,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ForkJoinPool;
 import java.util.function.Supplier;
+import javax.crypto.CipherSpi;
 
 public final class AmazonCorrettoCryptoProvider extends java.security.Provider {
   private static final MethodHandles.Lookup LOOKUP = MethodHandles.lookup();
@@ -146,25 +146,15 @@ public final class AmazonCorrettoCryptoProvider extends java.security.Provider {
 
     addService("Cipher", "AES/XTS/NoPadding", "AesXtsSpi", false);
 
-    addService("Cipher", "AES/CBC/NoPadding", "AesCbcSpi", false);
-    addService("Cipher", "AES_128/CBC/NoPadding", "AesCbcSpi", false);
-    addService("Cipher", "AES_192/CBC/NoPadding", "AesCbcSpi", false);
-    addService("Cipher", "AES_256/CBC/NoPadding", "AesCbcSpi", false);
-
-    addService("Cipher", "AES/CBC/PKCS5Padding", "AesCbcSpi", false);
-    addService("Cipher", "AES_128/CBC/PKCS5Padding", "AesCbcSpi", false);
-    addService("Cipher", "AES_192/CBC/PKCS5Padding", "AesCbcSpi", false);
-    addService("Cipher", "AES_256/CBC/PKCS5Padding", "AesCbcSpi", false);
-
-    addService("Cipher", "AES/CBC/PKCS7Padding", "AesCbcSpi", false);
-    addService("Cipher", "AES_128/CBC/PKCS7Padding", "AesCbcSpi", false);
-    addService("Cipher", "AES_192/CBC/PKCS7Padding", "AesCbcSpi", false);
-    addService("Cipher", "AES_256/CBC/PKCS7Padding", "AesCbcSpi", false);
-
-    addService("Cipher", "AES/CBC/ISO10126Padding", "AesCbcSpi", false);
-    addService("Cipher", "AES_128/CBC/ISO10126Padding", "AesCbcSpi", false);
-    addService("Cipher", "AES_192/CBC/ISO10126Padding", "AesCbcSpi", false);
-    addService("Cipher", "AES_256/CBC/ISO10126Padding", "AesCbcSpi", false);
+    addService(
+        "Cipher",
+        "AES",
+        "AesCbcSpi",
+        false,
+        singletonMap("SupportedModes", "CBC"),
+        "AES_128",
+        "AES_192",
+        "AES_256");
 
     addService("Cipher", "RSA/ECB/NoPadding", "RsaCipher$NoPadding");
     addService("Cipher", "RSA/ECB/Pkcs1Padding", "RsaCipher$Pkcs1");
@@ -388,32 +378,8 @@ public final class AmazonCorrettoCryptoProvider extends java.security.Provider {
           return SecretKeyGenerator.createAesKeyGeneratorSpi();
         }
 
-        if ("Cipher".equalsIgnoreCase(type) && "AES/XTS/NoPadding".equalsIgnoreCase(algo)) {
-          return new AesXtsSpi();
-        }
-
-        if ("Cipher".equalsIgnoreCase(type)
-            && AES_CBC_PKCS7_PADDING_NAMES.contains(algo.toLowerCase())) {
-          final boolean saveContext =
-              AmazonCorrettoCryptoProvider.this.nativeContextReleaseStrategy
-                  == Utils.NativeContextReleaseStrategy.LAZY;
-          return new AesCbcSpi(AesCbcSpi.Padding.PKCS7, saveContext);
-        }
-
-        if ("Cipher".equalsIgnoreCase(type)
-            && AES_CBC_NO_PADDING_NAMES.contains(algo.toLowerCase())) {
-          final boolean saveContext =
-              AmazonCorrettoCryptoProvider.this.nativeContextReleaseStrategy
-                  == Utils.NativeContextReleaseStrategy.LAZY;
-          return new AesCbcSpi(AesCbcSpi.Padding.NONE, saveContext);
-        }
-
-        if ("Cipher".equalsIgnoreCase(type)
-            && AES_CBC_ISO10126_PADDING_NAMES.contains(algo.toLowerCase())) {
-          final boolean saveContext =
-              AmazonCorrettoCryptoProvider.this.nativeContextReleaseStrategy
-                  == Utils.NativeContextReleaseStrategy.LAZY;
-          return new AesCbcSpi(AesCbcSpi.Padding.ISO10126, saveContext);
+        if ("Cipher".equalsIgnoreCase(type)) {
+          return getCipherSpiInstance(algo);
         }
 
         throw new NoSuchAlgorithmException(String.format("No service class for %s/%s", type, algo));
@@ -430,6 +396,26 @@ public final class AmazonCorrettoCryptoProvider extends java.security.Provider {
       } catch (Throwable t) {
         throw new NoSuchAlgorithmException("Unexpected error constructing algorithm", t);
       }
+    }
+
+    private CipherSpi getCipherSpiInstance(String algo) throws NoSuchAlgorithmException {
+      final boolean saveContext =
+          AmazonCorrettoCryptoProvider.this.nativeContextReleaseStrategy
+              == Utils.NativeContextReleaseStrategy.LAZY;
+      if ("AES/XTS/NoPadding".equalsIgnoreCase(algo)) {
+        return new AesXtsSpi();
+      }
+      if (AES_CBC_PKCS7_PADDING_NAMES.contains(algo.toLowerCase())) {
+        return new AesCbcSpi(AesCbcSpi.Padding.PKCS7, saveContext);
+      }
+      if (AES_CBC_ISO10126_PADDING_NAMES.contains(algo.toLowerCase())) {
+        return new AesCbcSpi(AesCbcSpi.Padding.ISO10126, saveContext);
+      }
+      // Allow the padding scheme to be set later by defaulting to a no-padding Cipher.
+      if (algo.toUpperCase().startsWith("AES")) {
+        return new AesCbcSpi(AesCbcSpi.Padding.NONE, saveContext);
+      }
+      throw new NoSuchAlgorithmException(format("No service class for Cipher/%s", algo));
     }
 
     private void checkTests() throws NoSuchAlgorithmException {

--- a/tst/com/amazon/corretto/crypto/provider/test/AesCbcTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/AesCbcTest.java
@@ -1278,4 +1278,10 @@ public class AesCbcTest {
         InvalidAlgorithmParameterException.class,
         () -> cipher.init(Cipher.ENCRYPT_MODE, key, nullParam));
   }
+
+  public void testNoPaddingException() {
+    TestUtil.assertThrows(
+        NoSuchPaddingException.class,
+        () -> Cipher.getInstance("AES/CBC/Notepad", TestUtil.NATIVE_PROVIDER));
+  }
 }


### PR DESCRIPTION
*Issue #, if available:*
ACCP-122, V1600360624

*Description of changes:*
Previously, we registered the AES/CBC service by registering separate services for each combination of cipher_aliases x padding_aliases. This results in a lot more services than is necessary, is more verbose, and more importantly breaks JCK compatibility tests. This refactor properly registers our AES/CBC implementation as one service that has multiple cipher aliases and different supported padding schemes.

To fix the JCK test, we implement the `engineSetPadding` interface and throw a `NoSuchPaddingException` as needed.

We also take the opportunity to make a quality of life improvement to the `singleTest` gradle task to force a rebuild the Java source to avoid staleness issues during development.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
