### PR TITLE
Support elliptic-curve aliases by comparing OIDs instead of names

### DIFF
--- a/tst/com/amazon/corretto/crypto/provider/test/EcGenTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/EcGenTest.java
@@ -378,7 +378,8 @@ public class EcGenTest {
 
   public static void assertECEquals(
       final String message, final ECGenParameterSpec expected, final ECGenParameterSpec actual) {
-    assertEquals(expected.getName(), actual.getName(), message);
+    assertEquals(
+        TestUtil.getCurveOid(expected.getName()), TestUtil.getCurveOid(actual.getName()), message);
   }
 
   private static class TestThread extends Thread {


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Since JDK 24, the `EcParametersTest` test fails since, instead expected curve name `secp256r1`, the actual value is `prime256v1`. The latter is a valid alternative name for the former.

The test case already covers the corner case that whenever JCE returns the OID instead of the human-readable name, it will compare both OIDs. This commit expands the same logic to always instead of names, default to OID comparison.

*Further  comments:*

While this PR contains just the test fix to accept the different aliased names, it should separately be followed up if expected and actual elliptic curve names must be identical, or if OID equality is sufficient.

_Note, since pull-request builds only cover JDK 8, 11 and 17, this issue doesn't show in CI/CD coverage. @WillChilds-Klein I suggest to extend pull-request build testing also with the most recent two LTS versions, JDK 21 and 25._

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
