### PR TITLE
Add `toString()` for `EvpRsaPublicKey` similar to SUN `RSAPublicKeyImpl`

### DIFF
--- a/src/com/amazon/corretto/crypto/provider/EvpRsaKey.java
+++ b/src/com/amazon/corretto/crypto/provider/EvpRsaKey.java
@@ -4,6 +4,7 @@ package com.amazon.corretto.crypto.provider;
 
 import java.math.BigInteger;
 import java.security.interfaces.RSAKey;
+import java.security.spec.AlgorithmParameterSpec;
 
 abstract class EvpRsaKey extends EvpKey implements RSAKey {
   private static final long serialVersionUID = 1;
@@ -32,5 +33,14 @@ abstract class EvpRsaKey extends EvpKey implements RSAKey {
     }
 
     return result;
+  }
+
+  public AlgorithmParameterSpec getParams() {
+    // RSA keys do not have parameters in ACCP, so we return null.
+    // This is already implemented as a default in the JDK interface `RSAKey`
+    // (which this class implements), but only as of Java 11.
+    // To maintain source compatibility with Java 8,
+    // we add this otherwise redundant implementation here.
+    return null;
   }
 }

--- a/src/com/amazon/corretto/crypto/provider/EvpRsaPublicKey.java
+++ b/src/com/amazon/corretto/crypto/provider/EvpRsaPublicKey.java
@@ -32,4 +32,22 @@ class EvpRsaPublicKey extends EvpRsaKey implements RSAPublicKey {
     }
     return result;
   }
+
+  @Override
+  public String toString() {
+    final BigInteger modulus = getModulus();
+
+    final StringBuffer sb = new StringBuffer(AmazonCorrettoCryptoProvider.PROVIDER_NAME);
+    sb.append(" ");
+    sb.append(getAlgorithm());
+    sb.append(" public key, ");
+    sb.append(modulus.bitLength());
+    sb.append(" bits\n  params: ");
+    sb.append(getParams());
+    sb.append("\n  modulus: ");
+    sb.append(modulus);
+    sb.append("\n  public exponent: ");
+    sb.append(getPublicExponent());
+    return sb.toString();
+  }
 }

--- a/tst/com/amazon/corretto/crypto/provider/test/RsaGenTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/RsaGenTest.java
@@ -19,12 +19,16 @@ import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidParameterException;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
+import java.security.Provider;
 import java.security.SecureRandom;
+import java.security.Security;
 import java.security.interfaces.RSAPrivateCrtKey;
 import java.security.interfaces.RSAPublicKey;
 import java.security.spec.RSAKeyGenParameterSpec;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import javax.crypto.Cipher;
 import org.bouncycastle.util.encoders.Hex;
 import org.junit.jupiter.api.Test;
@@ -353,5 +357,52 @@ public class RsaGenTest {
         }
       }
     }
+  }
+
+  private static final int KEY_SIZE = 2048;
+
+  private RSAPublicKey createPublicKey(Provider provider) throws GeneralSecurityException {
+    final KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA", provider);
+    generator.initialize(KEY_SIZE);
+    final KeyPair keyPair = generator.generateKeyPair();
+    return (RSAPublicKey) keyPair.getPublic();
+  }
+
+  private void checkToStringOutput(RSAPublicKey publicKey, String providerPrefix) {
+    final Pattern genericPattern =
+        Pattern.compile(
+            providerPrefix
+                + " "
+                + "RSA public key, (\\d+) bits\\s*\\n"
+                + "\\s*params: null\\s*\\n"
+                + "\\s*modulus: (\\d+)\\s*\\n"
+                + "\\s*public exponent: (\\d+)\\s*",
+            Pattern.DOTALL);
+    final Matcher matcher = genericPattern.matcher(publicKey.toString());
+    assertTrue(
+        matcher.find(),
+        providerPrefix
+            + " toString output should match expected pattern. Actual output:\n"
+            + publicKey.toString());
+    assertEquals(
+        String.valueOf(KEY_SIZE),
+        matcher.group(1),
+        providerPrefix + " pattern should capture correct bit length");
+    assertEquals(
+        publicKey.getModulus().toString(),
+        matcher.group(2),
+        providerPrefix + " pattern should capture correct modulus value");
+    assertEquals(
+        publicKey.getPublicExponent().toString(),
+        matcher.group(3),
+        providerPrefix + " pattern should capture correct public exponent value");
+  }
+
+  @Test
+  public void testRsaPublicKeyToString() throws GeneralSecurityException {
+    checkToStringOutput(createPublicKey(Security.getProvider("SunRsaSign")), "Sun");
+    checkToStringOutput(
+        createPublicKey(AmazonCorrettoCryptoProvider.INSTANCE),
+        AmazonCorrettoCryptoProvider.PROVIDER_NAME);
   }
 }


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

`EvpRsaPublicKey ` is currently lacking a `toString()` method.

In order to avoid friction for users adopting ACCP, this PR adds a `toString()` method with output similar to SUN `RSAPublicKeyImpl`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
