### PR TITLE
Refactor AES benchmarks, add AES CBC

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ Signature algorithms:
 * SHA512withECDSAinP1363Format
 * RSASSA-PSS
 * ED25519 (JDK 15+)
+* ED25519ph (JDK 15+)
+* ML-DSA
+* ML-DSA-ExtMu
 
 KeyPairGenerator:
 * EC

--- a/benchmarks/lib/src/jmh/java/com/amazon/corretto/crypto/provider/benchmarks/AesBase.java
+++ b/benchmarks/lib/src/jmh/java/com/amazon/corretto/crypto/provider/benchmarks/AesBase.java
@@ -1,0 +1,79 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package com.amazon.corretto.crypto.provider.benchmarks;
+
+import java.security.Key;
+import java.security.spec.AlgorithmParameterSpec;
+import javax.crypto.Cipher;
+import javax.crypto.spec.SecretKeySpec;
+
+public abstract class AesBase {
+  protected static final int PLAINTEXT_SIZE = 1024 * 1024;
+
+  protected Key key;
+  protected AlgorithmParameterSpec params1;
+  protected AlgorithmParameterSpec params2;
+  protected Cipher encryptor;
+  protected Cipher decryptor;
+  protected byte[] plaintext;
+  protected byte[] ciphertext;
+
+  protected abstract String getMode();
+
+  protected abstract AlgorithmParameterSpec createParameterSpec(byte[] iv);
+
+  protected abstract int getIvSize();
+
+  protected void setup(int keyBits, String provider, String padding) throws Exception {
+    BenchmarkUtils.setupProvider(provider);
+    key = new SecretKeySpec(BenchmarkUtils.getRandBytes(keyBits / 8), "AES");
+    params1 = createParameterSpec(BenchmarkUtils.getRandBytes(getIvSize()));
+    params2 = createParameterSpec(BenchmarkUtils.getRandBytes(getIvSize()));
+    final String algorithm = "AES/" + getMode() + "/" + padding;
+    encryptor = Cipher.getInstance(algorithm, provider);
+    decryptor = Cipher.getInstance(algorithm, provider);
+    encryptor.init(Cipher.ENCRYPT_MODE, key, params1);
+    decryptor.init(Cipher.DECRYPT_MODE, key, params1);
+    plaintext = BenchmarkUtils.getRandBytes(PLAINTEXT_SIZE);
+    ciphertext = encryptor.doFinal(plaintext);
+    encryptor.init(Cipher.ENCRYPT_MODE, key, params2);
+    decryptor.init(Cipher.DECRYPT_MODE, key, params2);
+  }
+
+  public byte[] oneShot1MiBEncrypt() throws Exception {
+    encryptor.init(Cipher.ENCRYPT_MODE, key, params1);
+    byte[] out = encryptor.doFinal(plaintext);
+    encryptor.init(Cipher.ENCRYPT_MODE, key, params2);
+    return out;
+  }
+
+  public byte[] oneShot1MiBDecrypt() throws Exception {
+    decryptor.init(Cipher.DECRYPT_MODE, key, params1);
+    byte[] out = decryptor.doFinal(ciphertext);
+    decryptor.init(Cipher.DECRYPT_MODE, key, params2);
+    return out;
+  }
+
+  public byte[] updateEncrypt(int chunkSize) throws Exception {
+    encryptor.init(Cipher.ENCRYPT_MODE, key, params1);
+    for (int ii = 0; ii < plaintext.length; ii += chunkSize) {
+      encryptor.update(plaintext, ii, chunkSize);
+    }
+    byte[] out = encryptor.doFinal();
+    encryptor.init(Cipher.ENCRYPT_MODE, key, params2);
+    return out;
+  }
+
+  public byte[] updateDecrypt(int chunkSize) throws Exception {
+    decryptor.init(Cipher.DECRYPT_MODE, key, params1);
+    for (int ii = 0; ii < plaintext.length; ii += chunkSize) {
+      decryptor.update(ciphertext, ii, chunkSize);
+    }
+    // Don't forget to include the auth tag if applicable. This is a no-op
+    // if plaintext and ciphertext are same length (i.e. no tag).
+    decryptor.update(ciphertext, plaintext.length, ciphertext.length - plaintext.length);
+    byte[] out = decryptor.doFinal();
+    decryptor.init(Cipher.DECRYPT_MODE, key, params2);
+    return out;
+  }
+}

--- a/benchmarks/lib/src/jmh/java/com/amazon/corretto/crypto/provider/benchmarks/AesCbcOneShot.java
+++ b/benchmarks/lib/src/jmh/java/com/amazon/corretto/crypto/provider/benchmarks/AesCbcOneShot.java
@@ -20,7 +20,7 @@ public class AesCbcOneShot extends AesBase {
   @Param({AmazonCorrettoCryptoProvider.PROVIDER_NAME, "BC", "SunJCE"})
   public String provider;
 
-  @Param({"NoPadding"})
+  @Param({"NoPadding", "PKCS5Padding" })
   public String padding;
 
   @Setup

--- a/benchmarks/lib/src/jmh/java/com/amazon/corretto/crypto/provider/benchmarks/AesCbcOneShot.java
+++ b/benchmarks/lib/src/jmh/java/com/amazon/corretto/crypto/provider/benchmarks/AesCbcOneShot.java
@@ -1,0 +1,55 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package com.amazon.corretto.crypto.provider.benchmarks;
+
+import java.security.spec.AlgorithmParameterSpec;
+import javax.crypto.spec.IvParameterSpec;
+
+import com.amazon.corretto.crypto.provider.AmazonCorrettoCryptoProvider;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+@State(Scope.Benchmark)
+public class AesCbcOneShot extends AesBase {
+  @Param({"128", "256"})
+  public int keyBits;
+
+  @Param({AmazonCorrettoCryptoProvider.PROVIDER_NAME, "BC", "SunJCE"})
+  public String provider;
+
+  @Param({"NoPadding"})
+  public String padding;
+
+  @Setup
+  public void setup() throws Exception {
+    super.setup(keyBits, provider, padding);
+  }
+
+  @Override
+  protected String getMode() {
+    return "CBC";
+  }
+
+  @Override
+  protected AlgorithmParameterSpec createParameterSpec(byte[] iv) {
+    return new IvParameterSpec(iv);
+  }
+
+  @Override
+  protected int getIvSize() {
+    return 16;
+  }
+
+  @Benchmark
+  public byte[] encrypt() throws Exception {
+    return super.oneShot1MiBEncrypt();
+  }
+
+  @Benchmark
+  public byte[] decrypt() throws Exception {
+    return super.oneShot1MiBDecrypt();
+  }
+}

--- a/benchmarks/lib/src/jmh/java/com/amazon/corretto/crypto/provider/benchmarks/AesCbcUpdate.java
+++ b/benchmarks/lib/src/jmh/java/com/amazon/corretto/crypto/provider/benchmarks/AesCbcUpdate.java
@@ -1,0 +1,58 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package com.amazon.corretto.crypto.provider.benchmarks;
+
+import java.security.spec.AlgorithmParameterSpec;
+import javax.crypto.spec.IvParameterSpec;
+
+import com.amazon.corretto.crypto.provider.AmazonCorrettoCryptoProvider;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+@State(Scope.Benchmark)
+public class AesCbcUpdate extends AesBase {
+  @Param({"128", "256"})
+  public int keyBits;
+
+  @Param({AmazonCorrettoCryptoProvider.PROVIDER_NAME, "BC", "SunJCE"})
+  public String provider;
+
+  @Param({"NoPadding"}) // Other values: { "PKCS5Padding", "ISO10126Padding" }
+  public String padding;
+
+  @Param({"16", "256"})
+  public int chunkSize;
+
+  @Setup
+  public void setup() throws Exception {
+    super.setup(keyBits, provider, padding);
+  }
+
+  @Override
+  protected String getMode() {
+    return "CBC";
+  }
+
+  @Override
+  protected AlgorithmParameterSpec createParameterSpec(byte[] iv) {
+    return new IvParameterSpec(iv);
+  }
+
+  @Override
+  protected int getIvSize() {
+    return 16;
+  }
+
+  @Benchmark
+  public byte[] encrypt() throws Exception {
+    return super.updateEncrypt(chunkSize);
+  }
+
+  @Benchmark
+  public byte[] decrypt() throws Exception {
+    return super.updateDecrypt(chunkSize);
+  }
+}

--- a/benchmarks/lib/src/jmh/java/com/amazon/corretto/crypto/provider/benchmarks/AesCbcUpdate.java
+++ b/benchmarks/lib/src/jmh/java/com/amazon/corretto/crypto/provider/benchmarks/AesCbcUpdate.java
@@ -20,7 +20,7 @@ public class AesCbcUpdate extends AesBase {
   @Param({AmazonCorrettoCryptoProvider.PROVIDER_NAME, "BC", "SunJCE"})
   public String provider;
 
-  @Param({"NoPadding"}) // Other values: { "PKCS5Padding", "ISO10126Padding" }
+  @Param({"NoPadding", "PKCS5Padding" })
   public String padding;
 
   @Param({"16", "256"})

--- a/benchmarks/lib/src/jmh/java/com/amazon/corretto/crypto/provider/benchmarks/AesCfbOneShot.java
+++ b/benchmarks/lib/src/jmh/java/com/amazon/corretto/crypto/provider/benchmarks/AesCfbOneShot.java
@@ -2,61 +2,54 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.amazon.corretto.crypto.provider.benchmarks;
 
-import java.net.URL;
-import java.net.URLClassLoader;
-import java.security.NoSuchAlgorithmException;
-import java.security.NoSuchProviderException;
-import java.security.Provider;
-import java.security.SecureRandom;
-import java.security.Security;
-import java.util.concurrent.TimeUnit;
-
-import javax.crypto.Cipher;
-import javax.crypto.KeyGenerator;
-import javax.crypto.SecretKey;
+import java.security.spec.AlgorithmParameterSpec;
 import javax.crypto.spec.IvParameterSpec;
 
 import com.amazon.corretto.crypto.provider.AmazonCorrettoCryptoProvider;
 import org.openjdk.jmh.annotations.Benchmark;
-import org.openjdk.jmh.annotations.BenchmarkMode;
-import org.openjdk.jmh.annotations.Fork;
-import org.openjdk.jmh.annotations.Level;
-import org.openjdk.jmh.annotations.Measurement;
-import org.openjdk.jmh.annotations.Mode;
-import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
-import org.openjdk.jmh.annotations.Warmup;
-import org.openjdk.jmh.infra.Blackhole;
 
 @State(Scope.Benchmark)
-public class AesCfbOneShot extends AesCfbBase {
-    @Param({"128", "256"})
-    public int keyBits;
+public class AesCfbOneShot extends AesBase {
+  @Param({"128", "256"})
+  public int keyBits;
 
-    @Param({AmazonCorrettoCryptoProvider.PROVIDER_NAME, "BC", "SunJCE"})
-    public String provider;
+  @Param({AmazonCorrettoCryptoProvider.PROVIDER_NAME, "BC", "SunJCE"})
+  public String provider;
 
-    @Setup
-    public void setup() throws Exception {
-        super.setup(keyBits, provider);
-    }
+  @Param({"NoPadding"})
+  public String padding;
 
-    @Benchmark
-    public byte[] oneShot1MiBEncrypt() throws Exception {
-        encryptor.init(Cipher.ENCRYPT_MODE, key, params1);
-        byte[] out = encryptor.doFinal(plaintext);
-        encryptor.init(Cipher.ENCRYPT_MODE, key, params2);
-        return out;
-    }
+  @Setup
+  public void setup() throws Exception {
+    super.setup(keyBits, provider, padding);
+  }
 
-    @Benchmark
-    public byte[] oneShot1MiBDecrypt() throws Exception {
-        decryptor.init(Cipher.DECRYPT_MODE, key, params1);
-        byte[] out = decryptor.doFinal(ciphertext);
-        decryptor.init(Cipher.DECRYPT_MODE, key, params2);
-        return out;
-    }
+  @Override
+  protected String getMode() {
+    return "CFB";
+  }
+
+  @Override
+  protected AlgorithmParameterSpec createParameterSpec(byte[] iv) {
+    return new IvParameterSpec(iv);
+  }
+
+  @Override
+  protected int getIvSize() {
+    return 16;
+  }
+
+  @Benchmark
+  public byte[] encrypt() throws Exception {
+    return super.oneShot1MiBEncrypt();
+  }
+
+  @Benchmark
+  public byte[] decrypt() throws Exception {
+    return super.oneShot1MiBDecrypt();
+  }
 }

--- a/benchmarks/lib/src/jmh/java/com/amazon/corretto/crypto/provider/benchmarks/AesCfbUpdate.java
+++ b/benchmarks/lib/src/jmh/java/com/amazon/corretto/crypto/provider/benchmarks/AesCfbUpdate.java
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.amazon.corretto.crypto.provider.benchmarks;
 
-import javax.crypto.Cipher;
+import java.security.spec.AlgorithmParameterSpec;
+import javax.crypto.spec.IvParameterSpec;
 
 import com.amazon.corretto.crypto.provider.AmazonCorrettoCryptoProvider;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -12,43 +13,46 @@ import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 
 @State(Scope.Benchmark)
-public class AesCfbUpdate extends AesCfbBase {
+public class AesCfbUpdate extends AesBase {
   @Param({"128", "256"})
   public int keyBits;
-
-  @Param({"16", "256"})
-  public int chunkSize;
 
   @Param({AmazonCorrettoCryptoProvider.PROVIDER_NAME, "BC", "SunJCE"})
   public String provider;
 
+  @Param({"NoPadding"})
+  public String padding;
+
+  @Param({"16", "256"})
+  public int chunkSize;
+
   @Setup
   public void setup() throws Exception {
-    super.setup(keyBits, provider);
-    assert PLAINTEXT_SIZE % chunkSize == 0;
+    super.setup(keyBits, provider, padding);
+  }
+
+  @Override
+  protected String getMode() {
+    return "CFB";
+  }
+
+  @Override
+  protected AlgorithmParameterSpec createParameterSpec(byte[] iv) {
+    return new IvParameterSpec(iv);
+  }
+
+  @Override
+  protected int getIvSize() {
+    return 16;
   }
 
   @Benchmark
-  public byte[] updateEncrypt() throws Exception {
-    encryptor.init(Cipher.ENCRYPT_MODE, key, params1);
-    for (int ii = 0; ii < plaintext.length; ii += chunkSize) {
-      encryptor.update(plaintext, ii, chunkSize);
-    }
-    byte[] out = encryptor.doFinal();
-    encryptor.init(Cipher.ENCRYPT_MODE, key, params2);
-    return out;
+  public byte[] encrypt() throws Exception {
+    return super.updateEncrypt(chunkSize);
   }
 
   @Benchmark
-  public byte[] updateDecrypt() throws Exception {
-    decryptor.init(Cipher.DECRYPT_MODE, key, params1);
-    for (int ii = 0; ii < plaintext.length; ii += chunkSize) {
-      decryptor.update(ciphertext, ii, chunkSize);
-    }
-    // don't forget to include the auth tag
-    decryptor.update(ciphertext, plaintext.length, ciphertext.length - plaintext.length);
-    byte[] out = decryptor.doFinal();
-    decryptor.init(Cipher.DECRYPT_MODE, key, params2);
-    return out;
+  public byte[] decrypt() throws Exception {
+    return super.updateDecrypt(chunkSize);
   }
 }

--- a/benchmarks/lib/src/jmh/java/com/amazon/corretto/crypto/provider/benchmarks/AesGcmOneShot.java
+++ b/benchmarks/lib/src/jmh/java/com/amazon/corretto/crypto/provider/benchmarks/AesGcmOneShot.java
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.amazon.corretto.crypto.provider.benchmarks;
 
-import javax.crypto.Cipher;
+import java.security.spec.AlgorithmParameterSpec;
+import javax.crypto.spec.GCMParameterSpec;
 
 import com.amazon.corretto.crypto.provider.AmazonCorrettoCryptoProvider;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -12,31 +13,43 @@ import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 
 @State(Scope.Benchmark)
-public class AesGcmOneShot extends AesGcmBase {
+public class AesGcmOneShot extends AesBase {
   @Param({"128", "256"})
   public int keyBits;
 
   @Param({AmazonCorrettoCryptoProvider.PROVIDER_NAME, "BC", "SunJCE"})
   public String provider;
 
+  @Param({"NoPadding"})
+  public String padding;
+
   @Setup
   public void setup() throws Exception {
-    super.setup(keyBits, provider);
+    super.setup(keyBits, provider, padding);
+  }
+
+  @Override
+  protected String getMode() {
+    return "GCM";
+  }
+
+  @Override
+  protected AlgorithmParameterSpec createParameterSpec(byte[] iv) {
+    return new GCMParameterSpec(128, iv);
+  }
+
+  @Override
+  protected int getIvSize() {
+    return 12;
   }
 
   @Benchmark
-  public byte[] oneShot1MiBEncrypt() throws Exception {
-    encryptor.init(Cipher.ENCRYPT_MODE, key, params1);
-    byte[] out = encryptor.doFinal(plaintext);
-    encryptor.init(Cipher.ENCRYPT_MODE, key, params2);
-    return out;
+  public byte[] encrypt() throws Exception {
+    return super.oneShot1MiBEncrypt();
   }
 
   @Benchmark
-  public byte[] oneShot1MiBDecrypt() throws Exception {
-    decryptor.init(Cipher.DECRYPT_MODE, key, params1);
-    byte[] out = decryptor.doFinal(ciphertext);
-    decryptor.init(Cipher.DECRYPT_MODE, key, params2);
-    return out;
+  public byte[] decrypt() throws Exception {
+    return super.oneShot1MiBDecrypt();
   }
 }


### PR DESCRIPTION
# Description

This commit cuts down on code duplication by refactoring common logic and parameters into `AesBase.java`. We also take the opportunity to add benchmarks for AES CBC. The consolidated benchmarks make it easy to parameterize by padding mode, but we defer this to avoid over-parameterizing the benchmark graphs until/if needed. We also considered marking cipher mode (i.e. GCM, CBC, or CFB) a benchmark parameter instead of distinct benchmark classes, but declined to do so for similar reasons.

# Testing

Ran the following command and confirmed that the suite subset executed correctly.

```
./gradlew -PaccpLocalJar="../../build/cmake/AmazonCorrettoCryptoProvider.jar" -PincludeBenchmark="Aes*" lib:jmh
```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
