### PR TITLE
Retry RSA key parsing to handle RSASSA-PSS OID

### DIFF
--- a/csrc/java_evp_keys.cpp
+++ b/csrc/java_evp_keys.cpp
@@ -104,8 +104,21 @@ JNIEXPORT jlong JNICALL Java_com_amazon_corretto_crypto_provider_EvpKeyFactory_p
 
         {
             jni_borrow borrow = jni_borrow(env, pkcs8Buff, "pkcs8Buff");
-            result.set(der2EvpPrivateKey(borrow, derLen, evpType, shouldCheckPrivate, EX_INVALID_KEY_SPEC));
-            if (EVP_PKEY_base_id(result) != evpType) {
+            // RSASSA-PSS keys use OID id-RSASSA-PSS (1.2.840.113549.1.1.10) which
+            // causes d2i_PrivateKey(EVP_PKEY_RSA, ...) to fail. Retry with
+            // EVP_PKEY_RSA_PSS if the initial parse fails for an RSA key type.
+            try {
+                result.set(der2EvpPrivateKey(borrow, derLen, evpType, shouldCheckPrivate, EX_INVALID_KEY_SPEC));
+            } catch (java_ex&) {
+                if (evpType == EVP_PKEY_RSA) {
+                    result.set(
+                        der2EvpPrivateKey(borrow, derLen, EVP_PKEY_RSA_PSS, shouldCheckPrivate, EX_INVALID_KEY_SPEC));
+                } else {
+                    throw;
+                }
+            }
+            int baseId = EVP_PKEY_base_id(result);
+            if (baseId != evpType && !(evpType == EVP_PKEY_RSA && baseId == EVP_PKEY_RSA_PSS)) {
                 throw_java_ex(EX_INVALID_KEY_SPEC, "Incorrect key type");
             }
         }
@@ -134,7 +147,8 @@ JNIEXPORT jlong JNICALL Java_com_amazon_corretto_crypto_provider_EvpKeyFactory_x
         {
             jni_borrow borrow = jni_borrow(env, x509Buff, "x509Buff");
             result.set(der2EvpPublicKey(borrow, derLen, EX_INVALID_KEY_SPEC));
-            if (EVP_PKEY_base_id(result) != evpType) {
+            int baseId = EVP_PKEY_base_id(result);
+            if (baseId != evpType && !(evpType == EVP_PKEY_RSA && baseId == EVP_PKEY_RSA_PSS)) {
                 throw_java_ex(EX_INVALID_KEY_SPEC, "Incorrect key type");
             }
         }

--- a/csrc/java_evp_keys.cpp
+++ b/csrc/java_evp_keys.cpp
@@ -111,6 +111,7 @@ JNIEXPORT jlong JNICALL Java_com_amazon_corretto_crypto_provider_EvpKeyFactory_p
                 result.set(der2EvpPrivateKey(borrow, derLen, evpType, shouldCheckPrivate, EX_INVALID_KEY_SPEC));
             } catch (java_ex&) {
                 if (evpType == EVP_PKEY_RSA) {
+                    ERR_clear_error();
                     result.set(
                         der2EvpPrivateKey(borrow, derLen, EVP_PKEY_RSA_PSS, shouldCheckPrivate, EX_INVALID_KEY_SPEC));
                 } else {

--- a/csrc/keyutils.cpp
+++ b/csrc/keyutils.cpp
@@ -34,7 +34,7 @@ EVP_PKEY* der2EvpPrivateKey(const unsigned char* der,
         throw_openssl(javaExceptionClass, "Unable to convert PKCS8_PRIV_KEY_INFO to EVP_PKEY");
     }
 
-    if (EVP_PKEY_base_id(result) == EVP_PKEY_RSA) {
+    if (isRsaKeyType(EVP_PKEY_base_id(result))) {
         const RSA* rsa = EVP_PKEY_get0_RSA(result);
 
         if (rsa) {
@@ -132,6 +132,7 @@ bool checkKey(const EVP_PKEY* key)
 
     switch (keyType) {
     case EVP_PKEY_RSA:
+    case EVP_PKEY_RSA_PSS:
         rsaKey = EVP_PKEY_get0_RSA(key);
         RSA_get0_factors(rsaKey, &p, &q);
         // RSA_check_key only works when sufficient private values are set

--- a/csrc/keyutils.h
+++ b/csrc/keyutils.h
@@ -88,6 +88,12 @@ EVP_PKEY* der2EvpPublicKey(const unsigned char* der, const int derLen, const cha
 bool checkKey(const EVP_PKEY* key);
 static bool inline BN_null_or_zero(const BIGNUM* bn) { return nullptr == bn || BN_is_zero(bn); }
 
+// Returns true if keyType is EVP_PKEY_RSA or EVP_PKEY_RSA_PSS. RSASSA-PSS keys
+// (OID 1.2.840.113549.1.1.10) are functionally identical to RSA keys but use a
+// different AlgorithmIdentifier, causing EVP_PKEY_base_id() to return
+// EVP_PKEY_RSA_PSS instead of EVP_PKEY_RSA.
+static inline bool isRsaKeyType(int keyType) { return keyType == EVP_PKEY_RSA || keyType == EVP_PKEY_RSA_PSS; }
+
 class raii_cipher_ctx {
 private:
     EVP_CIPHER_CTX* m_ctx;

--- a/csrc/sign.cpp
+++ b/csrc/sign.cpp
@@ -130,7 +130,7 @@ bool initializeContext(raii_env& env,
         }
     }
 
-    if (EVP_PKEY_base_id(ctx->getKey()) == EVP_PKEY_RSA) {
+    if (isRsaKeyType(EVP_PKEY_base_id(ctx->getKey()))) {
         if (!configurePadding(env, pctx, paddingType, mgfMdPtr, pssSaltLen)) {
             throw_openssl("Unable to configure padding");
         }
@@ -383,7 +383,7 @@ JNIEXPORT jboolean JNICALL Java_com_amazon_corretto_crypto_provider_EvpSignature
 
             // JCA/JCA requires us to try to throw an exception on corrupted signatures, but only if it isn't an RSA
             // signature
-            if (errorCode != 0 && keyType != EVP_PKEY_RSA) {
+            if (errorCode != 0 && !isRsaKeyType(keyType)) {
                 throw_java_ex(
                     EX_SIGNATURE_EXCEPTION, formatOpensslError(errorCode, "Unknown error verifying signature"));
             }
@@ -609,7 +609,7 @@ JNIEXPORT jboolean JNICALL Java_com_amazon_corretto_crypto_provider_EvpSignature
 
             // JCA/JCA requires us to try to throw an exception on corrupted signatures, but only if it isn't an RSA
             // signature
-            if (errorCode != 0 && EVP_PKEY_base_id(ctx.getKey()) != EVP_PKEY_RSA) {
+            if (errorCode != 0 && !isRsaKeyType(EVP_PKEY_base_id(ctx.getKey()))) {
                 throw_java_ex(
                     EX_SIGNATURE_EXCEPTION, formatOpensslError(errorCode, "Unknown error verifying signature"));
             }
@@ -639,7 +639,7 @@ JNIEXPORT jbyteArray JNICALL Java_com_amazon_corretto_crypto_provider_NoneWithRs
         EVP_PKEY* key = reinterpret_cast<EVP_PKEY*>(pKey);
         const EVP_MD* md = reinterpret_cast<const EVP_MD*>(hashMd);
 
-        if (EVP_PKEY_base_id(key) != EVP_PKEY_RSA) {
+        if (!isRsaKeyType(EVP_PKEY_base_id(key))) {
             throw_java_ex(EX_SIGNATURE_EXCEPTION, "Key must be RSA");
         }
 
@@ -716,7 +716,7 @@ JNIEXPORT jboolean JNICALL Java_com_amazon_corretto_crypto_provider_NoneWithRsa_
         EVP_PKEY* key = reinterpret_cast<EVP_PKEY*>(pKey);
         const EVP_MD* md = reinterpret_cast<const EVP_MD*>(hashMd);
 
-        if (EVP_PKEY_base_id(key) != EVP_PKEY_RSA) {
+        if (!isRsaKeyType(EVP_PKEY_base_id(key))) {
             throw_java_ex(EX_SIGNATURE_EXCEPTION, "Key must be RSA");
         }
 

--- a/tst/com/amazon/corretto/crypto/provider/test/EvpSignatureSpecificTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/EvpSignatureSpecificTest.java
@@ -929,9 +929,11 @@ public final class EvpSignatureSpecificTest {
     final PublicKey accpPub =
         accpKf.generatePublic(
             new java.security.spec.X509EncodedKeySpec(pssKeyPair.getPublic().getEncoded()));
+    assertEquals("RSA", accpPub.getAlgorithm());
     final PrivateKey accpPriv =
         accpKf.generatePrivate(
             new java.security.spec.PKCS8EncodedKeySpec(pssKeyPair.getPrivate().getEncoded()));
+    assertEquals("RSA", accpPriv.getAlgorithm());
 
     // Use translated keys to sign and verify
     final PSSParameterSpec pssSpec =

--- a/tst/com/amazon/corretto/crypto/provider/test/EvpSignatureSpecificTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/EvpSignatureSpecificTest.java
@@ -873,6 +873,82 @@ public final class EvpSignatureSpecificTest {
     assertThrows(InvalidKeyException.class, () -> signature.initVerify(emptyPublicKey));
   }
 
+  /**
+   * Reproduces GitHub issue #516: ACCP's RSASSA-PSS signature rejects keys generated via
+   * KeyPairGenerator.getInstance("RSASSA-PSS") with InvalidKeySpecException. RSASSA-PSS keys use
+   * OID 1.2.840.113549.1.1.10 (id-RSASSA-PSS) instead of 1.2.840.113549.1.1.1 (rsaEncryption),
+   * causing EVP_PKEY_base_id() to return EVP_PKEY_RSA_PSS rather than EVP_PKEY_RSA.
+   */
+  @Test
+  public void testRsassaPssKeysAccepted() throws Exception {
+    // Generate RSASSA-PSS keys using the JDK's default provider (SunRsaSign).
+    // These keys are encoded with OID id-RSASSA-PSS rather than rsaEncryption.
+    final KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSASSA-PSS");
+    kpg.initialize(2048);
+    final KeyPair pssKeyPair = kpg.generateKeyPair();
+    assertEquals("RSASSA-PSS", pssKeyPair.getPublic().getAlgorithm());
+
+    final PSSParameterSpec pssSpec =
+        new PSSParameterSpec("SHA-256", "MGF1", MGF1ParameterSpec.SHA256, 32, 1);
+
+    // Sign with ACCP using RSASSA-PSS key
+    final Signature signer = Signature.getInstance("RSASSA-PSS", NATIVE_PROVIDER);
+    signer.setParameter(pssSpec);
+    signer.initSign(pssKeyPair.getPrivate());
+    signer.update(MESSAGE);
+    final byte[] signature = signer.sign();
+
+    // Verify with ACCP using RSASSA-PSS key
+    final Signature verifier = Signature.getInstance("RSASSA-PSS", NATIVE_PROVIDER);
+    verifier.setParameter(pssSpec);
+    verifier.initVerify(pssKeyPair.getPublic());
+    verifier.update(MESSAGE);
+    assertTrue(verifier.verify(signature));
+
+    // Cross-verify: sign with ACCP's RSASSA-PSS key, verify with SunRsaSign
+    final Signature sunVerifier = Signature.getInstance("RSASSA-PSS", "SunRsaSign");
+    sunVerifier.setParameter(pssSpec);
+    sunVerifier.initVerify(pssKeyPair.getPublic());
+    sunVerifier.update(MESSAGE);
+    assertTrue(sunVerifier.verify(signature));
+  }
+
+  /**
+   * Tests that RSASSA-PSS keys work with ACCP's KeyFactory for both public and private key
+   * translation via PKCS8 and X509 encoded key specs.
+   */
+  @Test
+  public void testRsassaPssKeyFactory() throws Exception {
+    // Generate RSASSA-PSS keys using the JDK's default provider
+    final KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSASSA-PSS");
+    kpg.initialize(2048);
+    final KeyPair pssKeyPair = kpg.generateKeyPair();
+
+    // Translate RSASSA-PSS keys through ACCP's RSA KeyFactory
+    final KeyFactory accpKf = KeyFactory.getInstance("RSA", NATIVE_PROVIDER);
+    final PublicKey accpPub =
+        accpKf.generatePublic(
+            new java.security.spec.X509EncodedKeySpec(pssKeyPair.getPublic().getEncoded()));
+    final PrivateKey accpPriv =
+        accpKf.generatePrivate(
+            new java.security.spec.PKCS8EncodedKeySpec(pssKeyPair.getPrivate().getEncoded()));
+
+    // Use translated keys to sign and verify
+    final PSSParameterSpec pssSpec =
+        new PSSParameterSpec("SHA-256", "MGF1", MGF1ParameterSpec.SHA256, 32, 1);
+    final Signature signer = Signature.getInstance("RSASSA-PSS", NATIVE_PROVIDER);
+    signer.setParameter(pssSpec);
+    signer.initSign(accpPriv);
+    signer.update(MESSAGE);
+    final byte[] signature = signer.sign();
+
+    final Signature verifier = Signature.getInstance("RSASSA-PSS", NATIVE_PROVIDER);
+    verifier.setParameter(pssSpec);
+    verifier.initVerify(accpPub);
+    verifier.update(MESSAGE);
+    assertTrue(verifier.verify(signature));
+  }
+
   @SuppressWarnings("serial")
   private static class RawKey implements PublicKey, PrivateKey {
     private final String algorithm_;


### PR DESCRIPTION
*Issue #, if available:* Addresses #516

# Notes

In #516 @msteindorfer reported that ACCP fails to parse SunRsaSign-generated `RSASSA-PSS` keys. `RSA` and `RSASSA-PSS` keys should be identical in terms of key material, but OpenJDK [gives them different OIDs](https://github.com/openjdk/jdk/blob/a6db3f870218bc016ecc67e3f5e142d6491ac080/src/java.base/share/classes/sun/security/rsa/RSAUtil.java#L46-L47) on serialization, and ACCP only checks for `RSA`'s NID/OID as specified in [EvpKeyType](https://github.com/corretto/amazon-corretto-crypto-provider/blob/afcbb82a13b196dde3f535193aac4a6e4bd3801d/src/com/amazon/corretto/crypto/provider/EvpKeyType.java#L19-L24).

This PR adds a `RSASSA-PSS` retry when `RSA`-typed keys fail to parse and adjust native logic to handle either RSA value returned from AWS-LC's `EVP_PKEY_base_id()`.

# Testing

- new unit tests failed before changes, succeed after

---


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
