### PR TITLE
Upgrade to latest dependency versions. Esp jacoco for JDK21 compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -185,11 +185,11 @@ dependencies {
     jacocoAgent group: 'org.jacoco', name: 'org.jacoco.agent', version: '0.8.13', classifier: 'runtime'
 
     // Separate so we can extract the jar for the runner specifically
-    testRunner group: 'org.junit.platform', name: 'junit-platform-console-standalone', version: '1.13.2'
+    testRunner group: 'org.junit.platform', name: 'junit-platform-console-standalone', version: '1.10.3'
 
     testDep 'org.apiguardian:apiguardian-api:1.1.2'
-    testDep 'org.junit.jupiter:junit-jupiter:5.13.2'
-    testDep 'org.junit.vintage:junit-vintage-engine:5.13.2'
+    testDep 'org.junit.jupiter:junit-jupiter:5.10.3'
+    testDep 'org.junit.vintage:junit-vintage-engine:5.10.3'
     testDep 'org.bouncycastle:bcpkix-jdk18on:1.81'
     testDep 'org.bouncycastle:bcprov-jdk18on:1.81'
     testDep 'commons-codec:commons-codec:1.18.0'

--- a/build.gradle
+++ b/build.gradle
@@ -182,20 +182,20 @@ repositories {
 
 dependencies {
     // Separate so we can extract the jar for the agent specifically
-    jacocoAgent group: 'org.jacoco', name: 'org.jacoco.agent', version: '0.8.7', classifier: 'runtime'
+    jacocoAgent group: 'org.jacoco', name: 'org.jacoco.agent', version: '0.8.13', classifier: 'runtime'
 
     // Separate so we can extract the jar for the runner specifically
-    testRunner group: 'org.junit.platform', name: 'junit-platform-console-standalone', version: '1.8.2'
+    testRunner group: 'org.junit.platform', name: 'junit-platform-console-standalone', version: '1.13.2'
 
     testDep 'org.apiguardian:apiguardian-api:1.1.2'
-    testDep 'org.junit.jupiter:junit-jupiter:5.8.2'
-    testDep 'org.junit.vintage:junit-vintage-engine:5.8.2'
-    testDep 'org.bouncycastle:bcpkix-jdk18on:1.80'
-    testDep 'org.bouncycastle:bcprov-jdk18on:1.80'
-    testDep 'commons-codec:commons-codec:1.12'
-    testDep 'org.hamcrest:hamcrest:2.1'
-    testDep 'org.jacoco:org.jacoco.core:0.8.3'
-    testDep 'org.jacoco:org.jacoco.report:0.8.3'
+    testDep 'org.junit.jupiter:junit-jupiter:5.13.2'
+    testDep 'org.junit.vintage:junit-vintage-engine:5.13.2'
+    testDep 'org.bouncycastle:bcpkix-jdk18on:1.81'
+    testDep 'org.bouncycastle:bcprov-jdk18on:1.81'
+    testDep 'commons-codec:commons-codec:1.18.0'
+    testDep 'org.hamcrest:hamcrest:3.0'
+    testDep 'org.jacoco:org.jacoco.core:0.8.13'
+    testDep 'org.jacoco:org.jacoco.report:0.8.13'
 }
 
 defaultTasks 'release'


### PR DESCRIPTION


Issue #: #332 

Description of changes:
Upgrade to latest dependency versions. 
Esp jacoco for JDK21 compatibility and avoid `Unsupported class file major version 65` errors during compilation. 
[Major version 65 corresponds to Java 21](https://docs.oracle.com/javase/specs/jvms/se24/html/jvms-4.html#jvms-4.1-200-B.2)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
