### PR TITLE
Test BouncyCastle ML-DSA key serde

### DIFF
--- a/tst/com/amazon/corretto/crypto/provider/test/MLDSATest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/MLDSATest.java
@@ -90,9 +90,7 @@ public class MLDSATest {
         // support non-Bouncy-Castle keys.
         KeyFactory bcKf = KeyFactory.getInstance("ML-DSA", TestUtil.BC_PROVIDER);
         PublicKey bcPub = bcKf.generatePublic(new X509EncodedKeySpec(nativePub.getEncoded()));
-        // TODO uncomment below once BC supports CHOICE-encoded private keys
-        // PrivateKey bcPriv = bcKf.generatePrivate(new
-        // PKCS8EncodedKeySpec(nativePriv.getEncoded()));
+        PrivateKey bcPriv = bcKf.generatePrivate(new PKCS8EncodedKeySpec(nativePriv.getEncoded()));
 
         Provider nativeProv = NATIVE_PROVIDER;
         Provider bcProv = TestUtil.BC_PROVIDER;
@@ -102,8 +100,8 @@ public class MLDSATest {
 
         params.add(new TestParams(nativeProv, nativeProv, nativePriv, nativePub, message));
         params.add(new TestParams(nativeProv, bcProv, nativePriv, bcPub, message));
-        // params.add(new TestParams(bcProv, nativeProv, bcPriv, nativePub, message));
-        // params.add(new TestParams(bcProv, bcProv, bcPriv, bcPub, message));
+        params.add(new TestParams(bcProv, nativeProv, bcPriv, nativePub, message));
+        params.add(new TestParams(bcProv, bcProv, bcPriv, bcPub, message));
       }
     }
     return params;

--- a/tst/com/amazon/corretto/crypto/provider/test/MLDSATest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/MLDSATest.java
@@ -25,7 +25,6 @@ import java.security.spec.X509EncodedKeySpec;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIf;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -202,7 +201,6 @@ public class MLDSATest {
         });
   }
 
-  @Disabled("until BC updates to newer CHOICE priv key encoding format")
   @Test
   public void documentBouncyCastleDifferences() throws Exception {
     // ACCP and BouncyCastle both encode ML-DSA public keys in "expanded "form and ML-DSA private
@@ -215,7 +213,7 @@ public class MLDSATest {
     PublicKey bcPub = bcKf.generatePublic(new X509EncodedKeySpec(nativePub.getEncoded()));
     PrivateKey bcPriv = bcKf.generatePrivate(new PKCS8EncodedKeySpec(nativePriv.getEncoded()));
     TestUtil.assertArraysHexEquals(bcPub.getEncoded(), nativePub.getEncoded());
-    assertEquals(bcPriv.getEncoded().length + 2, nativePriv.getEncoded().length);
+    assertEquals(bcPriv.getEncoded().length, nativePriv.getEncoded().length);
     TestUtil.assertArraysHexEquals(bcPriv.getEncoded(), nativePriv.getEncoded());
 
     nativePair = KeyPairGenerator.getInstance("ML-DSA-65", NATIVE_PROVIDER).generateKeyPair();
@@ -224,7 +222,7 @@ public class MLDSATest {
     bcPub = bcKf.generatePublic(new X509EncodedKeySpec(nativePub.getEncoded()));
     bcPriv = bcKf.generatePrivate(new PKCS8EncodedKeySpec(nativePriv.getEncoded()));
     TestUtil.assertArraysHexEquals(bcPub.getEncoded(), nativePub.getEncoded());
-    assertEquals(bcPriv.getEncoded().length + 2, nativePriv.getEncoded().length);
+    assertEquals(bcPriv.getEncoded().length, nativePriv.getEncoded().length);
     TestUtil.assertArraysHexEquals(bcPriv.getEncoded(), nativePriv.getEncoded());
 
     nativePair = KeyPairGenerator.getInstance("ML-DSA-87", NATIVE_PROVIDER).generateKeyPair();


### PR DESCRIPTION
# Notes

Now that we've upgraded our BouncyCastle test dependency to [1.81](https://github.com/bcgit/bc-java/releases/tag/r1v81), we can test de/serialization interop for `CHOICE`-formatted ML-DSA private keys.

# Testing
- CI

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
