### PR TITLE
Add POSIX permissions checks to Loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,8 +348,7 @@ When changing between FIPS and non-FIPS builds, be sure to do a full `clean` of 
 * release: **Default target** depends on build, test, and coverage
 * overkill: Run **all** tests (no coverage)
 * generateEclipseClasspath: Generates a `.classpath` file which is understandable by Eclipse and VS Code to make development easier. (This should ideally be run prior to opening ACCP in your IDE.)
-* single_test: Runs a single unit test. The test is selected with the Java system property `SINGLE_TEST`. For example: `./gradlew single_test -DSINGLE_TEST=com.amazon.corretto.crypto.provider.test.EcGenTest`
-  (You may need to do a clean build when switching between selected tests.)
+* singleTest: Runs a single unit test. The test is selected with the Java system property `SINGLE_TEST`. For example: `./gradlew singleTest -DSINGLE_TEST=com.amazon.corretto.crypto.provider.test.EcGenTest`
 
 ## Configuration
 There are several ways to configure the ACCP as the highest priority provider in Java.


### PR DESCRIPTION
*Issue #, if available:*
CryptoAlg-3511

*Description of changes:*
Assertions around the POSIX permissions and owner of the temporary
directory created by `Loader` have been added to prevent a race
condition between creation of the directory and use of it for loading
the ACCP native library.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
