### PR TITLE
Change AWS-LC version tag and EC_PWT tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ plugins {
 
 group = 'software.amazon.cryptools'
 version = '2.5.0'
-ext.awsLcMainTag = 'v1.48.2'
+ext.awsLcMainTag = 'v1.60.0'
 ext.awsLcFipsTag = 'AWS-LC-FIPS-3.0.0'
 ext.isExperimentalFips = Boolean.getBoolean('EXPERIMENTAL_FIPS')
 ext.isFips = ext.isExperimentalFips || Boolean.getBoolean('FIPS')

--- a/tst/com/amazon/corretto/crypto/provider/test/FipsStatusTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/FipsStatusTest.java
@@ -101,7 +101,7 @@ public class FipsStatusTest {
     assumeTrue(provider.isFipsSelfTestFailureSkipAbort());
     assumeTrue(awsLcIsBuiltWitFipshBreakTest());
     testPwctBreakage("RSA", "RSA_PWCT");
-    testPwctBreakage("EC", "ECDSA_PWCT");
+    testPwctBreakage("EC", "EC_PWCT");
     testPwctBreakage("Ed25519", "EDDSA_PWCT");
     if (provider.isExperimentalFips()) { // can be removed when AWS-LC-FIPS supports ML-DSA
       testPwctBreakage("ML-DSA", "MLDSA_PWCT");


### PR DESCRIPTION
Change `awsLcMainTag` from 1.48.2 to 1.60.0 in `build.gradle` to support the latest AWS-LC release from #490. Changed `ECDSA_PWCT` to `EC_PWCT` to match AWS-LC latest release, to resolve the failing `AccpCiNoAbortFipsTests.`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
