### PR TITLE
Upgrade spotless and nexus gradle plugins

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,9 +7,9 @@ plugins {
     id 'java'
     id 'maven-publish'
     id 'signing'
-    id "com.diffplug.spotless" version "6.18.0"
+    id "com.diffplug.spotless" version "7.0.2"
     id "com.google.osdetector" version "1.7.3"
-    id "io.github.gradle-nexus.publish-plugin" version "1.1.0"
+    id "io.github.gradle-nexus.publish-plugin" version "2.0.0"
 }
 
 group = 'software.amazon.cryptools'

--- a/src/com/amazon/corretto/crypto/provider/AesGcmSpi.java
+++ b/src/com/amazon/corretto/crypto/provider/AesGcmSpi.java
@@ -183,6 +183,7 @@ final class AesGcmSpi extends CipherSpi {
   // when the same Java key object is used to initialize a Cipher that was previously used.
   private Key lastKey = null;
   private byte[] iv, key;
+
   /** GCM tag length in bytes. */
   private int tagLength = DEFAULT_TAG_LENGTH / 8;
 

--- a/src/com/amazon/corretto/crypto/provider/EvpHmac.java
+++ b/src/com/amazon/corretto/crypto/provider/EvpHmac.java
@@ -23,6 +23,7 @@ import javax.crypto.spec.SecretKeySpec;
 class EvpHmac extends MacSpi implements Cloneable {
   /** When passed to {@code evpMd} indicates that the native code should not call HMAC_Init_ex. */
   private static long DO_NOT_INIT = -1;
+
   /**
    * When passed to {@code evpMd} indicates that while {@code HMAC_Init_ex} must be called, it
    * should be called with NULL for both the key and evpMd parameters.
@@ -41,6 +42,7 @@ class EvpHmac extends MacSpi implements Cloneable {
    */
   private static native void updateCtxArray(
       byte[] ctx, byte[] key, long evpMd, byte[] input, int offset, int length);
+
   /**
    * @see {@link #updateCtxArray(byte[], byte[], long, byte[], int, int)}
    */
@@ -59,6 +61,7 @@ class EvpHmac extends MacSpi implements Cloneable {
    * @param result
    */
   private static native void doFinal(byte[] ctx, byte[] result);
+
   /**
    * @see {@link #doFinal(byte[], byte[])}
    */
@@ -77,6 +80,7 @@ class EvpHmac extends MacSpi implements Cloneable {
    */
   private static native void fastHmac(
       byte[] ctx, byte[] key, long evpMd, byte[] input, int offset, int length, byte[] result);
+
   /**
    * @see {@link #fastHmac(byte[], byte[], long, byte[], int, int, byte[])}
    */
@@ -243,6 +247,7 @@ class EvpHmac extends MacSpi implements Cloneable {
   private static class TestMacProvider extends Provider {
     private final String macName;
     private final Class<? extends MacSpi> spi;
+
     // The superconstructor taking a double version is deprecated in java 9.
     // However, the replacement for it is
     // unavailable in java 8, so to build on both with warnings on our only choice

--- a/src/com/amazon/corretto/crypto/provider/EvpKey.java
+++ b/src/com/amazon/corretto/crypto/provider/EvpKey.java
@@ -29,11 +29,13 @@ abstract class EvpKey implements Key, Destroyable {
   protected final InternalKey internalKey;
   protected final EvpKeyType type;
   protected final boolean isPublicKey;
+
   /**
    * Indicates that the backing native key is used by another java object and thus must not be
    * released by this one.
    */
   protected boolean sharedKey = false;
+
   /**
    * Indicates that this key is entirely managed within ACCP controlled code and thus we know when
    * we're done with it and can release it.

--- a/src/com/amazon/corretto/crypto/provider/MlDsaGen.java
+++ b/src/com/amazon/corretto/crypto/provider/MlDsaGen.java
@@ -12,6 +12,7 @@ class MlDsaGen extends KeyPairGeneratorSpi {
   private static native long generateEvpMlDsaKey(int level);
 
   private final AmazonCorrettoCryptoProvider provider_;
+
   /**
    * level_ corresponds to the purported NIST security level for each ML-DSA variant. It uniquely
    * determines which NID is used to request an ML-DSA key. -1 indicates it is uninitialized.

--- a/src/com/amazon/corretto/crypto/provider/SecretKeyGenerator.java
+++ b/src/com/amazon/corretto/crypto/provider/SecretKeyGenerator.java
@@ -82,14 +82,14 @@ class SecretKeyGenerator extends KeyGeneratorSpi {
    * SecretKeyGenerator to get a service (SPI) class.
    */
   private interface SecretKeyProperties {
-    String getName(); // the name of the algorithm, like AES
+    // the name of the algorithm, like AES
+    String getName();
 
-    int defaultKeySize(); // the default key size, in bits, to be used in case a key size is not
-    // provided
+    // the default key size, in bits, to be used in case a key size is not provided
+    int defaultKeySize();
 
-    void checkKeySizeIsValid(
-        int keySize); // throws an exception if the given algorithm does not support keys of
-    // "keySize"
+    // throws an exception if the given algorithm does not support keys of "keySize"
+    void checkKeySizeIsValid(int keySize);
   }
 
   static final class AesSecretKeyProperties implements SecretKeyProperties {

--- a/src/com/amazon/corretto/crypto/provider/Utils.java
+++ b/src/com/amazon/corretto/crypto/provider/Utils.java
@@ -63,6 +63,7 @@ final class Utils {
    * call to @{code EVP_get_digestbyname}.
    */
   static native long getEvpMdFromName(String digestName);
+
   /** Returns the output length for a digest in bytes specified by {@code evpMd}. */
   static native int getDigestLength(long evpMd);
 

--- a/tst/com/amazon/corretto/crypto/provider/test/EvpKeyAgreementTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/EvpKeyAgreementTest.java
@@ -88,6 +88,7 @@ public class EvpKeyAgreementTest {
 
     @SuppressWarnings("unused")
     private final KeyPairGenerator keyGen;
+
     // We test pairwise across lots of keypairs in an effort
     // to catch rarer edge-cases.
     private final KeyPair[] pairs;

--- a/tst/com/amazon/corretto/crypto/provider/test/EvpSignatureTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/EvpSignatureTest.java
@@ -296,6 +296,7 @@ public class EvpSignatureTest {
   public static Stream<TestParams> params() {
     return byteBufferParams().filter(TestParams::goodForArraysAndByteBuffers);
   }
+
   /** Test cases for ByteBuffer related tests. */
   public static Stream<TestParams> byteBufferParams() {
     try {

--- a/tst/com/amazon/corretto/crypto/provider/test/TestUtil.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/TestUtil.java
@@ -47,6 +47,7 @@ import org.junit.jupiter.api.Assumptions;
 public class TestUtil {
   public static final String RESOURCE_REFLECTION = "REFLECTIVE_TOOLS";
   public static final String RESOURCE_PROVIDER = "JCE_PROVIDER";
+
   /**
    * Pseudo-resource used by ACCP tests to enforce that certain tests run by themselves. All tests
    * should takea "READ" lock on this resource. Tests which require exclusive control should take a
@@ -780,6 +781,7 @@ public class TestUtil {
 
     return output;
   }
+
   // Returns the length of the output.
   public static int multiStepInPlaceArray(
       final Cipher cipher,


### PR DESCRIPTION
*Issue #332 *

*Description of changes:*
Upgrade spotless and nexus gradle plugins.

Current version of spotless (6.18.0) fails under JDK21 due to an error in its `googleJavaFormat` dependency.
Spotless >= [6.19.0](https://github.com/diffplug/spotless/blob/main/plugin-gradle/CHANGES.md#6190---2023-05-24) has the fixed googleJavaFormat >= [1.17.0](https://github.com/google/google-java-format/releases/tag/v1.17.0) which fixes the JDK21 compatibility issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
