### PR TITLE
Fix spotlessCppCheck build error

### DIFF
--- a/csrc/auto_free.h
+++ b/csrc/auto_free.h
@@ -63,7 +63,7 @@
         void releaseOwnership() { PTR_NAME(name) = NULL; }                                                             \
         void clear()                                                                                                   \
         {                                                                                                              \
-            CONCAT2(name, _free)(PTR_NAME(name));                                                                       \
+            CONCAT2(name, _free)(PTR_NAME(name));                                                                      \
             PTR_NAME(name) = NULL;                                                                                     \
         }                                                                                                              \
         name* operator->() { return *this; }                                                                           \


### PR DESCRIPTION
The current build fails with:

```
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':spotlessCppCheck'.
> The following files had format violations:
      csrc/auto_free.h
          @@ -63,7 +63,7 @@
           ········void·releaseOwnership()·{·PTR_NAME(name)·=·NULL;·}·····························································\
           ········void·clear()···································································································\
           ········{··············································································································\
          -············CONCAT2(name,·_free)(PTR_NAME(name));·······································································\
          +············CONCAT2(name,·_free)(PTR_NAME(name));······································································\
           ············PTR_NAME(name)·=·NULL;·····················································································\
           ········}··············································································································\
           ········name*·operator->()·{·return·*this;·}···········································································\
  Run './gradlew :spotlessApply' to fix these violations.
```

The fix is trivial.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
