### PR TITLE
Change ECDSA_PWCT to EC

### DIFF
--- a/tst/com/amazon/corretto/crypto/provider/test/FipsStatusTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/FipsStatusTest.java
@@ -101,7 +101,7 @@ public class FipsStatusTest {
     assumeTrue(provider.isFipsSelfTestFailureSkipAbort());
     assumeTrue(awsLcIsBuiltWitFipshBreakTest());
     testPwctBreakage("RSA", "RSA_PWCT");
-    testPwctBreakage("EC", "ECDSA_PWCT");
+    testPwctBreakage("EC", "EC_PWCT");
     testPwctBreakage("Ed25519", "EDDSA_PWCT");
     if (provider.isExperimentalFips()) { // can be removed when AWS-LC-FIPS supports ML-DSA
       testPwctBreakage("ML-DSA", "MLDSA_PWCT");


### PR DESCRIPTION
Change `ECDSA_PWCT` to `EC_PWCT`  in `FipsStatusTest` to update ACCP to match AWS-LC's latest release where it was [modified](https://github.com/aws/aws-lc/commit/4d690531cf09d84f14f7049c3c5fe136b12bca19#diff-78c7bb6e20bb19e25f9d7b16a98f3634ef588c3188e45d111e7ded2435808d9aR26). This will resolve the CodeBuild `AccpCiNoAbortFipsTests` CI job failure as it was failing due to this change.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
