### PR TITLE
Relax experimental FIPS check for ML-KEM

### DIFF
--- a/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
+++ b/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
@@ -593,7 +593,7 @@ public final class AmazonCorrettoCryptoProvider extends java.security.Provider {
 
     this.shouldRegisterAesCfb = (!isFips() || isExperimentalFips());
 
-    this.shouldRegisterMLKEM = (Utils.isMlKemSupported() && (!isFips() || isExperimentalFips()));
+    this.shouldRegisterMLKEM = Utils.isMlKemSupported();
 
     this.shouldRegisterX25519 = Utils.getJavaVersion() >= 11;
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The AWS-LC-FIPS version that we [track](https://github.com/corretto/amazon-corretto-crypto-provider/blob/fd14f47dec52c385e94d7d9206dc9387d73339d9/build.gradle#L18) (i.e. AWS-LC-FIPS-3.1.0) [has ML-KEM inside](https://github.com/aws/aws-lc/tree/AWS-LC-FIPS-3.1.0/crypto/fipsmodule/ml_kem) the FIPS module boundary, so the experimental FIPS check is no longer necessary.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
