### PR TITLE
Quash test details for successful tests

### DIFF
--- a/tst/com/amazon/corretto/crypto/provider/test/TestResultLogger.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/TestResultLogger.java
@@ -25,7 +25,6 @@ public class TestResultLogger implements TestWatcher {
 
   private static final String BRIGHT_TEXT = maybeColor("1");
   private static final String BRIGHT_RED_TEXT = maybeColor("31;1");
-  private static final String BRIGHT_GREEN_TEXT = maybeColor("32;1");
   private static final String BRIGHT_CYAN_TEXT = maybeColor("36;1");
   private static final String NORMAL_TEXT = maybeColor("0");
   private static final String NOT_YET_FAILED_NOTICE = " ";
@@ -34,8 +33,6 @@ public class TestResultLogger implements TestWatcher {
   @SuppressWarnings("unused")
   private static final String STARTED_NOTICE = BRIGHT_TEXT + "[STARTED]         " + NORMAL_TEXT;
 
-  private static final String PASSED_NOTICE =
-      BRIGHT_GREEN_TEXT + "[PASSED]          " + NORMAL_TEXT;
   private static final String ASSUMPTION_FAILED_NOTICE =
       BRIGHT_CYAN_TEXT + "[FALSE_ASSUMPTION]" + NORMAL_TEXT;
   private static final String FAILED_NOTICE = BRIGHT_RED_TEXT + "[FAILED]          " + NORMAL_TEXT;
@@ -51,7 +48,7 @@ public class TestResultLogger implements TestWatcher {
 
   @Override
   public void testSuccessful(ExtensionContext context) {
-    printNotice(PASSED_NOTICE, context);
+    // No-op
   }
 
   @Override


### PR DESCRIPTION
## Notes

Our output is too verbose. I tried to download test output from PR #485 and the zip file download timed out. My proposal to fix this is to skip logging of successful tests as those are both the most numerous and lowest-signal events.

## Testing

You can see the new `release` output in this PR's CI. Here's what running a single (successful) test looks like:

```
$ ./gradlew singleTest -DSINGLE_TEST=com.amazon.corretto.crypto.provider.test.EvpSignatureTest
Picked up JAVA_TOOL_OPTIONS: -Dlog4j2.formatMsgNoLookups=true

> Task :singleTest
[  1%] Creating Java archive code-only-jar.jar
...
[ 98%] Generating AmazonCorrettoCryptoProvider.jar
Picked up JAVA_TOOL_OPTIONS: -Dlog4j2.formatMsgNoLookups=true
Picked up JAVA_TOOL_OPTIONS: -Dlog4j2.formatMsgNoLookups=true
Picked up JAVA_TOOL_OPTIONS: -Dlog4j2.formatMsgNoLookups=true
Picked up JAVA_TOOL_OPTIONS: -Dlog4j2.formatMsgNoLookups=true
[100%] Built target accp-jar
Picked up JAVA_TOOL_OPTIONS: -Dlog4j2.formatMsgNoLookups=true

Thanks for using JUnit! Support its development at https://junit.org/sponsoring


Test run finished after 39916 ms
[        32 containers found      ]
[         0 containers skipped    ]
[        32 containers started    ]
[         0 containers aborted    ]
[        32 containers successful ]
[         0 containers failed     ]
[     67398 tests found           ]
[         0 tests skipped         ]
[     67398 tests started         ]
[         0 tests aborted         ]
[     67398 tests successful      ]
[         0 tests failed          ]


WARNING: Delegated to the 'execute' command.
         This behaviour has been deprecated and will be removed in a future release.
         Please use the 'execute' command directly.
[100%] Built target check-junit-single

BUILD SUCCESSFUL in 1m 4s
3 actionable tasks: 1 executed, 2 up-to-date
```

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
