### PR TITLE
Add `toString()` for `EvpEcPublicKey` similar to SUN `ECPublicKeyImpl`

### DIFF
--- a/src/com/amazon/corretto/crypto/provider/EvpEcPublicKey.java
+++ b/src/com/amazon/corretto/crypto/provider/EvpEcPublicKey.java
@@ -4,6 +4,7 @@ package com.amazon.corretto.crypto.provider;
 
 import java.math.BigInteger;
 import java.security.interfaces.ECPublicKey;
+import java.security.spec.ECParameterSpec;
 import java.security.spec.ECPoint;
 
 class EvpEcPublicKey extends EvpEcKey implements ECPublicKey {
@@ -42,5 +43,23 @@ class EvpEcPublicKey extends EvpEcKey implements ECPublicKey {
       }
     }
     return result;
+  }
+
+  @Override
+  public String toString() {
+    final ECParameterSpec parameterSpec = getParams();
+    final ECPoint point = getW();
+
+    final StringBuffer sb = new StringBuffer(AmazonCorrettoCryptoProvider.PROVIDER_NAME);
+    sb.append(" ");
+    sb.append(getAlgorithm());
+    sb.append(" public key, ");
+    sb.append(parameterSpec.getOrder().bitLength());
+    sb.append(" bits\n  public x coord: ");
+    sb.append(point.getAffineX());
+    sb.append("\n  public y coord: ");
+    sb.append(point.getAffineY());
+    sb.append("\n  parameters: ").append(parameterSpec);
+    return sb.toString();
   }
 }

--- a/tst/com/amazon/corretto/crypto/provider/test/EcGenTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/EcGenTest.java
@@ -21,6 +21,8 @@ import java.security.spec.X509EncodedKeySpec;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.bouncycastle.asn1.ASN1Encodable;
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 import org.bouncycastle.asn1.ASN1Sequence;
@@ -403,5 +405,53 @@ public class EcGenTest {
         }
       }
     }
+  }
+
+  private static final String CURVE_NAME = "secp256r1";
+
+  private ECPublicKey createECPublicKey(Provider provider) throws GeneralSecurityException {
+    final KeyPairGenerator generator = KeyPairGenerator.getInstance("EC", provider);
+    generator.initialize(new ECGenParameterSpec(CURVE_NAME));
+    final KeyPair keyPair = generator.generateKeyPair();
+    return (ECPublicKey) keyPair.getPublic();
+  }
+
+  private void checkEcToStringOutput(ECPublicKey publicKey, String providerPrefix) {
+    final Pattern genericPattern =
+        Pattern.compile(
+            providerPrefix
+                + " "
+                + "EC public key, (\\d+) bits\\n"
+                + "  public x coord: ([0-9]+)\\n"
+                + "  public y coord: ([0-9]+)\\n"
+                + "  parameters: (.+)",
+            Pattern.DOTALL);
+    final Matcher matcher = genericPattern.matcher(publicKey.toString());
+    assertTrue(
+        matcher.find(),
+        providerPrefix
+            + " toString output should match expected pattern. Actual output:\n"
+            + publicKey.toString());
+
+    final ECPoint w = publicKey.getW();
+    assertTrue(
+        matcher.group(1).matches("\\d+"),
+        providerPrefix + " pattern should capture bit length as digits");
+    assertEquals(
+        w.getAffineX().toString(),
+        matcher.group(2),
+        providerPrefix + " pattern should capture correct x coordinate value");
+    assertEquals(
+        w.getAffineY().toString(),
+        matcher.group(3),
+        providerPrefix + " pattern should capture correct y coordinate value");
+    assertTrue(matcher.group(4).length() > 0, providerPrefix + " pattern should capture params");
+  }
+
+  @Test
+  public void testECPublicKeyToString() throws GeneralSecurityException {
+    checkEcToStringOutput(createECPublicKey(Security.getProvider("SunEC")), "Sun");
+    checkEcToStringOutput(
+        createECPublicKey(NATIVE_PROVIDER.INSTANCE), NATIVE_PROVIDER.PROVIDER_NAME);
   }
 }


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

`EvpEcPublicKey` is currently lacking a `toString()` method.

In order to avoid friction for users adopting ACCP, this PR adds a `toString()` method with output similar to SUN `ECPublicKeyImpl`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
