### PR TITLE
Ensure key agreement validates parameters before retaining private key in field

### DIFF
--- a/src/com/amazon/corretto/crypto/provider/EvpKeyAgreement.java
+++ b/src/com/amazon/corretto/crypto/provider/EvpKeyAgreement.java
@@ -148,6 +148,11 @@ class EvpKeyAgreement extends KeyAgreementSpi {
     if (privKey != null) {
       privKey.releaseEphemeral();
     }
+    // If the following key translation throws an exception,
+    // then `key` must be invalid and we must not retain the `privKey` value
+    // to conform with JCE as described in JTREG test
+    // "sun/security/ec/ECDHKeyAgreementParamValidation.java".
+    privKey = null;
     privKey = provider_.translateKey(key, keyType_);
     reset();
   }


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

This PR aligns ACCP with JCE behavior and establishes compatibility with OpenJDK JTREG test `sun/security/ec/ECDHKeyAgreementParamValidation.java`, which was added in JDK 23.

For more information, see:
* https://bugs.openjdk.org/browse/JDK-8320449
* https://github.com/openjdk/jdk25u/commit/43d2d68da5f60cc45c5f9d9572020743579dc76c#diff-7054c55a121667407df602d45cb8828981b58f2723948244fe6392845421355e

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
