### PR TITLE
Pr 438 follow up

### DIFF
--- a/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
+++ b/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
@@ -663,11 +663,11 @@ public final class AmazonCorrettoCryptoProvider extends java.security.Provider {
     }
     if (getSelfTestStatus() == SelfTestStatus.NOT_RUN) {
       // If FIPS self tests haven't completed, give them a 5s timeout to complete.
-      final long timeout = 5 * 1000;
+      final long timeout = 3 * 1000;
       final long deadline = System.currentTimeMillis() + timeout;
       while (getSelfTestStatus() == SelfTestStatus.NOT_RUN) {
         try {
-          Thread.sleep(10);
+          Thread.sleep(1);
         } catch (Exception e) {
           throw new RuntimeCryptoException(e);
         }

--- a/tst/com/amazon/corretto/crypto/provider/test/EvpKeyFactoryTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/EvpKeyFactoryTest.java
@@ -86,17 +86,10 @@ public class EvpKeyFactoryTest {
     }
 
     for (String algorithm : ALGORITHMS) {
-      KeyPairGenerator kpg;
-      if (algorithm.startsWith("ML-DSA")
-          || (algorithm.startsWith("Ed") && TestUtil.getJavaVersion() < 15)) {
-        // JCE doesn't support ML-DSA until JDK24, and BouncyCastle currently
-        // serializes ML-DSA private keys via seeds.
-        // TODO: switch to BouncyCastle once BC supports CHOICE-encoded private keys
-        // Similarly, JDK doesn't support EdDSA/Ed25519 until JDK15
-        kpg = KeyPairGenerator.getInstance(algorithm, NATIVE_PROVIDER);
-      } else {
-        kpg = KeyPairGenerator.getInstance(algorithm);
-      }
+      KeyPairGenerator kpg =
+          getAlternateProvider(algorithm) == null
+              ? KeyPairGenerator.getInstance(algorithm)
+              : KeyPairGenerator.getInstance(algorithm, getAlternateProvider(algorithm));
       List<Arguments> keys = new ArrayList<>();
       if (algorithm.equals("EC")) {
         // Different curves can excercise different areas of ASN.1/DER and so should all be tested.
@@ -236,17 +229,10 @@ public class EvpKeyFactoryTest {
     final String algorithm = pubKey.getAlgorithm();
 
     final KeyFactory nativeFactory = KeyFactory.getInstance(algorithm, NATIVE_PROVIDER);
-    final KeyFactory jceFactory;
-    if (algorithm.startsWith("ML-DSA")
-        || (algorithm.startsWith("Ed") && TestUtil.getJavaVersion() < 15)) {
-      // JCE doesn't support ML-DSA until JDK24, and BouncyCastle currently
-      // serializes ML-DSA private keys via seeds.
-      // TODO: switch to BouncyCastle once BC supports CHOICE-encoded private keys
-      // Similarly, JDK doesn't support EdDSA/Ed25519 until JDK15
-      jceFactory = KeyFactory.getInstance(algorithm, NATIVE_PROVIDER);
-    } else {
-      jceFactory = KeyFactory.getInstance(algorithm);
-    }
+    final KeyFactory jceFactory =
+        getAlternateProvider(algorithm) == null
+            ? KeyFactory.getInstance(algorithm)
+            : KeyFactory.getInstance(algorithm, getAlternateProvider(algorithm));
 
     final X509EncodedKeySpec nativeSpec =
         nativeFactory.getKeySpec(pubKey, X509EncodedKeySpec.class);
@@ -315,17 +301,10 @@ public class EvpKeyFactoryTest {
     final String algorithm = privKey.getAlgorithm();
 
     final KeyFactory nativeFactory = KeyFactory.getInstance(algorithm, NATIVE_PROVIDER);
-    final KeyFactory jceFactory;
-    if (algorithm.startsWith("ML-DSA")
-        || (algorithm.startsWith("Ed") && TestUtil.getJavaVersion() < 15)) {
-      // JCE doesn't support ML-DSA until JDK24, and BouncyCastle currently
-      // serializes ML-DSA private keys via seeds.
-      // TODO: switch to BouncyCastle once BC supports CHOICE-encoded private keys
-      // Similarly, JDK doesn't support EdDSA/Ed25519 until JDK15
-      jceFactory = KeyFactory.getInstance(algorithm, NATIVE_PROVIDER);
-    } else {
-      jceFactory = KeyFactory.getInstance(algorithm);
-    }
+    final KeyFactory jceFactory =
+        getAlternateProvider(algorithm) == null
+            ? KeyFactory.getInstance(algorithm)
+            : KeyFactory.getInstance(algorithm, getAlternateProvider(algorithm));
 
     final PKCS8EncodedKeySpec nativeSpec =
         nativeFactory.getKeySpec(privKey, PKCS8EncodedKeySpec.class);
@@ -738,6 +717,26 @@ public class EvpKeyFactoryTest {
       this.nativeSample = nativeSample;
       this.jceSample = jceSample;
     }
+  }
+
+  // This method is used to determine whether tests should use an alternate provider for a given
+  // algorithm. In cases
+  // where JCE doesn't support the requested algorithm, the alternate provider will be returned. In
+  // cases where JCE does
+  // support the requested algorithm, null will be returned.
+  private static Provider getAlternateProvider(String algorithm) {
+    // JCE doesn't support ML-DSA until JDK24, and BouncyCastle currently serializes ML-DSA private
+    // keys via seeds.
+    // TODO: switch to BouncyCastle once BC supports CHOICE-encoded private keys
+    if (algorithm.startsWith("ML-DSA")
+        // Similarly, JDK doesn't support EdDSA/Ed25519 until JDK15
+        || ((algorithm.equals("Ed25519")
+                || algorithm.equals("Ed25519ph")
+                || algorithm.equals("EdDSA"))
+            && TestUtil.getJavaVersion() < 15)) {
+      return NATIVE_PROVIDER;
+    }
+    return null;
   }
 
   public static class NullDataKey implements Key {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Follow-ups from PR #438:

1. Tighten self test timeout and sleeps (discussed offline)
2. Tighten and consolidate some test logic (see [here][1])

[1]: https://github.com/corretto/amazon-corretto-crypto-provider/pull/438#discussion_r1985795148


## Testing

In addition to CI, I ran the script exercising `isFipsSelfTestFailureSkipAbort() == true`:

```
$ TEST_JAVA_HOME=/usr/lib/jvm/java-17-amazon-corretto.x86_64 ./tests/ci/run_accp_basic_tests.sh --fips-self-test-failure-no-abort
...
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
