### PR TITLE
Add support for ML-KEM

### DIFF
--- a/.github/workflows/macos_ci_jobs.yml
+++ b/.github/workflows/macos_ci_jobs.yml
@@ -86,7 +86,7 @@ jobs:
         java-version: '11'
         distribution: 'corretto'
 
-    # Test on Corretto 11.
+    # Test on Corretto 11 targetting JDK 8.
     - name: Build and run tests for ${{ env.PACKAGE_NAME }} in corretto 11
       env:
         TEST_JAVA_HOME: ${{ env.JAVA_HOME }}
@@ -118,7 +118,7 @@ jobs:
       with:
         java-version: '17'
         distribution: 'corretto'
-    # Test on Corretto 17.
+    # Test on Corretto 17 targetting JDK 8.
     - name: Build and run tests for ${{ env.PACKAGE_NAME }} in corretto 17
       env:
         TEST_JAVA_HOME: ${{ env.JAVA_HOME }}
@@ -197,7 +197,7 @@ jobs:
         java-version: '11'
         distribution: 'corretto'
 
-    # Test on Corretto 11.
+    # Test on Corretto 11 targetting JDK 8.
     - name: Build and run tests for ${{ env.PACKAGE_NAME }} in corretto 11
       env:
         TEST_JAVA_HOME: ${{ env.JAVA_HOME }}
@@ -229,7 +229,7 @@ jobs:
       with:
         java-version: '17'
         distribution: 'corretto'
-    # Test on Corretto 17.
+    # Test on Corretto 17 build targetting JDK 8.
     - name: Build and run tests for ${{ env.PACKAGE_NAME }} in corretto 17
       env:
         TEST_JAVA_HOME: ${{ env.JAVA_HOME }}
@@ -260,7 +260,7 @@ jobs:
       with:
         java-version: '17'
         distribution: 'corretto'
-    # Test on Corretto 17 with JDK 17 target.
+    # Test on Corretto 17 build targetting JDK 17.
     - name: Build and run tests for ${{ env.PACKAGE_NAME }} in corretto 17 targetting JDK 17 to include the jdk17plus folder
       env:
         TEST_JAVA_HOME: ${{ env.JAVA_HOME }}
@@ -291,7 +291,7 @@ jobs:
       with:
         java-version: '21'
         distribution: 'corretto'
-    # Test on Corretto 21 targetting JDK 21 .
+    # Test on Corretto 21 build targetting JDK 21 .
     - name: Build and run tests for ${{ env.PACKAGE_NAME }} in corretto 21 targetting JDK 21 to include the jdk17plus folder
       env:
         TEST_JAVA_HOME: ${{ env.JAVA_HOME }}

--- a/.github/workflows/macos_ci_jobs.yml
+++ b/.github/workflows/macos_ci_jobs.yml
@@ -86,7 +86,7 @@ jobs:
         java-version: '11'
         distribution: 'corretto'
 
-    # Test on Corretto 11 targetting JDK 8.
+    # Test on Corretto 11 targeting JDK 8.
     - name: Build and run tests for ${{ env.PACKAGE_NAME }} in corretto 11
       env:
         TEST_JAVA_HOME: ${{ env.JAVA_HOME }}
@@ -118,7 +118,7 @@ jobs:
       with:
         java-version: '17'
         distribution: 'corretto'
-    # Test on Corretto 17 targetting JDK 8.
+    # Test on Corretto 17 targeting JDK 8.
     - name: Build and run tests for ${{ env.PACKAGE_NAME }} in corretto 17
       env:
         TEST_JAVA_HOME: ${{ env.JAVA_HOME }}
@@ -197,7 +197,7 @@ jobs:
         java-version: '11'
         distribution: 'corretto'
 
-    # Test on Corretto 11 targetting JDK 8.
+    # Test on Corretto 11 targeting JDK 8.
     - name: Build and run tests for ${{ env.PACKAGE_NAME }} in corretto 11
       env:
         TEST_JAVA_HOME: ${{ env.JAVA_HOME }}
@@ -229,7 +229,7 @@ jobs:
       with:
         java-version: '17'
         distribution: 'corretto'
-    # Test on Corretto 17 build targetting JDK 8.
+    # Test on Corretto 17 build targeting JDK 8.
     - name: Build and run tests for ${{ env.PACKAGE_NAME }} in corretto 17
       env:
         TEST_JAVA_HOME: ${{ env.JAVA_HOME }}
@@ -260,8 +260,8 @@ jobs:
       with:
         java-version: '17'
         distribution: 'corretto'
-    # Test on Corretto 17 build targetting JDK 17.
-    - name: Build and run tests for ${{ env.PACKAGE_NAME }} in corretto 17 targetting JDK 17 to include the jdk17plus folder
+    # Test on Corretto 17 build targeting JDK 17.
+    - name: Build and run tests for ${{ env.PACKAGE_NAME }} in corretto 17 targeting JDK 17 to include the jdk17plus folder
       env:
         TEST_JAVA_HOME: ${{ env.JAVA_HOME }}
       run: |
@@ -291,8 +291,8 @@ jobs:
       with:
         java-version: '21'
         distribution: 'corretto'
-    # Test on Corretto 21 build targetting JDK 21 .
-    - name: Build and run tests for ${{ env.PACKAGE_NAME }} in corretto 21 targetting JDK 21 to include the jdk17plus folder
+    # Test on Corretto 21 build targeting JDK 21 .
+    - name: Build and run tests for ${{ env.PACKAGE_NAME }} in corretto 21 targeting JDK 21 to include the jdk17plus folder
       env:
         TEST_JAVA_HOME: ${{ env.JAVA_HOME }}
       run: |

--- a/.github/workflows/macos_ci_jobs.yml
+++ b/.github/workflows/macos_ci_jobs.yml
@@ -236,3 +236,35 @@ jobs:
       run: |
         ./tests/ci/run_accp_basic_tests.sh --lcov-ignore inconsistent
         ./tests/ci/run_accp_test_integration.sh
+  # Temporary JDK 17 ML-KEM job.
+  macOS17ArmTarget17:
+    name: JDK17MLKEM-TEMP
+    runs-on: macos-latest-xlarge
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+    - name: Install lcov dependencies from brew
+      run: |
+        env HOMEBREW_NO_AUTO_UPDATE=1 brew install lcov golang
+    - name: Setup pip
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.12'
+        cache: 'pip'
+    - name: Install gcovr
+      run: |
+        pip install gcovr
+    # Set up Corretto 17.
+    - name: Set up corretto 17
+      uses: actions/setup-java@v3
+      with:
+        java-version: '17'
+        distribution: 'corretto'
+    # Test on Corretto 17 with ML-KEM target.
+    - name: Build and run tests for ${{ env.PACKAGE_NAME }} in corretto 17 with ML-KEM
+      env:
+        TEST_JAVA_HOME: ${{ env.JAVA_HOME }}
+      run: |
+        ./tests/ci/run_accp_basic_tests.sh --lcov-ignore inconsistent --target-jdk-version 17
+        ./tests/ci/run_accp_test_integration.sh

--- a/.github/workflows/macos_ci_jobs.yml
+++ b/.github/workflows/macos_ci_jobs.yml
@@ -236,9 +236,8 @@ jobs:
       run: |
         ./tests/ci/run_accp_basic_tests.sh --lcov-ignore inconsistent
         ./tests/ci/run_accp_test_integration.sh
-  # Temporary JDK 17 ML-KEM job.
   macOS17ArmTarget17:
-    name: JDK17MLKEM-TEMP
+    name: JDK17ARM-TARGET-JDK17
     runs-on: macos-latest-xlarge
     steps:
     - uses: actions/checkout@v3
@@ -261,10 +260,41 @@ jobs:
       with:
         java-version: '17'
         distribution: 'corretto'
-    # Test on Corretto 17 with ML-KEM target.
-    - name: Build and run tests for ${{ env.PACKAGE_NAME }} in corretto 17 with ML-KEM
+    # Test on Corretto 17 with JDK 17 target.
+    - name: Build and run tests for ${{ env.PACKAGE_NAME }} in corretto 17 targetting JDK 17 to include the jdk17plus folder
       env:
         TEST_JAVA_HOME: ${{ env.JAVA_HOME }}
       run: |
         ./tests/ci/run_accp_basic_tests.sh --lcov-ignore inconsistent --target-jdk-version 17
+        ./tests/ci/run_accp_test_integration.sh
+  macOS21ArmTarget21:
+    name: JDK21ARM-TARGET-JDK21
+    runs-on: macos-latest-xlarge
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+    - name: Install lcov dependencies from brew
+      run: |
+        env HOMEBREW_NO_AUTO_UPDATE=1 brew install lcov golang
+    - name: Setup pip
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.12'
+        cache: 'pip'
+    - name: Install gcovr
+      run: |
+        pip install gcovr
+    # Set up Corretto 21.
+    - name: Set up corretto 21
+      uses: actions/setup-java@v3
+      with:
+        java-version: '21'
+        distribution: 'corretto'
+    # Test on Corretto 21 targetting JDK 21 .
+    - name: Build and run tests for ${{ env.PACKAGE_NAME }} in corretto 21 targetting JDK 21 to include the jdk17plus folder
+      env:
+        TEST_JAVA_HOME: ${{ env.JAVA_HOME }}
+      run: |
+        ./tests/ci/run_accp_basic_tests.sh --lcov-ignore inconsistent --target-jdk-version 21
         ./tests/ci/run_accp_test_integration.sh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,15 +168,12 @@ else()
     set(INCLUDE_JDK17PLUS_DIR TRUE)
 endif()
 
-# macro to filter source lists based on conditions and directory existence checks
+# macro to filter source lists based on conditions
 # FILTER_LIST: the list variable to filter
 # PATH_PATTERN: regex pattern to match paths for filtering (".*/jdk17plus/.*")
 # CONDITION: Boolean condition for whether or not the path PATH_PATTERN is excluded
-# CHECK_DIR: Directory path to check for existence - can remove after jdk17plus directory is merged to ACCP 
-macro(filter_sources_by_condition FILTER_LIST PATH_PATTERN CONDITION CHECK_DIR)
+macro(filter_sources_by_condition FILTER_LIST PATH_PATTERN CONDITION)
     if(NOT ${CONDITION})
-        list(FILTER ${FILTER_LIST} EXCLUDE REGEX "${PATH_PATTERN}")
-    elseif(CHECK_DIR AND NOT EXISTS "${CHECK_DIR}")
         list(FILTER ${FILTER_LIST} EXCLUDE REGEX "${PATH_PATTERN}")
     endif()
 endmacro()
@@ -188,11 +185,11 @@ endmacro()
 if (${CMAKE_VERSION} VERSION_LESS "3.12.0")
     file(GLOB_RECURSE ACCP_SRC "src/com/amazon/corretto/crypto/provider/*.java")
     file(GLOB_RECURSE ACCP_UTILS_SRC "src/com/amazon/corretto/crypto/utils/*.java")
-    filter_sources_by_condition(ACCP_SRC ".*/jdk17plus/.*" ${INCLUDE_JDK17PLUS_DIR} "${CMAKE_CURRENT_SOURCE_DIR}/src/com/amazon/corretto/crypto/provider/jdk17plus")
+    filter_sources_by_condition(ACCP_SRC ".*/jdk17plus/.*" ${INCLUDE_JDK17PLUS_DIR})
 else()
     file(GLOB_RECURSE ACCP_SRC CONFIGURE_DEPENDS "src/com/amazon/corretto/crypto/provider/*.java")
     file(GLOB_RECURSE ACCP_UTILS_SRC CONFIGURE_DEPENDS "src/com/amazon/corretto/crypto/utils/*.java")
-    filter_sources_by_condition(ACCP_SRC ".*/jdk17plus/.*" ${INCLUDE_JDK17PLUS_DIR} "${CMAKE_CURRENT_SOURCE_DIR}/src/com/amazon/corretto/crypto/provider/jdk17plus")
+    filter_sources_by_condition(ACCP_SRC ".*/jdk17plus/.*" ${INCLUDE_JDK17PLUS_DIR})
 endif()
 set(ACCP_SRC ${ACCP_SRC} ${ACCP_UTILS_SRC} ${GENERATED_JAVA_SRC})
 
@@ -360,6 +357,9 @@ if(EXPERIMENTAL_FIPS OR (NOT FIPS))
     set(C_SRC ${C_SRC} csrc/mldsa_gen.cpp)
 endif()
 
+if(INCLUDE_JDK17PLUS_DIR)
+    set(C_SRC ${C_SRC} csrc/mlkem_gen.cpp csrc/mlkem_spi.cpp)
+endif()
 add_library(amazonCorrettoCryptoProvider SHARED ${C_SRC})
 
 add_custom_command(
@@ -650,10 +650,10 @@ link_with_openssl(amazonCorrettoCryptoProvider)
 #       detected by CMake.
 if (${CMAKE_VERSION} VERSION_LESS "3.12.0")
     file(GLOB_RECURSE ACCP_TEST_SRC "tst/com/amazon/corretto/crypto/provider/*.java")
-    filter_sources_by_condition(ACCP_TEST_SRC ".*/jdk17plus/.*" ${INCLUDE_JDK17PLUS_DIR} "")
+    filter_sources_by_condition(ACCP_TEST_SRC ".*/jdk17plus/.*" ${INCLUDE_JDK17PLUS_DIR})
 else()
     file(GLOB_RECURSE ACCP_TEST_SRC CONFIGURE_DEPENDS "tst/com/amazon/corretto/crypto/provider/*.java")
-    filter_sources_by_condition(ACCP_TEST_SRC ".*/jdk17plus/.*" ${INCLUDE_JDK17PLUS_DIR} "")
+    filter_sources_by_condition(ACCP_TEST_SRC ".*/jdk17plus/.*" ${INCLUDE_JDK17PLUS_DIR})
 endif()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -351,14 +351,13 @@ else()
     set(TEST_FIPS_PROPERTY "-DFIPS=false")
 endif()
 
-if(INCLUDE_JDK17PLUS_DIR)
-    set(C_SRC ${C_SRC} csrc/mlkem_gen.cpp csrc/mlkem_spi.cpp)
-endif()
-
 # The source files under this guard should be removed and added to all builds, including FIPS,
 # once the corresponding algorithms are added to a FIPS branch of AWS-LC consumable by ACCP.
 if(EXPERIMENTAL_FIPS OR (NOT FIPS))
     set(C_SRC ${C_SRC} csrc/mldsa_gen.cpp)
+    if(INCLUDE_JDK17PLUS_DIR)
+        set(C_SRC ${C_SRC} csrc/mlkem_gen.cpp csrc/mlkem_spi.cpp)
+    endif()
 endif()
 
 add_library(amazonCorrettoCryptoProvider SHARED ${C_SRC})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -351,15 +351,15 @@ else()
     set(TEST_FIPS_PROPERTY "-DFIPS=false")
 endif()
 
+if(INCLUDE_JDK17PLUS_DIR)
+    set(C_SRC ${C_SRC} csrc/mlkem_gen.cpp csrc/mlkem_spi.cpp)
+endif()
+
 # The source files under this guard should be removed and added to all builds, including FIPS,
 # once the corresponding algorithms are added to a FIPS branch of AWS-LC consumable by ACCP.
 if(EXPERIMENTAL_FIPS OR (NOT FIPS))
-    if(INCLUDE_JDK17PLUS_DIR)
-        set(C_SRC ${C_SRC} csrc/mlkem_gen.cpp csrc/mlkem_spi.cpp)
-    endif()
     set(C_SRC ${C_SRC} csrc/mldsa_gen.cpp)
 endif()
-
 
 add_library(amazonCorrettoCryptoProvider SHARED ${C_SRC})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -354,12 +354,13 @@ endif()
 # The source files under this guard should be removed and added to all builds, including FIPS,
 # once the corresponding algorithms are added to a FIPS branch of AWS-LC consumable by ACCP.
 if(EXPERIMENTAL_FIPS OR (NOT FIPS))
+    if(INCLUDE_JDK17PLUS_DIR)
+        set(C_SRC ${C_SRC} csrc/mlkem_gen.cpp csrc/mlkem_spi.cpp)
+    endif()
     set(C_SRC ${C_SRC} csrc/mldsa_gen.cpp)
 endif()
 
-if(INCLUDE_JDK17PLUS_DIR)
-    set(C_SRC ${C_SRC} csrc/mlkem_gen.cpp csrc/mlkem_spi.cpp)
-endif()
+
 add_library(amazonCorrettoCryptoProvider SHARED ${C_SRC})
 
 add_custom_command(

--- a/build.gradle
+++ b/build.gradle
@@ -926,6 +926,13 @@ task generateEclipseClasspath {
     } // doLast
 } // generateEclipseClasspath
 
+// Exclude the JDK17Plus Folder when the target is below 17 or between 18-20 to exclude code containing the KEM API
+// as the KEM API was introduced in JDK 21 and backported to JDK 17
+def shouldExcludeJdk17Plus = {
+    def targetJdk = targetJdkVersion as Integer
+    return targetJdk < 17 || (targetJdk >= 18 && targetJdk < 21)
+}
+
 // Defining sourceSets will make gradle find the correct main and test folders,
 // instead of the default 'src/main/java' and 'src/test/java'.
 // This helps IDEs like IntelliJ that import Gradle projects to load and setup ACCP correctly
@@ -934,11 +941,17 @@ sourceSets {
     main {
         java {
             srcDirs 'src', 'template-src', 'build/cmake/generated-java'
+            if (shouldExcludeJdk17Plus()) {
+                exclude '**/jdk17plus/**'
+            }
         }
     }
     test {
         java {
             srcDirs 'tst'
+            if (shouldExcludeJdk17Plus()) {
+                exclude '**/jdk17plus/**'
+            }
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ plugins {
 
 group = 'software.amazon.cryptools'
 version = '2.5.0'
-ext.awsLcMainTag = 'v1.48.2'
+ext.awsLcMainTag = 'v1.60.0'
 ext.awsLcFipsTag = 'AWS-LC-FIPS-3.0.0'
 ext.isExperimentalFips = Boolean.getBoolean('EXPERIMENTAL_FIPS')
 ext.isFips = ext.isExperimentalFips || Boolean.getBoolean('FIPS')

--- a/csrc/java_evp_keys.cpp
+++ b/csrc/java_evp_keys.cpp
@@ -715,12 +715,13 @@ JNIEXPORT jbyteArray JNICALL Java_com_amazon_corretto_crypto_provider_EvpMlDsaPr
     return result;
 }
 #endif // !defined(FIPS_BUILD) || defined(EXPERIMENTAL_FIPS_BUILD)
+
 /*
  * Class:     com_amazon_corretto_crypto_provider_EvpKemKey
  * Method:    getKeySize
  * Signature: (J)I
  */
-JNIEXPORT jint JNICALL Java_com_amazon_corretto_crypto_provider_EvpKemKey_getKeySize(
+JNIEXPORT jint JNICALL Java_com_amazon_corretto_crypto_provider_EvpKemKey_nativeGetKeySize(
     JNIEnv* pEnv, jclass, jlong pkeyPtr)
 {
     EVP_PKEY* pkey = reinterpret_cast<EVP_PKEY*>(pkeyPtr);

--- a/csrc/java_evp_keys.cpp
+++ b/csrc/java_evp_keys.cpp
@@ -725,8 +725,9 @@ JNIEXPORT jint JNICALL Java_com_amazon_corretto_crypto_provider_EvpKemKey_native
     JNIEnv* pEnv, jclass, jlong pkeyPtr)
 {
     EVP_PKEY* pkey = reinterpret_cast<EVP_PKEY*>(pkeyPtr);
-    if (!pkey)
+    if (!pkey) {
         return -1;
+    }
 
     size_t key_len = 0;
     if (EVP_PKEY_get_raw_public_key(pkey, NULL, &key_len) == 1) {

--- a/csrc/java_evp_keys.cpp
+++ b/csrc/java_evp_keys.cpp
@@ -715,3 +715,21 @@ JNIEXPORT jbyteArray JNICALL Java_com_amazon_corretto_crypto_provider_EvpMlDsaPr
     return result;
 }
 #endif // !defined(FIPS_BUILD) || defined(EXPERIMENTAL_FIPS_BUILD)
+/*
+ * Class:     com_amazon_corretto_crypto_provider_EvpKemKey
+ * Method:    getKeySize
+ * Signature: (J)I
+ */
+JNIEXPORT jint JNICALL Java_com_amazon_corretto_crypto_provider_EvpKemKey_getKeySize(
+    JNIEnv* pEnv, jclass, jlong pkeyPtr)
+{
+    EVP_PKEY* pkey = reinterpret_cast<EVP_PKEY*>(pkeyPtr);
+    if (!pkey)
+        return -1;
+
+    size_t key_len = 0;
+    if (EVP_PKEY_get_raw_public_key(pkey, NULL, &key_len) == 1) {
+        return (jint)key_len;
+    }
+    return -1;
+}

--- a/csrc/mlkem_gen.cpp
+++ b/csrc/mlkem_gen.cpp
@@ -1,0 +1,43 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+#include <openssl/evp.h>
+#include <openssl/nid.h>
+
+#include "auto_free.h"
+#include "env.h"
+#include "generated-headers.h"
+
+using namespace AmazonCorrettoCryptoProvider;
+
+JNIEXPORT jlong JNICALL Java_com_amazon_corretto_crypto_provider_MlKemGen_generateEvpMlKemKey(
+    JNIEnv* pEnv, jclass, jint parameterSet)
+{
+    try {
+        raii_env env(pEnv);
+        EVP_PKEY_auto key;
+        EVP_PKEY_CTX_auto ctx = EVP_PKEY_CTX_auto::from(EVP_PKEY_CTX_new_id(EVP_PKEY_KEM, NULL));
+        CHECK_OPENSSL(ctx.isInitialized())
+        int nid;
+        switch (parameterSet) {
+        case 512:
+            nid = NID_MLKEM512;
+            break;
+        case 768:
+            nid = NID_MLKEM768;
+            break;
+        case 1024:
+            nid = NID_MLKEM1024;
+            break;
+        default:
+            throw java_ex(EX_ILLEGAL_ARGUMENT, "Invalid parameter set");
+        }
+
+        CHECK_OPENSSL(EVP_PKEY_CTX_kem_set_params(ctx, nid));
+        CHECK_OPENSSL(EVP_PKEY_keygen_init(ctx) == 1);
+        CHECK_OPENSSL(EVP_PKEY_keygen(ctx, key.getAddressOfPtr()));
+        return reinterpret_cast<jlong>(key.take());
+    } catch (java_ex& ex) {
+        ex.throw_to_java(pEnv);
+    }
+    return 0;
+}

--- a/csrc/mlkem_gen.cpp
+++ b/csrc/mlkem_gen.cpp
@@ -16,7 +16,7 @@ JNIEXPORT jlong JNICALL Java_com_amazon_corretto_crypto_provider_MlKemGen_genera
         raii_env env(pEnv);
         EVP_PKEY_auto key;
         EVP_PKEY_CTX_auto ctx = EVP_PKEY_CTX_auto::from(EVP_PKEY_CTX_new_id(EVP_PKEY_KEM, NULL));
-        CHECK_OPENSSL(ctx.isInitialized())
+        CHECK_OPENSSL(ctx.isInitialized());
         int nid;
         switch (parameterSet) {
         case 512:

--- a/csrc/mlkem_spi.cpp
+++ b/csrc/mlkem_spi.cpp
@@ -1,0 +1,58 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+#include <openssl/evp.h>
+
+#include "auto_free.h"
+#include "buffer.h"
+#include "env.h"
+#include "generated-headers.h"
+
+using namespace AmazonCorrettoCryptoProvider;
+
+#define MLKEM_SHARED_SECRET_LEN 32 // Shared secret produced by ML-KEM is always 32 bytes regardless of parameter set
+
+static EVP_PKEY_CTX_auto setupMlKemContext(JNIEnv* pEnv, jlong evpKeyPtr)
+{
+    EVP_PKEY* key = reinterpret_cast<EVP_PKEY*>(evpKeyPtr);
+    EVP_PKEY_CTX_auto ctx = EVP_PKEY_CTX_auto::from(EVP_PKEY_CTX_new(key, NULL));
+    CHECK_OPENSSL(ctx.isInitialized());
+    return ctx;
+}
+
+JNIEXPORT void JNICALL Java_com_amazon_corretto_crypto_provider_MlKemSpi_nativeEncapsulate(
+    JNIEnv* pEnv, jclass, jlong evpKeyPtr, jbyteArray ciphertextArray, jbyteArray sharedSecretArray)
+{
+    try {
+        raii_env env(pEnv);
+        EVP_PKEY_CTX_auto ctx = setupMlKemContext(pEnv, evpKeyPtr);
+
+        JBinaryBlob ciphertext(pEnv, nullptr, ciphertextArray);
+        JBinaryBlob shared_secret(pEnv, nullptr, sharedSecretArray);
+
+        size_t ciphertext_len = env->GetArrayLength(ciphertextArray);
+        size_t shared_secret_len = MLKEM_SHARED_SECRET_LEN;
+        CHECK_OPENSSL(
+            EVP_PKEY_encapsulate(ctx, ciphertext.get(), &ciphertext_len, shared_secret.get(), &shared_secret_len));
+    } catch (java_ex& ex) {
+        ex.throw_to_java(pEnv);
+    }
+}
+
+JNIEXPORT void JNICALL Java_com_amazon_corretto_crypto_provider_MlKemSpi_nativeDecapsulate(
+    JNIEnv* pEnv, jclass, jlong evpKeyPtr, jbyteArray ciphertextArray, jbyteArray sharedSecretArray)
+{
+    try {
+        raii_env env(pEnv);
+        EVP_PKEY_CTX_auto ctx = setupMlKemContext(pEnv, evpKeyPtr);
+
+        jsize ciphertext_len = env->GetArrayLength(ciphertextArray);
+        JBinaryBlob ciphertext(pEnv, nullptr, ciphertextArray);
+        JBinaryBlob shared_secret(pEnv, nullptr, sharedSecretArray);
+
+        size_t shared_secret_len = MLKEM_SHARED_SECRET_LEN;
+        CHECK_OPENSSL(
+            EVP_PKEY_decapsulate(ctx, shared_secret.get(), &shared_secret_len, ciphertext.get(), ciphertext_len));
+    } catch (java_ex& ex) {
+        ex.throw_to_java(pEnv);
+    }
+}

--- a/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
+++ b/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
@@ -577,7 +577,7 @@ public final class AmazonCorrettoCryptoProvider extends java.security.Provider {
 
     this.shouldRegisterAesCfb = (!isFips() || isExperimentalFips());
 
-    this.shouldRegisterMLKEM = (Utils.isKemSupported() && (!isFips() || isExperimentalFips()));
+    this.shouldRegisterMLKEM = Utils.isKemSupported();
     this.nativeContextReleaseStrategy = Utils.getNativeContextReleaseStrategyProperty();
 
     Utils.optionsFromProperty(ExtraCheck.class, extraChecks, "extrachecks");

--- a/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
+++ b/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
@@ -577,7 +577,7 @@ public final class AmazonCorrettoCryptoProvider extends java.security.Provider {
 
     this.shouldRegisterAesCfb = (!isFips() || isExperimentalFips());
 
-    this.shouldRegisterMLKEM = Utils.isKemSupported();
+    this.shouldRegisterMLKEM = (Utils.isMlKemSupported() && (!isFips() || isExperimentalFips()));
     this.nativeContextReleaseStrategy = Utils.getNativeContextReleaseStrategyProperty();
 
     Utils.optionsFromProperty(ExtraCheck.class, extraChecks, "extrachecks");

--- a/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
+++ b/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
@@ -106,10 +106,10 @@ public final class AmazonCorrettoCryptoProvider extends java.security.Provider {
     }
 
     if (shouldRegisterMLKEM) {
-      addService("KeyFactory", "ML-KEM", "EvpKeyFactory$MLKEM768");
-      addService("KeyFactory", "ML-KEM-512", "EvpKeyFactory$MLKEM512");
-      addService("KeyFactory", "ML-KEM-768", "EvpKeyFactory$MLKEM768");
-      addService("KeyFactory", "ML-KEM-1024", "EvpKeyFactory$MLKEM1024");
+      addService("KeyFactory", "ML-KEM", "EvpKeyFactory$MLKEM");
+      addService("KeyFactory", "ML-KEM-512", "EvpKeyFactory$MLKEM");
+      addService("KeyFactory", "ML-KEM-768", "EvpKeyFactory$MLKEM");
+      addService("KeyFactory", "ML-KEM-1024", "EvpKeyFactory$MLKEM");
     }
 
     // KeyFactories are used to convert key encodings to Java Key objects. ACCP's KeyFactory for
@@ -576,7 +576,7 @@ public final class AmazonCorrettoCryptoProvider extends java.security.Provider {
 
     this.shouldRegisterAesCfb = (!isFips() || isExperimentalFips());
 
-    this.shouldRegisterMLKEM = (Utils.isKemSupported() && (!isFips() || isExperimentalFips())); 
+    this.shouldRegisterMLKEM = (Utils.isKemSupported() && (!isFips() || isExperimentalFips()));
     this.nativeContextReleaseStrategy = Utils.getNativeContextReleaseStrategyProperty();
 
     Utils.optionsFromProperty(ExtraCheck.class, extraChecks, "extrachecks");
@@ -836,9 +836,7 @@ public final class AmazonCorrettoCryptoProvider extends java.security.Provider {
   private transient volatile KeyFactory xdhFactory;
   private transient volatile KeyFactory edFactory;
   private transient volatile KeyFactory mlDsaFactory;
-  private transient volatile KeyFactory kemFactory512;
-  private transient volatile KeyFactory kemFactory768;
-  private transient volatile KeyFactory kemFactory1024;
+  private transient volatile KeyFactory kemFactory;
 
   KeyFactory getKeyFactory(EvpKeyType keyType) {
     try {
@@ -869,10 +867,10 @@ public final class AmazonCorrettoCryptoProvider extends java.security.Provider {
           }
           return mlDsaFactory;
         case MLKEM:
-          if (kemFactory768 == null) {
-            kemFactory768 = KeyFactory.getInstance("ML-KEM-768", this);
+          if (kemFactory == null) {
+            kemFactory = KeyFactory.getInstance("ML-KEM", this);
           }
-          return kemFactory768;
+          return kemFactory;
         default:
           throw new AssertionError(String.format("Unsupported key type: %s", keyType.jceName));
       }

--- a/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
+++ b/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
@@ -164,9 +164,10 @@ public final class AmazonCorrettoCryptoProvider extends java.security.Provider {
     }
 
     if (shouldRegisterMLKEM) {
-      addService("KEM", "ML-KEM-512", "MlKemSpi$MlKem512");
-      addService("KEM", "ML-KEM-768", "MlKemSpi$MlKem768");
-      addService("KEM", "ML-KEM-1024", "MlKemSpi$MlKem1024");
+      addService("KEM", "ML-KEM", "MlKemSpi$MlKemSpi768");
+      addService("KEM", "ML-KEM-512", "MlKemSpi$MlKemSpi512");
+      addService("KEM", "ML-KEM-768", "MlKemSpi$MlKemSpi768");
+      addService("KEM", "ML-KEM-1024", "MlKemSpi$MlKemSpi1024");
     }
 
     addService("KeyGenerator", "AES", "SecretKeyGenerator", false);

--- a/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
+++ b/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
@@ -869,7 +869,7 @@ public final class AmazonCorrettoCryptoProvider extends java.security.Provider {
           return mlDsaFactory;
         case MLKEM:
           if (kemFactory == null) {
-            kemFactory = KeyFactory.getInstance("ML-KEM", this);
+            kemFactory = KeyFactory.getInstance(keyType.jceName, this);
           }
           return kemFactory;
         default:

--- a/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
+++ b/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
@@ -576,7 +576,7 @@ public final class AmazonCorrettoCryptoProvider extends java.security.Provider {
 
     this.shouldRegisterAesCfb = (!isFips() || isExperimentalFips());
 
-    this.shouldRegisterMLKEM = Utils.isKemSupported();
+    this.shouldRegisterMLKEM = (Utils.isKemSupported() && (!isFips() || isExperimentalFips())); 
     this.nativeContextReleaseStrategy = Utils.getNativeContextReleaseStrategyProperty();
 
     Utils.optionsFromProperty(ExtraCheck.class, extraChecks, "extrachecks");
@@ -868,21 +868,11 @@ public final class AmazonCorrettoCryptoProvider extends java.security.Provider {
             mlDsaFactory = KeyFactory.getInstance(keyType.jceName, this);
           }
           return mlDsaFactory;
-        case MLKEM_512:
-          if (kemFactory512 == null) {
-            kemFactory512 = KeyFactory.getInstance("ML-KEM-512", this);
-          }
-          return kemFactory512;
-        case MLKEM_768:
+        case MLKEM:
           if (kemFactory768 == null) {
             kemFactory768 = KeyFactory.getInstance("ML-KEM-768", this);
           }
           return kemFactory768;
-        case MLKEM_1024:
-          if (kemFactory1024 == null) {
-            kemFactory1024 = KeyFactory.getInstance("ML-KEM-1024", this);
-          }
-          return kemFactory1024;
         default:
           throw new AssertionError(String.format("Unsupported key type: %s", keyType.jceName));
       }

--- a/src/com/amazon/corretto/crypto/provider/EvpKemKey.java
+++ b/src/com/amazon/corretto/crypto/provider/EvpKemKey.java
@@ -1,0 +1,18 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package com.amazon.corretto.crypto.provider;
+
+public abstract class EvpKemKey extends EvpKey {
+
+  private final MlKemParameter parameterSet;
+  private static final long serialVersionUID = 1;
+
+  EvpKemKey(final InternalKey key, final EvpKeyType type, final boolean isPublicKey) {
+    super(key, type, isPublicKey);
+    this.parameterSet = MlKemParameter.getParameterSet(this.type);
+  }
+
+  public MlKemParameter getParameterSet() {
+    return parameterSet;
+  }
+}

--- a/src/com/amazon/corretto/crypto/provider/EvpKemKey.java
+++ b/src/com/amazon/corretto/crypto/provider/EvpKemKey.java
@@ -7,12 +7,25 @@ public abstract class EvpKemKey extends EvpKey {
   private final MlKemParameter parameterSet;
   private static final long serialVersionUID = 1;
 
-  EvpKemKey(final InternalKey key, final EvpKeyType type, final boolean isPublicKey) {
-    super(key, type, isPublicKey);
-    this.parameterSet = MlKemParameter.getParameterSet(this.type);
+  private static native int getKeySize(long ptr);
+
+  EvpKemKey(final InternalKey key, final boolean isPublicKey) {
+    super(key, EvpKeyType.MLKEM, isPublicKey);
+    int keySize = key.use(EvpKemKey::getKeySize);
+    this.parameterSet = MlKemParameter.fromKeySize(keySize);
+  }
+
+  private static MlKemParameter determineParameterSetFromKey(long ptr) {
+    int keySize = getKeySize(ptr);
+    return MlKemParameter.fromKeySize(keySize);
   }
 
   public MlKemParameter getParameterSet() {
     return parameterSet;
+  }
+
+  @Override
+  public String getAlgorithm() {
+    return parameterSet.getAlgorithmName();
   }
 }

--- a/src/com/amazon/corretto/crypto/provider/EvpKemKey.java
+++ b/src/com/amazon/corretto/crypto/provider/EvpKemKey.java
@@ -3,21 +3,17 @@
 package com.amazon.corretto.crypto.provider;
 
 public abstract class EvpKemKey extends EvpKey {
-
+  private final int keySize;
   private final MlKemParameter parameterSet;
   private static final long serialVersionUID = 1;
 
-  private static native int getKeySize(long ptr);
+  // Determine the key's parameter set based on the key size
+  private static native int nativeGetKeySize(long ptr);
 
   EvpKemKey(final InternalKey key, final boolean isPublicKey) {
     super(key, EvpKeyType.MLKEM, isPublicKey);
-    int keySize = key.use(EvpKemKey::getKeySize);
+    this.keySize = use(EvpKemKey::nativeGetKeySize);
     this.parameterSet = MlKemParameter.fromKeySize(keySize);
-  }
-
-  private static MlKemParameter determineParameterSetFromKey(long ptr) {
-    int keySize = getKeySize(ptr);
-    return MlKemParameter.fromKeySize(keySize);
   }
 
   public MlKemParameter getParameterSet() {

--- a/src/com/amazon/corretto/crypto/provider/EvpKemKey.java
+++ b/src/com/amazon/corretto/crypto/provider/EvpKemKey.java
@@ -2,8 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.amazon.corretto.crypto.provider;
 
-public abstract class EvpKemKey extends EvpKey {
-  private final int keySize;
+abstract class EvpKemKey extends EvpKey {
   private final MlKemParameter parameterSet;
   private static final long serialVersionUID = 1;
 
@@ -12,8 +11,7 @@ public abstract class EvpKemKey extends EvpKey {
 
   EvpKemKey(final InternalKey key, final boolean isPublicKey) {
     super(key, EvpKeyType.MLKEM, isPublicKey);
-    this.keySize = use(EvpKemKey::nativeGetKeySize);
-    this.parameterSet = MlKemParameter.fromKeySize(keySize);
+    this.parameterSet = MlKemParameter.fromKeySize(use(EvpKemKey::nativeGetKeySize));
   }
 
   public MlKemParameter getParameterSet() {

--- a/src/com/amazon/corretto/crypto/provider/EvpKemPrivateKey.java
+++ b/src/com/amazon/corretto/crypto/provider/EvpKemPrivateKey.java
@@ -1,0 +1,25 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package com.amazon.corretto.crypto.provider;
+
+import java.security.PrivateKey;
+
+public class EvpKemPrivateKey extends EvpKemKey implements PrivateKey {
+  private static final long serialVersionUID = 1;
+
+  EvpKemPrivateKey(final long ptr, final EvpKeyType type) {
+    this(new InternalKey(ptr), type);
+  }
+
+  EvpKemPrivateKey(final InternalKey key, final EvpKeyType type) {
+    super(key, type, false);
+  }
+
+  public EvpKemPublicKey getPublicKey() {
+    this.ephemeral = true;
+    this.sharedKey = true;
+    final EvpKemPublicKey result = new EvpKemPublicKey(internalKey, this.type);
+    result.sharedKey = true;
+    return result;
+  }
+}

--- a/src/com/amazon/corretto/crypto/provider/EvpKemPrivateKey.java
+++ b/src/com/amazon/corretto/crypto/provider/EvpKemPrivateKey.java
@@ -4,7 +4,7 @@ package com.amazon.corretto.crypto.provider;
 
 import java.security.PrivateKey;
 
-public class EvpKemPrivateKey extends EvpKemKey implements PrivateKey {
+class EvpKemPrivateKey extends EvpKemKey implements PrivateKey {
   private static final long serialVersionUID = 1;
 
   EvpKemPrivateKey(final long ptr) {

--- a/src/com/amazon/corretto/crypto/provider/EvpKemPrivateKey.java
+++ b/src/com/amazon/corretto/crypto/provider/EvpKemPrivateKey.java
@@ -7,18 +7,18 @@ import java.security.PrivateKey;
 public class EvpKemPrivateKey extends EvpKemKey implements PrivateKey {
   private static final long serialVersionUID = 1;
 
-  EvpKemPrivateKey(final long ptr, final EvpKeyType type) {
-    this(new InternalKey(ptr), type);
+  EvpKemPrivateKey(final long ptr) {
+    this(new InternalKey(ptr));
   }
 
-  EvpKemPrivateKey(final InternalKey key, final EvpKeyType type) {
-    super(key, type, false);
+  EvpKemPrivateKey(final InternalKey key) {
+    super(key, false);
   }
 
   public EvpKemPublicKey getPublicKey() {
     this.ephemeral = true;
     this.sharedKey = true;
-    final EvpKemPublicKey result = new EvpKemPublicKey(internalKey, this.type);
+    final EvpKemPublicKey result = new EvpKemPublicKey(internalKey);
     result.sharedKey = true;
     return result;
   }

--- a/src/com/amazon/corretto/crypto/provider/EvpKemPublicKey.java
+++ b/src/com/amazon/corretto/crypto/provider/EvpKemPublicKey.java
@@ -1,0 +1,17 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package com.amazon.corretto.crypto.provider;
+
+import java.security.PublicKey;
+
+public class EvpKemPublicKey extends EvpKemKey implements PublicKey {
+  private static final long serialVersionUID = 1;
+
+  EvpKemPublicKey(final long ptr, final EvpKeyType type) {
+    this(new InternalKey(ptr), type);
+  }
+
+  EvpKemPublicKey(final InternalKey key, final EvpKeyType type) {
+    super(key, type, true);
+  }
+}

--- a/src/com/amazon/corretto/crypto/provider/EvpKemPublicKey.java
+++ b/src/com/amazon/corretto/crypto/provider/EvpKemPublicKey.java
@@ -4,7 +4,7 @@ package com.amazon.corretto.crypto.provider;
 
 import java.security.PublicKey;
 
-public class EvpKemPublicKey extends EvpKemKey implements PublicKey {
+class EvpKemPublicKey extends EvpKemKey implements PublicKey {
   private static final long serialVersionUID = 1;
 
   EvpKemPublicKey(final long ptr) {

--- a/src/com/amazon/corretto/crypto/provider/EvpKemPublicKey.java
+++ b/src/com/amazon/corretto/crypto/provider/EvpKemPublicKey.java
@@ -7,11 +7,11 @@ import java.security.PublicKey;
 public class EvpKemPublicKey extends EvpKemKey implements PublicKey {
   private static final long serialVersionUID = 1;
 
-  EvpKemPublicKey(final long ptr, final EvpKeyType type) {
-    this(new InternalKey(ptr), type);
+  EvpKemPublicKey(final long ptr) {
+    this(new InternalKey(ptr));
   }
 
-  EvpKemPublicKey(final InternalKey key, final EvpKeyType type) {
-    super(key, type, true);
+  EvpKemPublicKey(final InternalKey key) {
+    super(key, true);
   }
 }

--- a/src/com/amazon/corretto/crypto/provider/EvpKeyFactory.java
+++ b/src/com/amazon/corretto/crypto/provider/EvpKeyFactory.java
@@ -345,20 +345,8 @@ abstract class EvpKeyFactory extends KeyFactorySpi {
     }
   }
 
-  static class MLKEM512 extends StandardEvpKeyFactory {
-    MLKEM512(AmazonCorrettoCryptoProvider provider) {
-      super(EvpKeyType.MLKEM, provider);
-    }
-  }
-
-  static class MLKEM768 extends StandardEvpKeyFactory {
-    MLKEM768(AmazonCorrettoCryptoProvider provider) {
-      super(EvpKeyType.MLKEM, provider);
-    }
-  }
-
-  static class MLKEM1024 extends StandardEvpKeyFactory {
-    MLKEM1024(AmazonCorrettoCryptoProvider provider) {
+  static class MLKEM extends StandardEvpKeyFactory {
+    MLKEM(AmazonCorrettoCryptoProvider provider) {
       super(EvpKeyType.MLKEM, provider);
     }
   }

--- a/src/com/amazon/corretto/crypto/provider/EvpKeyFactory.java
+++ b/src/com/amazon/corretto/crypto/provider/EvpKeyFactory.java
@@ -344,4 +344,22 @@ abstract class EvpKeyFactory extends KeyFactorySpi {
       super(EvpKeyType.MLDSA, provider);
     }
   }
+
+  static class MLKEM512 extends StandardEvpKeyFactory {
+    MLKEM512(AmazonCorrettoCryptoProvider provider) {
+      super(EvpKeyType.MLKEM_512, provider);
+    }
+  }
+
+  static class MLKEM768 extends StandardEvpKeyFactory {
+    MLKEM768(AmazonCorrettoCryptoProvider provider) {
+      super(EvpKeyType.MLKEM_768, provider);
+    }
+  }
+
+  static class MLKEM1024 extends StandardEvpKeyFactory {
+    MLKEM1024(AmazonCorrettoCryptoProvider provider) {
+      super(EvpKeyType.MLKEM_1024, provider);
+    }
+  }
 }

--- a/src/com/amazon/corretto/crypto/provider/EvpKeyFactory.java
+++ b/src/com/amazon/corretto/crypto/provider/EvpKeyFactory.java
@@ -347,19 +347,19 @@ abstract class EvpKeyFactory extends KeyFactorySpi {
 
   static class MLKEM512 extends StandardEvpKeyFactory {
     MLKEM512(AmazonCorrettoCryptoProvider provider) {
-      super(EvpKeyType.MLKEM_512, provider);
+      super(EvpKeyType.MLKEM, provider);
     }
   }
 
   static class MLKEM768 extends StandardEvpKeyFactory {
     MLKEM768(AmazonCorrettoCryptoProvider provider) {
-      super(EvpKeyType.MLKEM_768, provider);
+      super(EvpKeyType.MLKEM, provider);
     }
   }
 
   static class MLKEM1024 extends StandardEvpKeyFactory {
     MLKEM1024(AmazonCorrettoCryptoProvider provider) {
-      super(EvpKeyType.MLKEM_1024, provider);
+      super(EvpKeyType.MLKEM, provider);
     }
   }
 }

--- a/src/com/amazon/corretto/crypto/provider/EvpKeyType.java
+++ b/src/com/amazon/corretto/crypto/provider/EvpKeyType.java
@@ -20,7 +20,10 @@ enum EvpKeyType {
   EC("EC", 408, ECPublicKey.class, ECPrivateKey.class),
   XDH("XDH", 948, PublicKey.class, PrivateKey.class),
   EdDSA("EdDSA", 949, PublicKey.class, PrivateKey.class),
-  MLDSA("ML-DSA", 993, PublicKey.class, PrivateKey.class);
+  MLDSA("ML-DSA", 993, PublicKey.class, PrivateKey.class),
+  MLKEM_512("ML-KEM-512", 970, PublicKey.class, PrivateKey.class),
+  MLKEM_768("ML-KEM-768", 970, PublicKey.class, PrivateKey.class),
+  MLKEM_1024("ML-KEM-1024", 970, PublicKey.class, PrivateKey.class);
 
   final String jceName;
   final int nativeValue;
@@ -64,6 +67,10 @@ enum EvpKeyType {
         return new EvpEdPrivateKey(fn.applyAsLong(der.getEncoded(), nativeValue));
       case MLDSA:
         return new EvpMlDsaPrivateKey(fn.applyAsLong(der.getEncoded(), nativeValue));
+      case MLKEM_512:
+      case MLKEM_768:
+      case MLKEM_1024:
+        return new EvpKemPrivateKey(fn.applyAsLong(der.getEncoded(), nativeValue), this);
       default:
         throw new AssertionError("Unsupported key type");
     }
@@ -83,6 +90,10 @@ enum EvpKeyType {
         return new EvpEdPublicKey(fn.applyAsLong(der.getEncoded(), nativeValue));
       case MLDSA:
         return new EvpMlDsaPublicKey(fn.applyAsLong(der.getEncoded(), nativeValue));
+      case MLKEM_512:
+      case MLKEM_768:
+      case MLKEM_1024:
+        return new EvpKemPublicKey(fn.applyAsLong(der.getEncoded(), nativeValue), this);
       default:
         throw new AssertionError("Unsupported key type");
     }

--- a/src/com/amazon/corretto/crypto/provider/EvpKeyType.java
+++ b/src/com/amazon/corretto/crypto/provider/EvpKeyType.java
@@ -21,9 +21,7 @@ enum EvpKeyType {
   XDH("XDH", 948, PublicKey.class, PrivateKey.class),
   EdDSA("EdDSA", 949, PublicKey.class, PrivateKey.class),
   MLDSA("ML-DSA", 993, PublicKey.class, PrivateKey.class),
-  MLKEM_512("ML-KEM-512", 970, PublicKey.class, PrivateKey.class),
-  MLKEM_768("ML-KEM-768", 970, PublicKey.class, PrivateKey.class),
-  MLKEM_1024("ML-KEM-1024", 970, PublicKey.class, PrivateKey.class);
+  MLKEM("ML-KEM", 970, PublicKey.class, PrivateKey.class);
 
   final String jceName;
   final int nativeValue;
@@ -67,10 +65,8 @@ enum EvpKeyType {
         return new EvpEdPrivateKey(fn.applyAsLong(der.getEncoded(), nativeValue));
       case MLDSA:
         return new EvpMlDsaPrivateKey(fn.applyAsLong(der.getEncoded(), nativeValue));
-      case MLKEM_512:
-      case MLKEM_768:
-      case MLKEM_1024:
-        return new EvpKemPrivateKey(fn.applyAsLong(der.getEncoded(), nativeValue), this);
+      case MLKEM:
+        return new EvpKemPrivateKey(fn.applyAsLong(der.getEncoded(), nativeValue));
       default:
         throw new AssertionError("Unsupported key type");
     }
@@ -90,10 +86,8 @@ enum EvpKeyType {
         return new EvpEdPublicKey(fn.applyAsLong(der.getEncoded(), nativeValue));
       case MLDSA:
         return new EvpMlDsaPublicKey(fn.applyAsLong(der.getEncoded(), nativeValue));
-      case MLKEM_512:
-      case MLKEM_768:
-      case MLKEM_1024:
-        return new EvpKemPublicKey(fn.applyAsLong(der.getEncoded(), nativeValue), this);
+      case MLKEM:
+        return new EvpKemPublicKey(fn.applyAsLong(der.getEncoded(), nativeValue));
       default:
         throw new AssertionError("Unsupported key type");
     }

--- a/src/com/amazon/corretto/crypto/provider/MlKemGen.java
+++ b/src/com/amazon/corretto/crypto/provider/MlKemGen.java
@@ -1,0 +1,82 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package com.amazon.corretto.crypto.provider;
+
+import java.security.InvalidAlgorithmParameterException;
+import java.security.KeyPair;
+import java.security.KeyPairGeneratorSpi;
+import java.security.SecureRandom;
+import java.security.spec.AlgorithmParameterSpec;
+
+class MlKemGen extends KeyPairGeneratorSpi {
+  private final AmazonCorrettoCryptoProvider provider_;
+  private MlKemParameter parameterSet = null;
+
+  /** Generates a new ML-KEM key and returns a pointer to it. */
+  private static native long generateEvpMlKemKey(int parameterSet);
+
+  private MlKemGen(AmazonCorrettoCryptoProvider provider, MlKemParameter parameterSet) {
+    Loader.checkNativeLibraryAvailability();
+    provider_ = provider;
+    this.parameterSet = parameterSet;
+  }
+
+  MlKemGen(AmazonCorrettoCryptoProvider provider) {
+    this(provider, null);
+  }
+
+  @Override
+  public void initialize(int keysize, SecureRandom random) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void initialize(AlgorithmParameterSpec params, SecureRandom random)
+      throws InvalidAlgorithmParameterException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public KeyPair generateKeyPair() {
+    if (parameterSet == null) {
+      throw new IllegalStateException("Key type not set");
+    }
+    long pkey_ptr = generateEvpMlKemKey(parameterSet.getParameterSize());
+    final EvpKeyType keyType;
+    switch (parameterSet) {
+      case MLKEM_512:
+        keyType = EvpKeyType.MLKEM_512;
+        break;
+      case MLKEM_768:
+        keyType = EvpKeyType.MLKEM_768;
+        break;
+      case MLKEM_1024:
+        keyType = EvpKeyType.MLKEM_1024;
+        break;
+      default:
+        throw new IllegalStateException("Unknown ML-KEM Parameter Set.");
+    }
+
+    final EvpKemPrivateKey privateKey = new EvpKemPrivateKey(pkey_ptr, keyType);
+    final EvpKemPublicKey publicKey = privateKey.getPublicKey();
+    return new KeyPair(publicKey, privateKey);
+  }
+
+  public static final class MlKemGen512 extends MlKemGen {
+    public MlKemGen512(AmazonCorrettoCryptoProvider provider) {
+      super(provider, MlKemParameter.MLKEM_512);
+    }
+  }
+
+  public static final class MlKemGen768 extends MlKemGen {
+    public MlKemGen768(AmazonCorrettoCryptoProvider provider) {
+      super(provider, MlKemParameter.MLKEM_768);
+    }
+  }
+
+  public static final class MlKemGen1024 extends MlKemGen {
+    public MlKemGen1024(AmazonCorrettoCryptoProvider provider) {
+      super(provider, MlKemParameter.MLKEM_1024);
+    }
+  }
+}

--- a/src/com/amazon/corretto/crypto/provider/MlKemGen.java
+++ b/src/com/amazon/corretto/crypto/provider/MlKemGen.java
@@ -9,24 +9,15 @@ import java.security.SecureRandom;
 import java.security.spec.AlgorithmParameterSpec;
 
 class MlKemGen extends KeyPairGeneratorSpi {
-  private final AmazonCorrettoCryptoProvider provider_;
   private MlKemParameter parameterSet = null;
 
   /** Generates a new ML-KEM key and returns a pointer to it. */
   private static native long generateEvpMlKemKey(int parameterSet);
 
-  private MlKemGen(AmazonCorrettoCryptoProvider provider, MlKemParameter parameterSet) {
+  private MlKemGen(MlKemParameter parameterSet) {
     Loader.checkNativeLibraryAvailability();
-    provider_ = provider;
-
-    if (parameterSet == null) {
-      throw new IllegalStateException("Key type not set");
-    }
+    Utils.requireNonNull(parameterSet, "MlKemParameter can not be null");
     this.parameterSet = parameterSet;
-  }
-
-  MlKemGen(AmazonCorrettoCryptoProvider provider) {
-    this(provider, null);
   }
 
   @Override
@@ -51,19 +42,19 @@ class MlKemGen extends KeyPairGeneratorSpi {
 
   public static final class MlKemGen512 extends MlKemGen {
     public MlKemGen512(AmazonCorrettoCryptoProvider provider) {
-      super(provider, MlKemParameter.MLKEM_512);
+      super(MlKemParameter.MLKEM_512);
     }
   }
 
   public static final class MlKemGen768 extends MlKemGen {
     public MlKemGen768(AmazonCorrettoCryptoProvider provider) {
-      super(provider, MlKemParameter.MLKEM_768);
+      super(MlKemParameter.MLKEM_768);
     }
   }
 
   public static final class MlKemGen1024 extends MlKemGen {
     public MlKemGen1024(AmazonCorrettoCryptoProvider provider) {
-      super(provider, MlKemParameter.MLKEM_1024);
+      super(MlKemParameter.MLKEM_1024);
     }
   }
 }

--- a/src/com/amazon/corretto/crypto/provider/MlKemGen.java
+++ b/src/com/amazon/corretto/crypto/provider/MlKemGen.java
@@ -18,6 +18,10 @@ class MlKemGen extends KeyPairGeneratorSpi {
   private MlKemGen(AmazonCorrettoCryptoProvider provider, MlKemParameter parameterSet) {
     Loader.checkNativeLibraryAvailability();
     provider_ = provider;
+
+    if (parameterSet == null) {
+      throw new IllegalStateException("Key type not set");
+    }
     this.parameterSet = parameterSet;
   }
 
@@ -38,26 +42,9 @@ class MlKemGen extends KeyPairGeneratorSpi {
 
   @Override
   public KeyPair generateKeyPair() {
-    if (parameterSet == null) {
-      throw new IllegalStateException("Key type not set");
-    }
     long pkey_ptr = generateEvpMlKemKey(parameterSet.getParameterSize());
-    final EvpKeyType keyType;
-    switch (parameterSet) {
-      case MLKEM_512:
-        keyType = EvpKeyType.MLKEM_512;
-        break;
-      case MLKEM_768:
-        keyType = EvpKeyType.MLKEM_768;
-        break;
-      case MLKEM_1024:
-        keyType = EvpKeyType.MLKEM_1024;
-        break;
-      default:
-        throw new IllegalStateException("Unknown ML-KEM Parameter Set.");
-    }
 
-    final EvpKemPrivateKey privateKey = new EvpKemPrivateKey(pkey_ptr, keyType);
+    final EvpKemPrivateKey privateKey = new EvpKemPrivateKey(pkey_ptr);
     final EvpKemPublicKey publicKey = privateKey.getPublicKey();
     return new KeyPair(publicKey, privateKey);
   }

--- a/src/com/amazon/corretto/crypto/provider/MlKemParameter.java
+++ b/src/com/amazon/corretto/crypto/provider/MlKemParameter.java
@@ -56,16 +56,16 @@ public enum MlKemParameter {
     return "ML-KEM-" + parameterSize;
   }
 
-  public static MlKemParameter getParameterSet(EvpKeyType type) {
-    switch (type) {
-      case MLKEM_512:
-        return MLKEM_512;
-      case MLKEM_768:
-        return MLKEM_768;
-      case MLKEM_1024:
-        return MLKEM_1024;
-      default:
-        throw new IllegalArgumentException("Unsupported EvpKeyType: " + type);
+  public static MlKemParameter fromKeySize(int keySize) {
+    if (keySize == MLKEM_512.publicKeySize || keySize == MLKEM_512.secretKeySize) {
+      return MLKEM_512;
+    } else if (keySize == MLKEM_768.publicKeySize || keySize == MLKEM_768.secretKeySize) {
+      return MLKEM_768;
+    } else if (keySize == MLKEM_1024.publicKeySize || keySize == MLKEM_1024.secretKeySize) {
+      return MLKEM_1024;
+    } else {
+      throw new IllegalArgumentException(
+          "Cannot determine ML-KEM parameter set from key size: " + keySize);
     }
   }
 }

--- a/src/com/amazon/corretto/crypto/provider/MlKemParameter.java
+++ b/src/com/amazon/corretto/crypto/provider/MlKemParameter.java
@@ -23,19 +23,6 @@ enum MlKemParameter {
     this.ciphertextSize = ciphertextSize;
   }
 
-  public static MlKemParameter fromParameterSize(int parameterSet) {
-    switch (parameterSet) {
-      case 512:
-        return MLKEM_512;
-      case 768:
-        return MLKEM_768;
-      case 1024:
-        return MLKEM_1024;
-      default:
-        throw new IllegalArgumentException("Invalid ML-KEM parameter set: " + parameterSet);
-    }
-  }
-
   public static MlKemParameter fromKemName(String name) {
     switch (name) {
       case "ML-KEM-512":
@@ -47,14 +34,6 @@ enum MlKemParameter {
       default:
         throw new IllegalArgumentException("Invalid ML-KEM name: " + name);
     }
-  }
-
-  public int getPublicKeySize() {
-    return publicKeySize;
-  }
-
-  public int getSecretKeySize() {
-    return secretKeySize;
   }
 
   public int getCiphertextSize() {

--- a/src/com/amazon/corretto/crypto/provider/MlKemParameter.java
+++ b/src/com/amazon/corretto/crypto/provider/MlKemParameter.java
@@ -1,0 +1,71 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package com.amazon.corretto.crypto.provider;
+
+public enum MlKemParameter {
+  // (parameterSize, publicKeySize, secretKeySize, ciphertextSize) -
+  // https://github.com/aws/aws-lc/blob/765955a298614877554522143f12c86200f61551/crypto/fipsmodule/ml_kem/ml_kem.h#L4
+  MLKEM_512(512, 800, 1632, 768),
+  MLKEM_768(768, 1184, 2400, 1088),
+  MLKEM_1024(1024, 1568, 3168, 1568);
+
+  private final int parameterSize;
+  private final int publicKeySize;
+  private final int secretKeySize;
+  private final int ciphertextSize;
+  // Shared secret size is constant across all parameter sets for ML-KEM
+  public static final int SHARED_SECRET_SIZE = 32;
+
+  MlKemParameter(int parameterSize, int publicKeySize, int secretKeySize, int ciphertextSize) {
+    this.parameterSize = parameterSize;
+    this.publicKeySize = publicKeySize;
+    this.secretKeySize = secretKeySize;
+    this.ciphertextSize = ciphertextSize;
+  }
+
+  public static MlKemParameter fromParameterSize(int parameterSet) {
+    switch (parameterSet) {
+      case 512:
+        return MLKEM_512;
+      case 768:
+        return MLKEM_768;
+      case 1024:
+        return MLKEM_1024;
+      default:
+        throw new IllegalArgumentException("Invalid ML-KEM parameter set: " + parameterSet);
+    }
+  }
+
+  public int getPublicKeySize() {
+    return publicKeySize;
+  }
+
+  public int getSecretKeySize() {
+    return secretKeySize;
+  }
+
+  public int getCiphertextSize() {
+    return ciphertextSize;
+  }
+
+  public int getParameterSize() {
+    return parameterSize;
+  }
+
+  public String getAlgorithmName() {
+    return "ML-KEM-" + parameterSize;
+  }
+
+  public static MlKemParameter getParameterSet(EvpKeyType type) {
+    switch (type) {
+      case MLKEM_512:
+        return MLKEM_512;
+      case MLKEM_768:
+        return MLKEM_768;
+      case MLKEM_1024:
+        return MLKEM_1024;
+      default:
+        throw new IllegalArgumentException("Unsupported EvpKeyType: " + type);
+    }
+  }
+}

--- a/src/com/amazon/corretto/crypto/provider/MlKemParameter.java
+++ b/src/com/amazon/corretto/crypto/provider/MlKemParameter.java
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.amazon.corretto.crypto.provider;
 
-public enum MlKemParameter {
+enum MlKemParameter {
   // (parameterSize, publicKeySize, secretKeySize, ciphertextSize) -
   // https://github.com/aws/aws-lc/blob/765955a298614877554522143f12c86200f61551/crypto/fipsmodule/ml_kem/ml_kem.h#L4
   MLKEM_512(512, 800, 1632, 768),

--- a/src/com/amazon/corretto/crypto/provider/MlKemParameter.java
+++ b/src/com/amazon/corretto/crypto/provider/MlKemParameter.java
@@ -36,6 +36,19 @@ public enum MlKemParameter {
     }
   }
 
+  public static MlKemParameter fromKemName(String name) {
+    switch (name) {
+      case "ML-KEM-512":
+        return MLKEM_512;
+      case "ML-KEM-768":
+        return MLKEM_768;
+      case "ML-KEM-1024":
+        return MLKEM_1024;
+      default:
+        throw new IllegalArgumentException("Invalid ML-KEM name: " + name);
+    }
+  }
+
   public int getPublicKeySize() {
     return publicKeySize;
   }

--- a/src/com/amazon/corretto/crypto/provider/Utils.java
+++ b/src/com/amazon/corretto/crypto/provider/Utils.java
@@ -619,6 +619,32 @@ final class Utils {
     return getNativeContextReleaseStrategyProperty(PROPERTY_NATIVE_CONTEXT_RELEASE_STRATEGY);
   }
 
+  /**
+   * Determines if ML-KEM support is available. Checks both Java KEM support (Java 17 with
+   * javax.crypto.KEM or Java 21+) and ACCP implementation availability. Requires ML-KEM classes to
+   * be compiled into JAR via -DTARGET_JDK_VERSION.
+   *
+   * @return true if both Java KEM support and ACCP ML-KEM implementation are available
+   */
+  static boolean isKemSupported() {
+    int javaVersion = getJavaVersion();
+
+    if (javaVersion == 17 || javaVersion >= 21) {
+      try {
+        // Check KEM availability for both Java 17 and 21+
+        Class.forName("javax.crypto.KEM");
+
+        // Check ACCP implementation was compiled for both versions
+        Class.forName("com.amazon.corretto.crypto.provider.MlKemSpi");
+        return true;
+      } catch (ClassNotFoundException e) {
+        return false;
+      }
+    }
+
+    return false;
+  }
+
   static native void releaseEvpCipherCtx(long ctxPtr);
 
   public static byte[] checkAesKey(final Key key) throws InvalidKeyException {

--- a/src/com/amazon/corretto/crypto/provider/Utils.java
+++ b/src/com/amazon/corretto/crypto/provider/Utils.java
@@ -626,7 +626,7 @@ final class Utils {
    *
    * @return true if both Java KEM support and ACCP ML-KEM implementation are available
    */
-  static boolean isKemSupported() {
+  static boolean isMlKemSupported() {
     int javaVersion = getJavaVersion();
 
     if (javaVersion == 17 || javaVersion >= 21) {

--- a/src/com/amazon/corretto/crypto/provider/jdk17plus/MlKemSpi.java
+++ b/src/com/amazon/corretto/crypto/provider/jdk17plus/MlKemSpi.java
@@ -120,20 +120,20 @@ abstract class MlKemSpi implements KEMSpi {
     return new MlKemDecapsulatorSpi(kemKey, kemKey.getParameterSet());
   }
 
-  public static final class MlKem512 extends MlKemSpi {
-    public MlKem512() {
+  public static final class MlKemSpi512 extends MlKemSpi {
+    public MlKemSpi512() {
       super(MlKemParameter.MLKEM_512);
     }
   }
 
-  public static final class MlKem768 extends MlKemSpi {
-    public MlKem768() {
+  public static final class MlKemSpi768 extends MlKemSpi {
+    public MlKemSpi768() {
       super(MlKemParameter.MLKEM_768);
     }
   }
 
-  public static final class MlKem1024 extends MlKemSpi {
-    public MlKem1024() {
+  public static final class MlKemSpi1024 extends MlKemSpi {
+    public MlKemSpi1024() {
       super(MlKemParameter.MLKEM_1024);
     }
   }

--- a/src/com/amazon/corretto/crypto/provider/jdk17plus/MlKemSpi.java
+++ b/src/com/amazon/corretto/crypto/provider/jdk17plus/MlKemSpi.java
@@ -1,0 +1,214 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package com.amazon.corretto.crypto.provider;
+
+import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidKeyException;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.SecureRandom;
+import java.security.spec.AlgorithmParameterSpec;
+import java.security.spec.NamedParameterSpec;
+import java.util.Objects;
+import javax.crypto.DecapsulateException;
+import javax.crypto.KEM;
+import javax.crypto.KEMSpi;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+
+abstract class MlKemSpi implements KEMSpi {
+
+  protected final MlKemParameter parameterSet;
+
+  private static native void nativeEncapsulate(
+      long evpKeyPtr, byte[] ciphertext, byte[] sharedSecret);
+
+  private static native void nativeDecapsulate(
+      long evpKeyPtr, byte[] ciphertext, byte[] sharedSecret);
+
+  protected MlKemSpi(MlKemParameter parameterSet) {
+    Loader.checkNativeLibraryAvailability();
+    this.parameterSet = parameterSet;
+  }
+
+  /**
+   * Validates that a NamedParameterSpec is compatible with the given ML-KEM key. Ensures the spec's
+   * algorithm name matches the key's parameter set.
+   *
+   * @param spec the algorithm parameter spec (must not be null)
+   * @param key the parameter set of the given
+   * @throws InvalidAlgorithmParameterException if spec is null, wrong type, or incompatible with
+   *     key
+   */
+  private static void validateParameterSpec(AlgorithmParameterSpec spec, String parameterSet)
+      throws InvalidAlgorithmParameterException {
+
+    if (spec == null) {
+      throw new InvalidAlgorithmParameterException("Please pass in a non-null parameter spec.");
+    }
+    if (!(spec instanceof NamedParameterSpec)) {
+      throw new InvalidAlgorithmParameterException("ACCP can only accept NamedParameterSpec");
+    }
+
+    NamedParameterSpec namedSpec = (NamedParameterSpec) spec;
+    if (!namedSpec.getName().equals(parameterSet)) {
+      throw new InvalidAlgorithmParameterException(
+          "Unsupported parameters. Please use valid parameters");
+    }
+  }
+
+  @Override
+  public KEMSpi.EncapsulatorSpi engineNewEncapsulator(
+      PublicKey publicKey, AlgorithmParameterSpec spec, SecureRandom secureRandom)
+      throws InvalidAlgorithmParameterException, InvalidKeyException {
+
+    if (publicKey == null) {
+      throw new InvalidKeyException("Public key cannot be null");
+    }
+
+    // AWS-LC handles randomness for ML-KEM
+    if (secureRandom != null) {
+      throw new InvalidAlgorithmParameterException(
+          "SecureRandom must be null - AWS-LC handles its own randomness");
+    }
+    if (!(publicKey instanceof EvpKemPublicKey)) {
+      throw new InvalidKeyException("Unsupported public key type");
+    }
+
+    EvpKemPublicKey kemKey = (EvpKemPublicKey) publicKey;
+    String keyParamSetName = kemKey.getParameterSet().getAlgorithmName();
+    validateParameterSpec(spec, keyParamSetName);
+
+    return new MlKemEncapsulatorSpi(kemKey, kemKey.getParameterSet());
+  }
+
+  @Override
+  public KEMSpi.DecapsulatorSpi engineNewDecapsulator(
+      PrivateKey privateKey, AlgorithmParameterSpec spec)
+      throws InvalidAlgorithmParameterException, InvalidKeyException {
+
+    if (privateKey == null) {
+      throw new InvalidKeyException("Private key cannot be null");
+    }
+    if (!(privateKey instanceof EvpKemPrivateKey)) {
+      throw new InvalidKeyException("Unsupported private key type");
+    }
+    EvpKemPrivateKey kemKey = (EvpKemPrivateKey) privateKey;
+    String keyParamSetName = kemKey.getParameterSet().getAlgorithmName();
+    validateParameterSpec(spec, keyParamSetName);
+
+    return new MlKemDecapsulatorSpi(kemKey, kemKey.getParameterSet());
+  }
+
+  public static final class MlKem512 extends MlKemSpi {
+    public MlKem512() {
+      super(MlKemParameter.MLKEM_512);
+    }
+  }
+
+  public static final class MlKem768 extends MlKemSpi {
+    public MlKem768() {
+      super(MlKemParameter.MLKEM_768);
+    }
+  }
+
+  public static final class MlKem1024 extends MlKemSpi {
+    public MlKem1024() {
+      super(MlKemParameter.MLKEM_1024);
+    }
+  }
+
+  private static class MlKemEncapsulatorSpi implements KEMSpi.EncapsulatorSpi {
+    private final EvpKemPublicKey publicKey;
+    private final MlKemParameter parameterSet;
+
+    MlKemEncapsulatorSpi(EvpKemPublicKey publicKey, MlKemParameter parameterSet) {
+      this.publicKey = publicKey;
+      this.parameterSet = parameterSet;
+    }
+
+    @Override
+    public KEM.Encapsulated engineEncapsulate(int from, int to, String algorithm) {
+
+      Objects.checkFromToIndex(from, to, engineSecretSize());
+      Objects.requireNonNull(algorithm, "Please specify an algorithm.");
+
+      // ACCP currently only supports full shared secret extraction
+      if (from != 0 || to != engineSecretSize()) {
+        throw new UnsupportedOperationException(
+            "ACCP only supports extracting the full shared secret. ML-KEM's shared secret size is"
+                + " always 32 bytes.");
+      }
+
+      if (!"Generic".equals(algorithm)
+          && !"ML-KEM".equals(algorithm)
+          && !parameterSet.getAlgorithmName().equals(algorithm)) {
+        throw new UnsupportedOperationException(
+            "Only Generic, ML-KEM, or "
+                + parameterSet.getAlgorithmName()
+                + " algorithm is supported, got: "
+                + algorithm);
+      }
+
+      byte[] ciphertext = new byte[engineEncapsulationSize()];
+      // shared secret size of ML-KEM is always 32 bytes regardless of parameter set
+      byte[] sharedSecret = new byte[engineSecretSize()];
+      publicKey.useVoid(ptr -> nativeEncapsulate(ptr, ciphertext, sharedSecret));
+      return new KEM.Encapsulated(new SecretKeySpec(sharedSecret, algorithm), ciphertext, null);
+    }
+
+    @Override
+    public int engineSecretSize() {
+      return MlKemParameter.SHARED_SECRET_SIZE;
+    }
+
+    @Override
+    public int engineEncapsulationSize() {
+      return parameterSet.getCiphertextSize();
+    }
+  }
+
+  private static class MlKemDecapsulatorSpi implements KEMSpi.DecapsulatorSpi {
+    private final EvpKemPrivateKey privateKey;
+    private final MlKemParameter parameterSet;
+
+    MlKemDecapsulatorSpi(EvpKemPrivateKey privateKey, MlKemParameter parameterSet) {
+      this.privateKey = privateKey;
+      this.parameterSet = parameterSet;
+    }
+
+    @Override
+    public SecretKey engineDecapsulate(byte[] encapsulation, int from, int to, String algorithm)
+        throws DecapsulateException {
+
+      Objects.checkFromToIndex(from, to, engineSecretSize());
+      Objects.requireNonNull(algorithm);
+      Objects.requireNonNull(encapsulation);
+
+      if (!"Generic".equals(algorithm)
+          && !"ML-KEM".equals(algorithm)
+          && !parameterSet.getAlgorithmName().equals(algorithm)) {
+        throw new UnsupportedOperationException(
+            "Only Generic or "
+                + parameterSet.getAlgorithmName()
+                + " algorithm is supported, got: "
+                + algorithm);
+      }
+
+      // shared secret size of ML-KEM is always 32 bytes regardless of parameter set
+      byte[] sharedSecret = new byte[engineSecretSize()];
+      privateKey.useVoid(ptr -> nativeDecapsulate(ptr, encapsulation, sharedSecret));
+      return new SecretKeySpec(sharedSecret, algorithm);
+    }
+
+    @Override
+    public int engineSecretSize() {
+      return MlKemParameter.SHARED_SECRET_SIZE;
+    }
+
+    @Override
+    public int engineEncapsulationSize() {
+      return parameterSet.getCiphertextSize();
+    }
+  }
+}

--- a/src/com/amazon/corretto/crypto/provider/jdk17plus/MlKemSpi.java
+++ b/src/com/amazon/corretto/crypto/provider/jdk17plus/MlKemSpi.java
@@ -196,6 +196,10 @@ abstract class MlKemSpi implements KEMSpi {
       Objects.requireNonNull(encapsulation);
       validateAlgorithm(algorithm, parameterSet.getAlgorithmName());
 
+      if (encapsulation.length != engineEncapsulationSize()) {
+        throw new DecapsulateException("The size of the encapsulation is invalid.");
+      }
+
       byte[] sharedSecret = new byte[engineSecretSize()];
       privateKey.useVoid(ptr -> nativeDecapsulate(ptr, encapsulation, sharedSecret));
       return new SecretKeySpec(sharedSecret, algorithm);

--- a/tests/ci/run_accp_basic_tests.sh
+++ b/tests/ci/run_accp_basic_tests.sh
@@ -8,6 +8,7 @@ testing_fips=false
 testing_experimental_fips=false
 testing_fips_self_test_skip_abort=false
 testing_fips_test_break=false
+target_jdk_version=""
 
 # Depending on lcov version, either inconsistent or source needs to be passed
 lcov_ignore=source
@@ -33,6 +34,10 @@ while [[ $# -gt 0 ]]; do
         testing_fips_test_break=true
         shift
         ;;
+    --target-jdk-version)
+        target_jdk_version="$2"
+        shift 2
+        ;;
     *)
         echo "$1 is not supported."
         exit 1
@@ -54,6 +59,7 @@ if (( "$version" <= "10" )); then
         -DALLOW_FIPS_TEST_BREAK=$testing_fips_test_break \
         -DFIPS=$testing_fips \
         -DLCOV_IGNORE=$lcov_ignore \
+        -DTARGET_JDK_VERSION=$target_jdk_version \
         coverage test
     exit $?
 fi
@@ -70,4 +76,5 @@ export PATH=$JAVA_HOME/bin:$PATH
     -DALLOW_FIPS_TEST_BREAK=$testing_fips_test_break \
     -DFIPS=$testing_fips \
     -DLCOV_IGNORE=$lcov_ignore \
+    -DTARGET_JDK_VERSION=$target_jdk_version \
     release

--- a/tst/com/amazon/corretto/crypto/provider/test/EdDSATest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/EdDSATest.java
@@ -487,8 +487,6 @@ public class EdDSATest {
       e.printStackTrace();
       fail("Failed to verify null signature.");
     }
-    assertFalse(jceSig.verify(null));
-
     // Test BouncyCastle behavior
     KeyPair keyPair2 = bcGen.generateKeyPair();
     Signature bcSig = Signature.getInstance("Ed25519", BOUNCYCASTLE_PROVIDER);

--- a/tst/com/amazon/corretto/crypto/provider/test/EdDSATest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/EdDSATest.java
@@ -481,6 +481,8 @@ public class EdDSATest {
     TestUtil.assertThrows(NullPointerException.class, () -> jceSig.update((byte[]) null));
     // Test with null signature
     jceSig.initVerify(keyPair.getPublic());
+    // On older targets such as JDK 17, verifying a null signature will return false.
+    // However, in JDK 21, this returns a SignatureException why is we must catch the exception.
     try {
       assertFalse(jceSig.verify(null));
     } catch (SignatureException e) {

--- a/tst/com/amazon/corretto/crypto/provider/test/EdDSATest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/EdDSATest.java
@@ -484,8 +484,7 @@ public class EdDSATest {
     try {
       assertFalse(jceSig.verify(null));
     } catch (SignatureException e) {
-      e.printStackTrace();
-      fail("Failed to verify null signature.");
+      throw new SignatureException(e);
     }
     // Test BouncyCastle behavior
     KeyPair keyPair2 = bcGen.generateKeyPair();

--- a/tst/com/amazon/corretto/crypto/provider/test/EdDSATest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/EdDSATest.java
@@ -481,6 +481,12 @@ public class EdDSATest {
     TestUtil.assertThrows(NullPointerException.class, () -> jceSig.update((byte[]) null));
     // Test with null signature
     jceSig.initVerify(keyPair.getPublic());
+    try {
+      assertFalse(jceSig.verify(null));
+    } catch (SignatureException e) {
+      e.printStackTrace();
+      fail("Failed to verify null signature.");
+    }
     assertFalse(jceSig.verify(null));
 
     // Test BouncyCastle behavior

--- a/tst/com/amazon/corretto/crypto/provider/test/EdDSATest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/EdDSATest.java
@@ -484,7 +484,7 @@ public class EdDSATest {
     try {
       assertFalse(jceSig.verify(null));
     } catch (SignatureException e) {
-      throw new SignatureException(e);
+      // JDK 21 throws SignatureException for null signature
     }
     // Test BouncyCastle behavior
     KeyPair keyPair2 = bcGen.generateKeyPair();

--- a/tst/com/amazon/corretto/crypto/provider/test/EvpKeyFactoryTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/EvpKeyFactoryTest.java
@@ -752,7 +752,7 @@ public class EvpKeyFactoryTest {
     // TODO: switch to BouncyCastle once BC supports CHOICE-encoded private keys
     // Similarly, JDK doesn't support EdDSA/Ed25519 until JDK15, and XDH/X25519 until JDK11
     Map<Integer, List<String>> jdkAlgorithmSupport = new HashMap<>();
-    jdkAlgorithmSupport.put(24, Arrays.asList("ML-DSA"));
+    jdkAlgorithmSupport.put(24, Arrays.asList("ML-DSA", "ML-KEM"));
     jdkAlgorithmSupport.put(15, Arrays.asList("Ed25519", "Ed25519ph", "EdDSA"));
     jdkAlgorithmSupport.put(11, Arrays.asList("XDH", "X25519"));
     for (Map.Entry<Integer, List<String>> entry : jdkAlgorithmSupport.entrySet()) {
@@ -760,6 +760,7 @@ public class EvpKeyFactoryTest {
           && entry.getValue().stream().anyMatch(algorithm::startsWith)) {
         return NATIVE_PROVIDER;
       }
+
     }
     return null;
   }

--- a/tst/com/amazon/corretto/crypto/provider/test/EvpKeyFactoryTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/EvpKeyFactoryTest.java
@@ -760,7 +760,6 @@ public class EvpKeyFactoryTest {
           && entry.getValue().stream().anyMatch(algorithm::startsWith)) {
         return NATIVE_PROVIDER;
       }
-
     }
     return null;
   }

--- a/tst/com/amazon/corretto/crypto/provider/test/FipsStatusTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/FipsStatusTest.java
@@ -101,7 +101,7 @@ public class FipsStatusTest {
     assumeTrue(provider.isFipsSelfTestFailureSkipAbort());
     assumeTrue(awsLcIsBuiltWitFipshBreakTest());
     testPwctBreakage("RSA", "RSA_PWCT");
-    testPwctBreakage("EC", "EC_PWT");
+    testPwctBreakage("EC", "EC_PWCT");
     testPwctBreakage("Ed25519", "EDDSA_PWCT");
     if (provider.isExperimentalFips()) { // can be removed when AWS-LC-FIPS supports ML-DSA
       testPwctBreakage("ML-DSA", "MLDSA_PWCT");

--- a/tst/com/amazon/corretto/crypto/provider/test/FipsStatusTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/FipsStatusTest.java
@@ -101,7 +101,7 @@ public class FipsStatusTest {
     assumeTrue(provider.isFipsSelfTestFailureSkipAbort());
     assumeTrue(awsLcIsBuiltWitFipshBreakTest());
     testPwctBreakage("RSA", "RSA_PWCT");
-    testPwctBreakage("EC", "ECDSA_PWCT");
+    testPwctBreakage("EC", "EC_PWT");
     testPwctBreakage("Ed25519", "EDDSA_PWCT");
     if (provider.isExperimentalFips()) { // can be removed when AWS-LC-FIPS supports ML-DSA
       testPwctBreakage("ML-DSA", "MLDSA_PWCT");

--- a/tst/com/amazon/corretto/crypto/provider/test/TestUtil.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/TestUtil.java
@@ -40,6 +40,7 @@ import org.bouncycastle.crypto.digests.SHA224Digest;
 import org.bouncycastle.crypto.digests.SHA256Digest;
 import org.bouncycastle.crypto.digests.SHA384Digest;
 import org.bouncycastle.crypto.digests.SHA512Digest;
+import org.bouncycastle.jcajce.spec.MLKEMParameterSpec;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.junit.jupiter.api.Assumptions;
 
@@ -822,6 +823,20 @@ public class TestUtil {
       return ascendingPattern(inputLen);
     }
     return constantPattern(inputLen, choice);
+  }
+
+  // Map ACCP parameter set names to BouncyCastle MLKEMParameterSpec constants
+  static MLKEMParameterSpec getMlKemParamSpec(String paramSet) {
+    switch (paramSet) {
+      case "ML-KEM-512":
+        return MLKEMParameterSpec.ml_kem_512;
+      case "ML-KEM-768":
+        return MLKEMParameterSpec.ml_kem_768;
+      case "ML-KEM-1024":
+        return MLKEMParameterSpec.ml_kem_1024;
+      default:
+        throw new IllegalArgumentException("Unknown parameter set: " + paramSet);
+    }
   }
 
   static Digest bcDigest(final String digest) {

--- a/tst/com/amazon/corretto/crypto/provider/test/jdk17plus/MlKemTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/jdk17plus/MlKemTest.java
@@ -108,9 +108,7 @@ public class MlKemTest {
     SecretKey sharedSecret = encapsulated.key();
     byte[] ciphertext = encapsulated.encapsulation();
     assertEquals(
-        SHARED_SECRET_SIZE,
-        sharedSecret.getEncoded().length,
-        "Shared secret should be 32 bytes");
+        SHARED_SECRET_SIZE, sharedSecret.getEncoded().length, "Shared secret should be 32 bytes");
 
     KEM.Decapsulator decapsulator = decapsulatorKem.newDecapsulator(params.priv, paramSpec);
     SecretKey recoveredSecret = decapsulator.decapsulate(ciphertext);
@@ -200,10 +198,7 @@ public class MlKemTest {
 
     KEM.Encapsulator encapsulator = kem.newEncapsulator(pair.getPublic(), paramSpec, null);
 
-    assertEquals(
-        SHARED_SECRET_SIZE,
-        encapsulator.secretSize(),
-        "Secret size should be 32 bytes");
+    assertEquals(SHARED_SECRET_SIZE, encapsulator.secretSize(), "Secret size should be 32 bytes");
     assertEquals(
         expectedCiphertextSize,
         encapsulator.encapsulationSize(),
@@ -261,8 +256,7 @@ public class MlKemTest {
         "Specific algorithm should be preserved");
 
     // Test that ML-KEM generic also works
-    KEM.Encapsulated encapsulatedMlKem =
-        encapsulator.encapsulate(0, SHARED_SECRET_SIZE, "ML-KEM");
+    KEM.Encapsulated encapsulatedMlKem = encapsulator.encapsulate(0, SHARED_SECRET_SIZE, "ML-KEM");
     assertEquals(
         "ML-KEM", encapsulatedMlKem.key().getAlgorithm(), "ML-KEM algorithm should be preserved");
   }

--- a/tst/com/amazon/corretto/crypto/provider/test/jdk17plus/MlKemTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/jdk17plus/MlKemTest.java
@@ -26,7 +26,6 @@ import javax.crypto.KEM;
 import javax.crypto.SecretKey;
 import org.bouncycastle.jcajce.interfaces.MLKEMPrivateKey;
 import org.bouncycastle.jcajce.spec.KTSParameterSpec;
-import org.bouncycastle.jcajce.spec.MLKEMParameterSpec;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.parallel.Execution;
@@ -311,7 +310,7 @@ public class MlKemTest {
 
     // Test BC keys and convert to ACCP using ACCP's key factory, test if they're equal
     KeyPairGenerator bcKeyGen = KeyPairGenerator.getInstance("ML-KEM", TestUtil.BC_PROVIDER);
-    bcKeyGen.initialize(getMLKEMParamSpec(paramSet));
+    bcKeyGen.initialize(TestUtil.getMlKemParamSpec(paramSet));
     KeyPair bcKeyPair = bcKeyGen.generateKeyPair();
 
     // set BC's private key to be encoded in expandedKey format, not seed, by passing false to
@@ -360,20 +359,6 @@ public class MlKemTest {
           encapsulated.key().getEncoded(),
           bcSecret.getEncoded(),
           "ACCP and BouncyCastle should produce identical shared secrets for " + paramSet);
-    }
-  }
-
-  // Map ACCP parameter set names to BouncyCastle MLKEMParameterSpec constants
-  private MLKEMParameterSpec getMLKEMParamSpec(String paramSet) {
-    switch (paramSet) {
-      case "ML-KEM-512":
-        return MLKEMParameterSpec.ml_kem_512;
-      case "ML-KEM-768":
-        return MLKEMParameterSpec.ml_kem_768;
-      case "ML-KEM-1024":
-        return MLKEMParameterSpec.ml_kem_1024;
-      default:
-        throw new IllegalArgumentException("Unknown parameter set: " + paramSet);
     }
   }
 }

--- a/tst/com/amazon/corretto/crypto/provider/test/jdk17plus/MlKemTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/jdk17plus/MlKemTest.java
@@ -342,6 +342,7 @@ public class MlKemTest {
     try {
       KEM.getInstance("ML-KEM", TestUtil.BC_PROVIDER);
       bcHasKemProvider = true;
+      System.out.println("We caught");
     } catch (java.security.NoSuchAlgorithmException e) {
       System.out.println(
           "BouncyCastle does not register the KEM API on JDK versions older than 21. Please try"

--- a/tst/com/amazon/corretto/crypto/provider/test/jdk17plus/MlKemTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/jdk17plus/MlKemTest.java
@@ -1,0 +1,357 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package com.amazon.corretto.crypto.provider.test;
+
+import static com.amazon.corretto.crypto.provider.test.TestUtil.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import com.amazon.corretto.crypto.provider.AmazonCorrettoCryptoProvider;
+import com.amazon.corretto.crypto.provider.EvpKemPublicKey;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.KeyFactory;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.PrivateKey;
+import java.security.Provider;
+import java.security.PublicKey;
+import java.security.spec.NamedParameterSpec;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.security.spec.X509EncodedKeySpec;
+import java.util.ArrayList;
+import java.util.List;
+import javax.crypto.KEM;
+import javax.crypto.SecretKey;
+import org.bouncycastle.jcajce.interfaces.MLKEMPrivateKey;
+import org.bouncycastle.jcajce.spec.KTSParameterSpec;
+import org.bouncycastle.jcajce.spec.MLKEMParameterSpec;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+@Execution(ExecutionMode.CONCURRENT)
+@ExtendWith(TestResultLogger.class)
+@ResourceLock(value = TestUtil.RESOURCE_GLOBAL, mode = ResourceAccessMode.READ)
+public class MlKemTest {
+  private static final AmazonCorrettoCryptoProvider NATIVE_PROVIDER =
+      AmazonCorrettoCryptoProvider.INSTANCE;
+
+  // ML-KEM constants
+  // See https://github.com/aws/aws-lc/blob/main/crypto/fipsmodule/ml_kem/ml_kem.h
+  private static final int SHARED_SECRET_SIZE = 32;
+  private static final int MLKEM_512_PARAM_SIZE = 512;
+  private static final int MLKEM_768_PARAM_SIZE = 768;
+  private static final int MLKEM_1024_PARAM_SIZE = 1024;
+  private static final int MLKEM_512_CIPHERTEXT_SIZE = 768;
+  private static final int MLKEM_768_CIPHERTEXT_SIZE = 1088;
+  private static final int MLKEM_1024_CIPHERTEXT_SIZE = 1568;
+
+  private static class TestParams {
+    private final Provider encapsulatorProv;
+    private final Provider decapsulatorProv;
+    private final PrivateKey priv;
+    private final PublicKey pub;
+    private final String parameterSet;
+
+    public TestParams(
+        Provider encapsulatorProv,
+        Provider decapsulatorProv,
+        PrivateKey priv,
+        PublicKey pub,
+        String parameterSet) {
+      this.encapsulatorProv = encapsulatorProv;
+      this.decapsulatorProv = decapsulatorProv;
+      this.priv = priv;
+      this.pub = pub;
+      this.parameterSet = parameterSet;
+    }
+
+    public String toString() {
+      return String.format(
+          "encapsulator: %s, decapsulator: %s, parameter set: %s",
+          encapsulatorProv.getName(), decapsulatorProv.getName(), parameterSet);
+    }
+  }
+
+  private static List<TestParams> getParams() throws Exception {
+    List<TestParams> params = new ArrayList<TestParams>();
+    for (String paramSet : new String[] {"ML-KEM-512", "ML-KEM-768", "ML-KEM-1024"}) {
+      KeyPair keyPair = KeyPairGenerator.getInstance(paramSet, NATIVE_PROVIDER).generateKeyPair();
+      PublicKey nativePub = keyPair.getPublic();
+      PrivateKey nativePriv = keyPair.getPrivate();
+
+      Provider nativeProv = NATIVE_PROVIDER;
+
+      params.add(new TestParams(nativeProv, nativeProv, nativePriv, nativePub, paramSet));
+    }
+    return params;
+  }
+
+  @ParameterizedTest
+  @MethodSource("getParams")
+  public void testKemRoundTrips(TestParams params) throws Exception {
+    KEM encapsulatorKem = KEM.getInstance(params.parameterSet, params.encapsulatorProv);
+    KEM decapsulatorKem = KEM.getInstance(params.parameterSet, params.decapsulatorProv);
+
+    NamedParameterSpec paramSpec = new NamedParameterSpec(params.parameterSet);
+
+    KEM.Encapsulator encapsulator = encapsulatorKem.newEncapsulator(params.pub, paramSpec, null);
+    KEM.Encapsulated encapsulated = encapsulator.encapsulate();
+
+    assertNotNull(encapsulated, "Encapsulated result should not be null");
+    assertNotNull(encapsulated.key(), "Shared secret should not be null");
+    assertNotNull(encapsulated.encapsulation(), "Ciphertext should not be null");
+
+    SecretKey sharedSecret = encapsulated.key();
+    byte[] ciphertext = encapsulated.encapsulation();
+    assertEquals(
+        SHARED_SECRET_SIZE, sharedSecret.getEncoded().length, "Shared secret should be 32 bytes");
+
+    KEM.Decapsulator decapsulator = decapsulatorKem.newDecapsulator(params.priv, paramSpec);
+    SecretKey recoveredSecret = decapsulator.decapsulate(ciphertext);
+    assertNotNull(recoveredSecret, "Recovered secret should not be null");
+    assertEquals(
+        SHARED_SECRET_SIZE,
+        recoveredSecret.getEncoded().length,
+        "Recovered secret should be 32 bytes");
+    assertArrayEquals(
+        sharedSecret.getEncoded(),
+        recoveredSecret.getEncoded(),
+        "Original and recovered secrets should match");
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"ML-KEM-512", "ML-KEM-768", "ML-KEM-1024"})
+  public void testKeyGeneration(String paramSet) throws Exception {
+    KeyPairGenerator keyGen = KeyPairGenerator.getInstance(paramSet, NATIVE_PROVIDER);
+    KeyPair keyPair = keyGen.generateKeyPair();
+
+    assertNotNull(keyPair);
+    assertNotNull(keyPair.getPrivate());
+    assertNotNull(keyPair.getPublic());
+
+    assertEquals(paramSet, keyPair.getPrivate().getAlgorithm());
+    assertEquals(paramSet, keyPair.getPublic().getAlgorithm());
+  }
+
+  @Test
+  public void testParameterSetValidation() throws Exception {
+    KeyPair pair512 = KeyPairGenerator.getInstance("ML-KEM-512", NATIVE_PROVIDER).generateKeyPair();
+    KeyPair pair768 = KeyPairGenerator.getInstance("ML-KEM-768", NATIVE_PROVIDER).generateKeyPair();
+    KeyPair pair1024 =
+        KeyPairGenerator.getInstance("ML-KEM-1024", NATIVE_PROVIDER).generateKeyPair();
+
+    EvpKemPublicKey pub512 = (EvpKemPublicKey) pair512.getPublic();
+    EvpKemPublicKey pub768 = (EvpKemPublicKey) pair768.getPublic();
+    EvpKemPublicKey pub1024 = (EvpKemPublicKey) pair1024.getPublic();
+
+    assertEquals(MLKEM_512_PARAM_SIZE, pub512.getParameterSet().getParameterSize());
+    assertEquals(MLKEM_768_PARAM_SIZE, pub768.getParameterSet().getParameterSize());
+    assertEquals(MLKEM_1024_PARAM_SIZE, pub1024.getParameterSet().getParameterSize());
+
+    assertEquals("ML-KEM-512", pub512.getAlgorithm());
+    assertEquals("ML-KEM-768", pub768.getAlgorithm());
+    assertEquals("ML-KEM-1024", pub1024.getAlgorithm());
+  }
+
+  @Test
+  public void testParameterSpecMismatch() throws Exception {
+
+    KeyPair pair768 = KeyPairGenerator.getInstance("ML-KEM-768", NATIVE_PROVIDER).generateKeyPair();
+    KEM kem512 = KEM.getInstance("ML-KEM-512", NATIVE_PROVIDER);
+
+    NamedParameterSpec wrongSpec = new NamedParameterSpec("ML-KEM-512");
+
+    assertThrows(
+        InvalidAlgorithmParameterException.class,
+        () -> kem512.newEncapsulator(pair768.getPublic(), wrongSpec, null));
+    assertThrows(
+        InvalidAlgorithmParameterException.class,
+        () -> kem512.newDecapsulator(pair768.getPrivate(), wrongSpec));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"ML-KEM-512", "ML-KEM-768", "ML-KEM-1024"})
+  public void testCiphertextSizes(String paramSet) throws Exception {
+    int[] expectedSizes = {
+      MLKEM_512_CIPHERTEXT_SIZE, MLKEM_768_CIPHERTEXT_SIZE, MLKEM_1024_CIPHERTEXT_SIZE
+    };
+    String[] paramSets = {"ML-KEM-512", "ML-KEM-768", "ML-KEM-1024"};
+
+    int expectedSize = expectedSizes[java.util.Arrays.asList(paramSets).indexOf(paramSet)];
+
+    KeyPair pair = KeyPairGenerator.getInstance(paramSet, NATIVE_PROVIDER).generateKeyPair();
+    KEM kem = KEM.getInstance(paramSet, NATIVE_PROVIDER);
+
+    NamedParameterSpec paramSpec = new NamedParameterSpec(paramSet);
+    KEM.Encapsulator encapsulator = kem.newEncapsulator(pair.getPublic(), paramSpec, null);
+    KEM.Encapsulated encapsulated = encapsulator.encapsulate();
+
+    assertEquals(
+        expectedSize,
+        encapsulated.encapsulation().length,
+        "Ciphertext size should match expected value for " + paramSet);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"ML-KEM-512", "ML-KEM-768", "ML-KEM-1024"})
+  public void testEncapsulatorProperties(String paramSet) throws Exception {
+    int[] expectedCiphertextSizes = {
+      MLKEM_512_CIPHERTEXT_SIZE, MLKEM_768_CIPHERTEXT_SIZE, MLKEM_1024_CIPHERTEXT_SIZE
+    };
+    String[] paramSets = {"ML-KEM-512", "ML-KEM-768", "ML-KEM-1024"};
+
+    int expectedCiphertextSize =
+        expectedCiphertextSizes[java.util.Arrays.asList(paramSets).indexOf(paramSet)];
+
+    KeyPair pair = KeyPairGenerator.getInstance(paramSet, NATIVE_PROVIDER).generateKeyPair();
+    KEM kem = KEM.getInstance(paramSet, NATIVE_PROVIDER);
+    NamedParameterSpec paramSpec = new NamedParameterSpec(paramSet);
+
+    KEM.Encapsulator encapsulator = kem.newEncapsulator(pair.getPublic(), paramSpec, null);
+
+    assertEquals(SHARED_SECRET_SIZE, encapsulator.secretSize(), "Secret size should be 32 bytes");
+    assertEquals(
+        expectedCiphertextSize,
+        encapsulator.encapsulationSize(),
+        "Ciphertext size should match expected value");
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"ML-KEM-512", "ML-KEM-768", "ML-KEM-1024"})
+  public void testGenericAlgorithmHandling(String paramSet) throws Exception {
+    KeyPair pair = KeyPairGenerator.getInstance(paramSet, NATIVE_PROVIDER).generateKeyPair();
+    KEM kem = KEM.getInstance(paramSet, NATIVE_PROVIDER);
+    NamedParameterSpec paramSpec = new NamedParameterSpec(paramSet);
+
+    KEM.Encapsulator encapsulator = kem.newEncapsulator(pair.getPublic(), paramSpec, null);
+    KEM.Decapsulator decapsulator = kem.newDecapsulator(pair.getPrivate(), paramSpec);
+
+    KEM.Encapsulated encapsulatedGeneric =
+        encapsulator.encapsulate(0, SHARED_SECRET_SIZE, "Generic");
+
+    assertNotNull(encapsulatedGeneric, "Encapsulated result should not be null");
+    assertNotNull(encapsulatedGeneric.key(), "Shared secret should not be null");
+    assertEquals(
+        SHARED_SECRET_SIZE,
+        encapsulatedGeneric.key().getEncoded().length,
+        "Shared secret should be 32 bytes");
+
+    // "Generic" should be preserved as-is
+    assertEquals(
+        "Generic",
+        encapsulatedGeneric.key().getAlgorithm(),
+        "Generic algorithm should be preserved");
+
+    SecretKey recoveredGeneric =
+        decapsulator.decapsulate(
+            encapsulatedGeneric.encapsulation(), 0, SHARED_SECRET_SIZE, "Generic");
+
+    assertNotNull(recoveredGeneric, "Recovered secret should not be null");
+    assertEquals(
+        SHARED_SECRET_SIZE,
+        recoveredGeneric.getEncoded().length,
+        "Recovered secret should be 32 bytes");
+    assertEquals(
+        "Generic", recoveredGeneric.getAlgorithm(), "Generic algorithm should be preserved");
+
+    assertArrayEquals(
+        encapsulatedGeneric.key().getEncoded(),
+        recoveredGeneric.getEncoded(),
+        "Encapsulated and decapsulated secrets should match");
+
+    KEM.Encapsulated encapsulatedSpecific =
+        encapsulator.encapsulate(0, SHARED_SECRET_SIZE, paramSet);
+    assertEquals(
+        paramSet,
+        encapsulatedSpecific.key().getAlgorithm(),
+        "Specific algorithm should be preserved");
+
+    // Test that ML-KEM generic also works
+    KEM.Encapsulated encapsulatedMlKem = encapsulator.encapsulate(0, SHARED_SECRET_SIZE, "ML-KEM");
+    assertEquals(
+        "ML-KEM", encapsulatedMlKem.key().getAlgorithm(), "ML-KEM algorithm should be preserved");
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"ML-KEM-512", "ML-KEM-768", "ML-KEM-1024"})
+  public void testBouncyCastleInteroperability(String paramSet) throws Exception {
+
+    KeyPair accpKeyPair = KeyPairGenerator.getInstance(paramSet, NATIVE_PROVIDER).generateKeyPair();
+
+    // Test BouncyCastle can import ACCP keys
+    KeyFactory bcKf = KeyFactory.getInstance("ML-KEM", TestUtil.BC_PROVIDER);
+    PublicKey bcPub =
+        bcKf.generatePublic(new X509EncodedKeySpec(accpKeyPair.getPublic().getEncoded()));
+    PrivateKey bcPriv =
+        bcKf.generatePrivate(new PKCS8EncodedKeySpec(accpKeyPair.getPrivate().getEncoded()));
+
+    assertNotNull(bcPub, "BouncyCastle should import ACCP public key");
+    assertNotNull(bcPriv, "BouncyCastle should import ACCP private key");
+    assertArrayEquals(
+        accpKeyPair.getPublic().getEncoded(),
+        bcPub.getEncoded(),
+        "Public key encoding should be preserved");
+    assertArrayEquals(
+        accpKeyPair.getPrivate().getEncoded(),
+        bcPriv.getEncoded(),
+        "Private key encoding should be preserved");
+
+    // Test BC keys and convert to ACCP using ACCP's key factory, test if they're equal
+    KeyPairGenerator bcKeyGen = KeyPairGenerator.getInstance("ML-KEM", TestUtil.BC_PROVIDER);
+    bcKeyGen.initialize(getMLKEMParamSpec(paramSet));
+    KeyPair bcKeyPair = bcKeyGen.generateKeyPair();
+
+    // set BC's private key to be encoded in expandedKey format, not seed, by passing false to
+    // getPrivateKey(), per https://datatracker.ietf.org/doc/draft-ietf-lamps-kyber-certificates/
+    // This is due to AWS-LC currently only supporting expandedKey format for encode/decode
+    // https://github.com/bcgit/bc-java/blob/b41f23936724284a20f10dff13c76896a846031b/prov/src/main/java/org/bouncycastle/jcajce/interfaces/MLKEMPrivateKey.java#L35
+    MLKEMPrivateKey bcPrivateKeyExpanded =
+        ((MLKEMPrivateKey) bcKeyPair.getPrivate()).getPrivateKey(false);
+
+    KeyFactory accpKeyFactory =
+        KeyFactory.getInstance(bcKeyPair.getPrivate().getAlgorithm(), NATIVE_PROVIDER);
+    PublicKey accpPublicKey =
+        accpKeyFactory.generatePublic(new X509EncodedKeySpec(bcKeyPair.getPublic().getEncoded()));
+    PrivateKey accpPrivateKey =
+        accpKeyFactory.generatePrivate(new PKCS8EncodedKeySpec(bcPrivateKeyExpanded.getEncoded()));
+    assertArrayEquals(accpPublicKey.getEncoded(), bcKeyPair.getPublic().getEncoded());
+    assertArrayEquals(accpPrivateKey.getEncoded(), bcPrivateKeyExpanded.getEncoded());
+
+    // Test ACCP's encapsulation can be decapsulated by BouncyCastle
+    KEM accpKem = KEM.getInstance(paramSet, NATIVE_PROVIDER);
+    NamedParameterSpec accpParamSpec = new NamedParameterSpec(paramSet);
+    KEM.Encapsulated encapsulated =
+        accpKem.newEncapsulator(accpKeyPair.getPublic(), accpParamSpec, null).encapsulate();
+    KEM bcKem = KEM.getInstance("ML-KEM", TestUtil.BC_PROVIDER); // BC uses Generic ML-KEM
+
+    // Configure BC to not apply KDF processing to get raw shared secret
+    KTSParameterSpec bcParamSpec = new KTSParameterSpec.Builder("Generic", 256).withNoKdf().build();
+    SecretKey bcSecret =
+        bcKem.newDecapsulator(bcPriv, bcParamSpec).decapsulate(encapsulated.encapsulation());
+    assertArrayEquals(
+        encapsulated.key().getEncoded(),
+        bcSecret.getEncoded(),
+        "ACCP and BouncyCastle should produce identical shared secrets for " + paramSet);
+  }
+
+  private MLKEMParameterSpec getMLKEMParamSpec(String paramSet) {
+    switch (paramSet) {
+      case "ML-KEM-512":
+        return MLKEMParameterSpec.ml_kem_512;
+      case "ML-KEM-768":
+        return MLKEMParameterSpec.ml_kem_768;
+      case "ML-KEM-1024":
+        return MLKEMParameterSpec.ml_kem_1024;
+      default:
+        throw new IllegalArgumentException("Unknown parameter set: " + paramSet);
+    }
+  }
+}

--- a/tst/com/amazon/corretto/crypto/provider/test/jdk17plus/MlKemTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/jdk17plus/MlKemTest.java
@@ -173,6 +173,22 @@ public class MlKemTest {
         () -> kem512.newDecapsulator(pair768.getPrivate(), wrongSpec));
   }
 
+  @Test
+  public void testKeyFactorySelfConversion() throws Exception {
+    KeyPairGenerator keyGen = KeyPairGenerator.getInstance("ML-KEM", NATIVE_PROVIDER);
+    KeyPair originalKeyPair = keyGen.generateKeyPair();
+
+    KeyFactory keyFactory = KeyFactory.getInstance("ML-KEM", NATIVE_PROVIDER);
+
+    byte[] publicKeyEncoded = originalKeyPair.getPublic().getEncoded();
+    PublicKey publicKey = keyFactory.generatePublic(new X509EncodedKeySpec(publicKeyEncoded));
+    assertArrayEquals(publicKeyEncoded, publicKey.getEncoded());
+
+    byte[] privateKeyEncoded = originalKeyPair.getPrivate().getEncoded();
+    PrivateKey privateKey = keyFactory.generatePrivate(new PKCS8EncodedKeySpec(privateKeyEncoded));
+    assertArrayEquals(privateKeyEncoded, privateKey.getEncoded());
+  }
+
   @ParameterizedTest
   @ValueSource(strings = {"ML-KEM-512", "ML-KEM-768", "ML-KEM-1024"})
   public void testCiphertextSizes(String paramSet) throws Exception {


### PR DESCRIPTION
This PR adds ML-KEM support to ACCP by implementing KEM base classes and ML-KEM from AWS-LC. The implementation supports all three ML-KEM parameter sets (512, 768, 1024) with full encapsulation/decapsulation functionality.

The [KEM](https://docs.oracle.com/en/java/javase/22/docs/api/java.base/javax/crypto/KEM.html) and [KemSpi](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/javax/crypto/KEMSpi.html) APIs are only supported in JDK 17 and 21+, requiring the `TARGET_JDK_VERSION` to be set to JDK 17 or 21+ when building ACCP for ML-KEM.  

ACCP can only export ML-KEM keys in `expandedKey` format as per the [draft standard](https://www.ietf.org/archive/id/draft-ietf-lamps-dilithium-certificates-12.html#appendix-C.2), as currently AWS-LC does not support exporting KEM keys in seed format. This means that Bouncy Castle can import all ACCP keys but ACCP can only import Bouncy Castle ML-KEM keys that are in `expandedKey` format. 

Unit tests are written in`MlKemTest.java`, and were verified using  `./gradlew clean singleTest -DSINGLE_TEST=com.amazon.corretto.crypto.provider.test.MlKemTest -DTARGET_JDK_VERSION=17.`  `MlKemTest.java` tests ML-KEM key generation, encapsulation/decapsulation, parameter set validation, valid ciphertext sizes and shared secret generation. It also verifies compatibility with BouncyCastle through ACCP's ML-KEM KeyFactory.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.