### PR TITLE
Fix classname field of AES KeyGenerator Service

### DIFF
--- a/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
+++ b/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
@@ -144,7 +144,7 @@ public final class AmazonCorrettoCryptoProvider extends java.security.Provider {
       addService("KeyPairGenerator", "ML-DSA-87", "MlDsaGen$MlDsaGen87");
     }
 
-    addService("KeyGenerator", "AES", "keygeneratorspi.SecretKeyGenerator", false);
+    addService("KeyGenerator", "AES", "SecretKeyGenerator", false);
 
     addService("Cipher", "AES/XTS/NoPadding", "AesXtsSpi", false);
 


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
In PR #280 the package hierarchy for this class was flattened, but this
line of code was not updated to reflect this. In practice, this all
worked and continued to work since we don't 'useReflection' to
instantiate this crypto service. However, we do send up the classname
into the JCA so whatever that uses it for may have been broken until
now.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
