### PR TITLE
Remove "AES" Cipher alias

### DIFF
--- a/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
+++ b/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
@@ -148,13 +148,13 @@ public final class AmazonCorrettoCryptoProvider extends java.security.Provider {
 
     addService(
         "Cipher",
-        "AES",
+        "AES/CBC",
         "AesCbcSpi",
         false,
         singletonMap("SupportedModes", "CBC"),
-        "AES_128",
-        "AES_192",
-        "AES_256");
+        "AES_128/CBC",
+        "AES_192/CBC",
+        "AES_256/CBC");
 
     addService("Cipher", "RSA/ECB/NoPadding", "RsaCipher$NoPadding");
     addService("Cipher", "RSA/ECB/Pkcs1Padding", "RsaCipher$Pkcs1");
@@ -435,7 +435,7 @@ public final class AmazonCorrettoCryptoProvider extends java.security.Provider {
         return new AesCbcSpi(AesCbcSpi.Padding.ISO10126, saveContext);
       }
       // Allow the padding scheme to be set later by defaulting to a no-padding Cipher.
-      if (algo.toUpperCase().startsWith("AES")) {
+      if (algo.toUpperCase().startsWith("AES/CBC")) {
         return new AesCbcSpi(AesCbcSpi.Padding.NONE, saveContext);
       }
       throw new NoSuchAlgorithmException(format("No service class for Cipher/%s", algo));

--- a/tst/com/amazon/corretto/crypto/provider/test/AesCbcTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/AesCbcTest.java
@@ -1279,6 +1279,7 @@ public class AesCbcTest {
         () -> cipher.init(Cipher.ENCRYPT_MODE, key, nullParam));
   }
 
+  @Test
   public void testNoPaddingException() {
     TestUtil.assertThrows(
         NoSuchPaddingException.class,


### PR DESCRIPTION
*Issue #, if available:* Issue #444

*Description of changes:*

## Notes

@josalmi-sc reports in Issue #444 that as of v2.5.0, ACCP registers an `AES/CBC/PKCS5Padding` Cipher implementation under the (under-specified) alias `AES`. This diverges from OpenJDK's `AES` alias default of AES ECB (see source code [here](https://github.com/corretto/corretto-11/blob/9cb32ac57caa8efb211c1e90cc3aa297d202889f/src/java.base/share/classes/com/sun/crypto/provider/SunJCE.java#L188), [here](https://github.com/corretto/corretto-11/blob/9cb32ac57caa8efb211c1e90cc3aa297d202889f/src/java.base/share/classes/com/sun/crypto/provider/AESCipher.java#L185C20-L185C30), and [here](https://github.com/corretto/corretto-11/blob/develop/src/java.base/share/classes/com/sun/crypto/provider/CipherCore.java#L163) and JCA docs section "Creating a Cipher Object" [here](https://docs.oracle.com/javase/8/docs/technotes/guides/security/crypto/CryptoSpec.html#Cipher)).

This PR updates the `AES` Cipher alias added in 0a83799a to `AES/CBC`.

## Testing

I started by adding the aforementioned test in b08541e and observed that it failed. After the `AES` Cipher alias was subsequently removed in 5f5b666, the test passed.


---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
