### PR TITLE
Convert explicitly from `int` to `byte` to avoid 'lossy-conversions' Java compiler warning with Java 20+

### DIFF
--- a/tst/com/amazon/corretto/crypto/provider/test/AesTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/AesTest.java
@@ -881,7 +881,7 @@ public class AesTest {
 
     for (int bit = 0; bit < data.length * 8; bit++) {
       byte[] corruptData = data.clone();
-      corruptData[bit / 8] ^= (1 << (bit % 8));
+      corruptData[bit / 8] ^= (byte) (1 << (bit % 8));
 
       Cipher check = Cipher.getInstance(ALGO_NAME, NATIVE_PROVIDER);
       check.init(Cipher.DECRYPT_MODE, key, algorithmParameterSpec, rnd);
@@ -906,7 +906,7 @@ public class AesTest {
 
     for (int bit = 0; bit < data.length * 8; bit++) {
       byte[] corruptData = data.clone();
-      corruptData[bit / 8] ^= (1 << (bit % 8));
+      corruptData[bit / 8] ^= (byte) (1 << (bit % 8));
 
       Cipher check = Cipher.getInstance(ALGO_NAME, NATIVE_PROVIDER);
       check.init(Cipher.DECRYPT_MODE, key, algorithmParameterSpec, rnd);
@@ -934,7 +934,7 @@ public class AesTest {
 
     for (int bit = 0; bit < data.length * 8; bit++) {
       byte[] corruptData = data.clone();
-      corruptData[bit / 8] ^= (1 << (bit % 8));
+      corruptData[bit / 8] ^= (byte) (1 << (bit % 8));
       ByteBuffer corruptBuff = ByteBuffer.wrap(corruptData);
       ByteBuffer outputBuff = ByteBuffer.wrap(output);
 

--- a/tst/com/amazon/corretto/crypto/provider/test/EvpSignatureSpecificTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/EvpSignatureSpecificTest.java
@@ -210,7 +210,7 @@ public final class EvpSignatureSpecificTest {
 
     for (int bitpos = 0; bitpos < signature.length * 8; bitpos++) {
       byte[] badSignature = signature.clone();
-      badSignature[bitpos / 8] ^= (1 << (bitpos % 8));
+      badSignature[bitpos / 8] ^= (byte) (1 << (bitpos % 8));
 
       sig.update(message);
       try {


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

This avoids `javac` warning "warning: [lossy-conversions] implicit cast from int to byte in compound assignment is possibly lossy" on Java 20+.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
