### PR TITLE
Increase AWS-LC FIPS error message limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,10 +213,8 @@ ACCP artifacts on Maven can be verified using the following PGP keys:
 
 
 ### Gradle
-Add the following to your `build.gradle` file. If you already have a
-`dependencies` block in your `build.gradle`, you can add the ACCP line to your
-existing block.
-For more information, please see [VERSIONING.rst](https://github.com/corretto/amazon-corretto-crypto-provider/blob/main/VERSIONING.rst).
+
+Add something like following to your `build.gradle` file.
 
 ```groovy
 dependencies {
@@ -224,10 +222,16 @@ dependencies {
 }
 ```
 
+If you already have a `dependencies` block in your `build.gradle`, you can add the ACCP line to your existing block.
+
+The above sample configuration assumes you're using the `linux-x86_64` platform. If you're using another platform, please refer to the "Installation" parent section above and substitute appropriately.
+
 For Gradle builds, the [os-detector plugin](https://github.com/google/osdetector-gradle-plugin)
-could be used so that one does not have to explicitly specify the platform.
+can be used to avoid explicitly specifying the platform.
 [Here](https://github.com/corretto/amazon-corretto-crypto-provider/blob/f1d54b34cf4765789314941dbeefdafd35a4da58/examples/gradle-kt-dsl/lib/build.gradle.kts#L30)
 is an example.
+
+For more version information, please see [VERSIONING.rst](https://github.com/corretto/amazon-corretto-crypto-provider/blob/main/VERSIONING.rst).
 
 ### Bundle ACCP with JDK
 We provide two scripts that allow one to add ACCP to their JDKs: one for JDK8 and one for JDKs 11+.

--- a/csrc/fips_status.cpp
+++ b/csrc/fips_status.cpp
@@ -17,7 +17,8 @@ extern "C" void AWS_LC_fips_failure_callback(char const* message);
 #if defined(FIPS_SELF_TEST_SKIP_ABORT)
 void AWS_LC_fips_failure_callback(char const* message)
 {
-    const size_t char_limit = 128;
+    // Must track https://github.com/aws/aws-lc/blob/e4885d5e22f7dc482dd6bfa713b0e1b763b5c538/crypto/fipsmodule/self_check/self_check.c#L52
+    const size_t char_limit = 10315;    // (2 * (2 * 2560)) + 42 + 33
     if (strnlen(message, char_limit + 1) > char_limit) {
         fprintf(stderr, "AWS_LC_fips_failure_callback invoked with message message exceeding %lu chars\n", char_limit);
         return;

--- a/csrc/fips_status.cpp
+++ b/csrc/fips_status.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 #include <openssl/crypto.h>
 #include <cstdio>
+#include <cstring>
 #include <functional>
 #include <jni.h>
 #include <string.h>
@@ -17,14 +18,16 @@ extern "C" void AWS_LC_fips_failure_callback(char const* message);
 #if defined(FIPS_SELF_TEST_SKIP_ABORT)
 void AWS_LC_fips_failure_callback(char const* message)
 {
-    // Must track https://github.com/aws/aws-lc/blob/e4885d5e22f7dc482dd6bfa713b0e1b763b5c538/crypto/fipsmodule/self_check/self_check.c#L52
-    const size_t char_limit = 10315;    // (2 * (2 * 2560)) + 42 + 33
-    if (strnlen(message, char_limit + 1) > char_limit) {
-        fprintf(stderr, "AWS_LC_fips_failure_callback invoked with message message exceeding %lu chars\n", char_limit);
-        return;
-    }
     fprintf(stderr, "AWS_LC_fips_failure_callback invoked with message: '%s'\n", message);
-    fipsStatusErrors.push_back(message);
+    // Must track
+    // https://github.com/aws/aws-lc/blob/e4885d5e22f7dc482dd6bfa713b0e1b763b5c538/crypto/fipsmodule/self_check/self_check.c#L52
+    const size_t char_limit = 10315; // (2 * (2 * 2560)) + 42 + 33
+    if (strnlen(message, char_limit + 1) > char_limit) {
+        std::string truncated(message, 0, char_limit);
+        fipsStatusErrors.push_back(truncated);
+    } else {
+        fipsStatusErrors.push_back(message);
+    }
 }
 #else
 void AWS_LC_fips_failure_callback(char const* message)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Additionally, we truncate oversized messages and append them to the queue to prevent information loss.

Finally, we add an adjacent gradle configuration clarification to `README.md`.

---


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
