### PR TITLE
Refactor Git tags to enable use in downstream build scripts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,16 +14,16 @@ plugins {
 
 group = 'software.amazon.cryptools'
 version = '2.5.0'
-awsLcMainTag = 'v1.44.0'
-awsLcFipsTag = 'AWS-LC-FIPS-3.0.0'
+ext.awsLcMainTag = 'v1.44.0'
+ext.awsLcFipsTag = 'AWS-LC-FIPS-3.0.0'
 ext.isExperimentalFips = Boolean.getBoolean('EXPERIMENTAL_FIPS')
 ext.isFips = ext.isExperimentalFips || Boolean.getBoolean('FIPS')
 
 if (ext.isExperimentalFips || !ext.isFips) {
     // Experimental FIPS uses the same AWS-LC version as non-FIPS builds.
-    ext.awsLcGitVersionId = awsLcMainTag
+    ext.awsLcGitVersionId = ext.awsLcMainTag
 } else {
-    ext.awsLcGitVersionId = awsLcFipsTag
+    ext.awsLcGitVersionId = ext.awsLcFipsTag
 }
 
 // Check for user inputted git version ID.

--- a/build.gradle
+++ b/build.gradle
@@ -14,14 +14,16 @@ plugins {
 
 group = 'software.amazon.cryptools'
 version = '2.5.0'
+awsLcMainTag = 'v1.44.0'
+awsLcFipsTag = 'AWS-LC-FIPS-3.0.0'
 ext.isExperimentalFips = Boolean.getBoolean('EXPERIMENTAL_FIPS')
 ext.isFips = ext.isExperimentalFips || Boolean.getBoolean('FIPS')
 
 if (ext.isExperimentalFips || !ext.isFips) {
     // Experimental FIPS uses the same AWS-LC version as non-FIPS builds.
-    ext.awsLcGitVersionId = 'v1.44.0'
+    ext.awsLcGitVersionId = awsLcMainTag
 } else {
-    ext.awsLcGitVersionId = 'AWS-LC-FIPS-3.0.0'
+    ext.awsLcGitVersionId = awsLcFipsTag
 }
 
 // Check for user inputted git version ID.


### PR DESCRIPTION
*Description of changes:*
Refactoring Git Tag strings into gradle project vars, so it can be used in downstream build scripts

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
