### PR TITLE
minor: Fix typo in benchmarks README

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -16,7 +16,7 @@ The reports are saved under `lib/build/results/jmh`.
 ```
 
 * `-Pfips` flag can be used to use the FIPS artifacts for benchmarking.
-* `-PaccpVerion="ACCP_VERSION"` can be used to run benchmarks for a specific version of ACCP
+* `-PaccpVersion="ACCP_VERSION"` can be used to run benchmarks for a specific version of ACCP
 
 ### Benchmarking locally built ACCP
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Fixes typo in command line examples for version specification in command line for Gradle

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
