### PR TITLE
PR 433 follow ups

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ ACCP did not track a FIPS branch/release version of AWS-LC until ACCP v2.3.0. Be
 | 2.4.0               | 1.30.1         | 2.0.13              |
 | 2.4.1               | 1.30.1         | 2.0.13              |
 | 2.5.0               | 1.47.0         | 3.0.0               |
+| 2.6.0               | 1.48.2         | 3.0.0               |
 
 Notable differences between ACCP and ACCP-FIPS:
 * ACCP uses [the latest release of AWS-LC](https://github.com/aws/aws-lc/releases), whereas, ACCP-FIPS uses [the fips-2022-11-02 branch of AWS-LC](https://github.com/aws/aws-lc/tree/fips-2022-11-02).

--- a/build.gradle
+++ b/build.gradle
@@ -273,6 +273,8 @@ task buildAwsLc {
                 }
 
                 if (isFipsSelfTestFailureSkipAbort) {
+                    println "Building AWS-LC to enable CPU jitter sampling when seeding its DRBG"
+                    args '-DENABLE_FIPS_ENTROPY_CPU_JITTER=ON'
                     println "Building AWS-LC to call callback instead of aborting on self-test failure"
                     cmakeCFlags += '-DAWSLC_FIPS_FAILURE_CALLBACK '
                 }

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ plugins {
 
 group = 'software.amazon.cryptools'
 version = '2.5.0'
-ext.awsLcMainTag = 'v1.47.0'
+ext.awsLcMainTag = 'v1.48.2'
 ext.awsLcFipsTag = 'AWS-LC-FIPS-3.0.0'
 ext.isExperimentalFips = Boolean.getBoolean('EXPERIMENTAL_FIPS')
 ext.isFips = ext.isExperimentalFips || Boolean.getBoolean('FIPS')
@@ -260,7 +260,7 @@ task buildAwsLc {
                 args '-DCMAKE_BUILD_TYPE=RelWithDebInfo'
                 args "-DCMAKE_INSTALL_PREFIX=${sharedObjectOutDir}"
                 args "-DCMAKE_VERBOSE_MAKEFILE:BOOL=ON"
-
+                def cmakeCFlags = ""
 
                 if (isFips) {
                     println "Building AWS-LC in FIPS mode"
@@ -269,13 +269,15 @@ task buildAwsLc {
 
                 if (allowFipsTestBreak) {
                     println "Building AWS-LC with hooks to break FIPS tests"
-                    args '-DFIPS_BREAK_TEST=TESTS'
+                    cmakeCFlags += '-DBORINGSSL_FIPS_BREAK_TESTS '
                 }
 
                 if (isFipsSelfTestFailureSkipAbort) {
                     println "Building AWS-LC to call callback instead of aborting on self-test failure"
-                    args '-DCMAKE_C_FLAGS="-DAWSLC_FIPS_FAILURE_CALLBACK"'
+                    cmakeCFlags += '-DAWSLC_FIPS_FAILURE_CALLBACK '
                 }
+
+                args "-DCMAKE_C_FLAGS='${cmakeCFlags}'"
 
                 args '.'
             }

--- a/csrc/fips_status.cpp
+++ b/csrc/fips_status.cpp
@@ -71,10 +71,17 @@ extern "C" JNIEXPORT bool JNICALL
 Java_com_amazon_corretto_crypto_provider_AmazonCorrettoCryptoProvider_isFipsStatusOkInternal(
     JNIEnv* env, jobject thisObj)
 {
+#if defined(EXPERIMENTAL_FIPS_BUILD)
     if (!FIPS_is_entropy_cpu_jitter()) {
         AWS_LC_fips_failure_callback("CPU Jitter is not enabled");
         return false;
     }
+#else
+    // Below macro check can be removed once we consume an AWS-LC-FIPS verison with |FIPS_is_entropy_cpu_jitter|.
+    // Until then, this function should never be called unless we're in EXPERIMENTAL_FIPS_BUILD, so abort below
+    // to alert us when EXPERIMENTAL_FIPS_BUILD is dropped from FIPS_SELF_TEST_SKIP_ABORT in testing.
+    abort();
+#endif
     return fipsStatusErrors.size() == 0;
 }
 

--- a/csrc/fips_status.cpp
+++ b/csrc/fips_status.cpp
@@ -1,5 +1,6 @@
 // Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+#include <openssl/crypto.h>
 #include <cstdio>
 #include <functional>
 #include <jni.h>
@@ -66,10 +67,15 @@ Java_com_amazon_corretto_crypto_provider_AmazonCorrettoCryptoProvider_getFipsSel
     return arrayList;
 }
 
-extern "C" JNIEXPORT int JNICALL
-Java_com_amazon_corretto_crypto_provider_AmazonCorrettoCryptoProvider_fipsStatusErrorCount(JNIEnv* env, jobject thisObj)
+extern "C" JNIEXPORT bool JNICALL
+Java_com_amazon_corretto_crypto_provider_AmazonCorrettoCryptoProvider_isFipsStatusOkInternal(
+    JNIEnv* env, jobject thisObj)
 {
-    return fipsStatusErrors.size();
+    if (!FIPS_is_entropy_cpu_jitter()) {
+        AWS_LC_fips_failure_callback("CPU Jitter is not enabled");
+        return false;
+    }
+    return fipsStatusErrors.size() == 0;
 }
 
 // TEST methods below

--- a/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
+++ b/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
@@ -652,7 +652,7 @@ public final class AmazonCorrettoCryptoProvider extends java.security.Provider {
     return Loader.FIPS_BUILD;
   }
 
-  private native int fipsStatusErrorCount();
+  private native boolean isFipsStatusOkInternal();
 
   /**
    * @return true if and only if the underlying libcrypto library's FIPS related checks pass
@@ -676,7 +676,7 @@ public final class AmazonCorrettoCryptoProvider extends java.security.Provider {
         }
       }
     }
-    return fipsStatusErrorCount() == 0;
+    return isFipsStatusOkInternal();
   }
 
   private native List<String> getFipsSelfTestFailuresInternal();


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

# Notes

This PR contains a few follow ups to PR #433:
- Now that AWS-LC has [wired up](https://github.com/aws/aws-lc/commit/3cf0777000dab8670595d4c1e0ab8b6fac182e81) EdDSA keygen failures through the EVP API, clean up a few TODOs
- Adjust how we set CMake's CFlags due to a [minor breakage](https://github.com/aws/aws-lc/commit/b4d7108a6d36ae079a9d8308248bbffc26369813) incurred by our AWS-LC version bump.
- To allow testing against AWS-LC artifacts that aren't built with `BORINGSSL_FIPS_BREAK_TESTS`, add a check/assumption in the relevant unit test
- Enable CPU jitter in AWS-LC when ACCP's `FIPS_SELF_TEST_SKIP_ABORT` is set and incorporate a runtime check into the health status

# Testing

With `BORINGSSL_FIPS_BREAK_TESTS` enabled in AWS-LC:

```
$ JAVA_HOME=/usr/lib/jvm/java-17-amazon-corretto/ ./gradlew cmake_clean singleTest -DEXPERIMENTAL_FIPS=true -DFIPS_SELF_TEST_SKIP_ABORT=true -DALLOW_FIPS_TEST_BREAK=true -DSINGLE_TEST=com.amazon.corretto.crypto.provider.test.FipsStatusTest
...
 [PASSED]           com.amazon.corretto.crypto.provider.test.FipsStatusTest.givenAccpBuiltWithFips_whenAWS_LC_fips_failure_callback_expectException: givenAccpBuiltWithFips_whenAWS_LC_fips_failure_callback_expectException()
AWS_LC_fips_failure_callback invoked with message: 'RSA keygen checks failed'
AWS_LC_fips_failure_callback invoked with message: 'RSA keygen checks failed'
AWS_LC_fips_failure_callback invoked with message: 'EC keygen checks failed'
AWS_LC_fips_failure_callback invoked with message: 'Ed25519 keygen PCT failed'
AWS_LC_fips_failure_callback invoked with message: 'ML-DSA keygen PCT failed'
AWS_LC_fips_failure_callback invoked with message: 'ML-DSA self tests failed'
AWS_LC_fips_failure_callback invoked with message: 'ML-DSA keygen PCT failed'
 [PASSED]           com.amazon.corretto.crypto.provider.test.FipsStatusTest.testPwctBreakageSkipAbort: testPwctBreakageSkipAbort()
...
Test run finished after 1221 ms
[         3 containers found      ]
[         0 containers skipped    ]
[         3 containers started    ]
[         0 containers aborted    ]
[         3 containers successful ]
[         0 containers failed     ]
[         2 tests found           ]
[         0 tests skipped         ]
[         2 tests started         ]
[         0 tests aborted         ]
[         2 tests successful      ]
[         0 tests failed          ]
...
BUILD SUCCESSFUL in 39s
```

With `BORINGSSL_FIPS_BREAK_TESTS` disabled in AWS-LC:

```
$ JAVA_HOME=/usr/lib/jvm/java-17-amazon-corretto/ ./gradlew cmake_clean singleTest -DEXPERIMENTAL_FIPS=true -DFIPS_SELF_TEST_SKIP_ABORT=true -DALLOW_FIPS_TEST_BREAK=false -DSINGLE_TEST=com.amazon.corretto.crypto.provider.test.FipsStatusTest
...
 [PASSED]           com.amazon.corretto.crypto.provider.test.FipsStatusTest.givenAccpBuiltWithFips_whenAWS_LC_fips_failure_callback_expectException: givenAccpBuiltWithFips_whenAWS_LC_fips_failure_callback_expectException()
 [FALSE_ASSUMPTION] com.amazon.corretto.crypto.provider.test.FipsStatusTest.testPwctBreakageSkipAbort: testPwctBreakageSkipAbort()org.opentest4j.TestAbortedException: Assumption failed: assumption is not true
 ...
Test run finished after 1051 ms
[         3 containers found      ]
[         0 containers skipped    ]
[         3 containers started    ]
[         0 containers aborted    ]
[         3 containers successful ]
[         0 containers failed     ]
[         2 tests found           ]
[         0 tests skipped         ]
[         2 tests started         ]
[         1 tests aborted         ]
[         1 tests successful      ]
[         0 tests failed          ]
...
BUILD SUCCESSFUL in 3m 7s
```

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
