### PR TITLE
Bump AWS-LC dependency to 1.45

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ plugins {
 
 group = 'software.amazon.cryptools'
 version = '2.5.0'
-ext.awsLcMainTag = 'v1.44.0'
+ext.awsLcMainTag = 'v1.45.0'
 ext.awsLcFipsTag = 'AWS-LC-FIPS-3.0.0'
 ext.isExperimentalFips = Boolean.getBoolean('EXPERIMENTAL_FIPS')
 ext.isFips = ext.isExperimentalFips || Boolean.getBoolean('FIPS')

--- a/tst/com/amazon/corretto/crypto/provider/test/MLDSATest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/MLDSATest.java
@@ -236,21 +236,11 @@ public class MLDSATest {
     assertThrows(
         InvalidKeyException.class, () -> bcSignature.initSign(finalNativePair.getPrivate()));
 
-    // ACCP can't use BouncyCastle private keys due to seed/expanded encoding difference
-    Signature finalNativeSignature = Signature.getInstance("ML-DSA", NATIVE_PROVIDER);
-    final KeyPair finalBcPair = bcPair;
-    assertThrows(
-        InvalidKeyException.class, () -> finalNativeSignature.initSign(finalBcPair.getPrivate()));
-
-    // However, ACCP can use BouncyCastle public keys
+    // However, ACCP can use BouncyCastle KeyPairs with seed-encoded  PrivateKeys
     Signature nativeSignature = Signature.getInstance("ML-DSA", NATIVE_PROVIDER);
-    nativeSignature.initSign(nativePair.getPrivate());
+    nativeSignature.initSign(bcPair.getPrivate());
     byte[] sigBytes = nativeSignature.sign();
-    assertNotNull(sigBytes);
-    PublicKey bcPub =
-        KeyFactory.getInstance("ML-DSA", TestUtil.BC_PROVIDER)
-            .generatePublic(new X509EncodedKeySpec(nativePair.getPublic().getEncoded()));
-    nativeSignature.initVerify(bcPub);
+    nativeSignature.initVerify(bcPair.getPublic());
     assertTrue(nativeSignature.verify(sigBytes));
   }
 


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*

AWS-LC [PR #2157](https://github.com/aws/aws-lc/pull/2157) newly supports parsing ML-DSA private keys from seeds, as BouncyCastle does, so we update our relevant interop test.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
