### PR TITLE
Throw InvalidKeyException in sig init if Key alg is null

### DIFF
--- a/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
+++ b/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
@@ -689,14 +689,15 @@ public final class AmazonCorrettoCryptoProvider extends java.security.Provider {
       final long timeout = 3 * 1000;
       final long deadline = System.currentTimeMillis() + timeout;
       while (status == SelfTestStatus.NOT_RUN) {
+        if (System.currentTimeMillis() > deadline) {
+          throw new RuntimeCryptoException("FIPS self tests timed out");
+        }
         try {
           Thread.sleep(1);
         } catch (Exception e) {
           throw new RuntimeCryptoException(e);
         }
-        if (System.currentTimeMillis() > deadline) {
-          throw new RuntimeCryptoException("FIPS self tests timed out");
-        }
+        status = SelfTestSuite.AWS_LC_SELF_TESTS.getCachedResult().getStatus();
       }
     }
     return isFipsStatusOkInternal();

--- a/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
+++ b/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
@@ -688,7 +688,7 @@ public final class AmazonCorrettoCryptoProvider extends java.security.Provider {
       // If FIPS self tests haven't completed, give them a 3s timeout to complete.
       final long timeout = 3 * 1000;
       final long deadline = System.currentTimeMillis() + timeout;
-      while (status == SelfTestStatus.NOT_RUN) {
+      do {
         if (System.currentTimeMillis() > deadline) {
           throw new RuntimeCryptoException("FIPS self tests timed out");
         }
@@ -698,7 +698,7 @@ public final class AmazonCorrettoCryptoProvider extends java.security.Provider {
           throw new RuntimeCryptoException(e);
         }
         status = SelfTestSuite.AWS_LC_SELF_TESTS.getCachedResult().getStatus();
-      }
+      } while (status == SelfTestStatus.NOT_RUN);
     }
     return isFipsStatusOkInternal();
   }

--- a/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
+++ b/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
@@ -682,11 +682,13 @@ public final class AmazonCorrettoCryptoProvider extends java.security.Provider {
     if (!isFips() || !isFipsSelfTestFailureSkipAbort()) {
       throw new UnsupportedOperationException("ACCP not built with FIPS_SELF_TEST_SKIP_ABORT");
     }
-    if (getSelfTestStatus() == SelfTestStatus.NOT_RUN) {
-      // If FIPS self tests haven't completed, give them a 5s timeout to complete.
+    // For "FipsStatus", we only care about AWS-LC's self test status.
+    SelfTestStatus status = SelfTestSuite.AWS_LC_SELF_TESTS.getCachedResult().getStatus();
+    if (status == SelfTestStatus.NOT_RUN) {
+      // If FIPS self tests haven't completed, give them a 3s timeout to complete.
       final long timeout = 3 * 1000;
       final long deadline = System.currentTimeMillis() + timeout;
-      while (getSelfTestStatus() == SelfTestStatus.NOT_RUN) {
+      while (status == SelfTestStatus.NOT_RUN) {
         try {
           Thread.sleep(1);
         } catch (Exception e) {

--- a/src/com/amazon/corretto/crypto/provider/EvpSignatureBase.java
+++ b/src/com/amazon/corretto/crypto/provider/EvpSignatureBase.java
@@ -104,6 +104,9 @@ abstract class EvpSignatureBase extends SignatureSpi {
     if (privateKey == null) {
       throw new InvalidKeyException("Key must not be null");
     }
+    if (privateKey.getAlgorithm() == null) {
+      throw new InvalidKeyException("Key algorithm must not be null");
+    }
 
     if (untranslatedKey_ != privateKey) {
       if (!keyType_.jceName.equalsIgnoreCase(privateKey.getAlgorithm())
@@ -128,6 +131,9 @@ abstract class EvpSignatureBase extends SignatureSpi {
       throws InvalidKeyException {
     if (publicKey == null) {
       throw new InvalidKeyException("Key must not be null");
+    }
+    if (publicKey.getAlgorithm() == null) {
+      throw new InvalidKeyException("Key algorithm must not be null");
     }
 
     if (untranslatedKey_ != publicKey) {

--- a/tst/com/amazon/corretto/crypto/provider/test/AesGcmKatTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/AesGcmKatTest.java
@@ -133,7 +133,7 @@ public final class AesGcmKatTest {
     }
   }
 
-  private static Cipher getCipher() throws GeneralSecurityException {
+  private Cipher getCipher() throws GeneralSecurityException {
     return Cipher.getInstance("AES/GCM/NoPadding", TestUtil.NATIVE_PROVIDER);
   }
 }

--- a/tst/com/amazon/corretto/crypto/provider/test/EvpSignatureSpecificTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/EvpSignatureSpecificTest.java
@@ -821,6 +821,55 @@ public final class EvpSignatureSpecificTest {
     assertThrows(InvalidAlgorithmParameterException.class, () -> signer.setParameter(params));
   }
 
+  @Test
+  public void testInvalidKey() throws Exception {
+    final Signature signature = Signature.getInstance("SHA256withRSA", NATIVE_PROVIDER);
+
+    assertThrows(InvalidKeyException.class, () -> signature.initSign((PrivateKey) null));
+    assertThrows(InvalidKeyException.class, () -> signature.initVerify((PublicKey) null));
+
+    // Unfortunately we need to instantiate public/private separately because JDK 17+
+    // forbids casting across module boundaries, throwing java.lang.ClassCastException
+    PrivateKey emptyPrivateKey =
+        new PrivateKey() {
+          @Override
+          public String getAlgorithm() {
+            return null;
+          }
+
+          @Override
+          public String getFormat() {
+            return null;
+          }
+
+          @Override
+          public byte[] getEncoded() {
+            return null;
+          }
+        };
+
+    PublicKey emptyPublicKey =
+        new PublicKey() {
+          @Override
+          public String getAlgorithm() {
+            return null;
+          }
+
+          @Override
+          public String getFormat() {
+            return null;
+          }
+
+          @Override
+          public byte[] getEncoded() {
+            return null;
+          }
+        };
+
+    assertThrows(InvalidKeyException.class, () -> signature.initSign(emptyPrivateKey));
+    assertThrows(InvalidKeyException.class, () -> signature.initVerify(emptyPublicKey));
+  }
+
   @SuppressWarnings("serial")
   private static class RawKey implements PublicKey, PrivateKey {
     private final String algorithm_;


### PR DESCRIPTION
*Issue #, if available:* t/V1749540670

*Description of changes:*

This is a small change to match [OpenJDK's behavior](https://github.com/corretto/corretto-17/blob/f11c13eeefe3d8795a7ab6fd78cb9479786fea5a/src/java.base/share/classes/sun/security/rsa/RSASignature.java#L124C21-L126).

We also modify `isFipsStatusOk()` to only consider AWS-LC's self-tests and disregard ACCP's own, which are irrelevant to FIPS. Using the full self test suite caused a deadlock on JDK8 because HMAC self-tests calling `Mac.newInstance` would check `isFipsStatusOk()`, which would in turn await the HMAC self-tests, etc.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
