### PR TITLE
Add MlKemUtils with ML-KEM seed private key expansion

### DIFF
--- a/.github/workflows/codecov-ci.yml
+++ b/.github/workflows/codecov-ci.yml
@@ -26,7 +26,7 @@ jobs:
         env:
           TEST_JAVA_HOME: ${{ env.JAVA_HOME }}
         run: |
-          ./tests/ci/run_accp_basic_tests.sh --lcov-ignore inconsistent
+          ./tests/ci/run_accp_basic_tests.sh --lcov-ignore inconsistent --target-jdk-version 17
           ./tests/ci/run_accp_test_integration.sh
       - name: Upload Java coverage report to Codecov
         env:

--- a/csrc/keyutils.cpp
+++ b/csrc/keyutils.cpp
@@ -231,6 +231,53 @@ size_t encodeExpandedMLDSAPrivateKey(const EVP_PKEY* key, uint8_t** out)
     }
     return out_len;
 }
+
+size_t encodeExpandedMLKEMPrivateKey(const EVP_PKEY* key, uint8_t** out)
+{
+    CHECK_OPENSSL(key);
+    CHECK_OPENSSL(EVP_PKEY_id(key) == EVP_PKEY_KEM);
+    CHECK_OPENSSL(out);
+    size_t raw_len = 0;
+    CHECK_OPENSSL(EVP_PKEY_get_raw_private_key(key, nullptr, &raw_len));
+    int nid = NID_undef;
+    // See FIPS 203, Table 3: secret_key_len per parameter set
+    switch (raw_len) {
+    case 1632:
+        nid = NID_MLKEM512;
+        break;
+    case 2400:
+        nid = NID_MLKEM768;
+        break;
+    case 3168:
+        nid = NID_MLKEM1024;
+        break;
+    default:
+        throw_java_ex(EX_ILLEGAL_ARGUMENT, "Invalid ML-KEM secret key size");
+    }
+    OPENSSL_buffer_auto raw_expanded(raw_len);
+    CHECK_OPENSSL(EVP_PKEY_get_raw_private_key(key, raw_expanded, &raw_len));
+    CBB cbb, pkcs8, algorithm, priv, expanded;
+    CBB_init(&cbb, 0);
+    // Encoding below is based on expandedKey CHOICE member of PrivateKey ASN.1 structures in:
+    // https://datatracker.ietf.org/doc/rfc9935/ section 6
+    // spotless:off
+    if (!CBB_add_asn1(&cbb, &pkcs8, CBS_ASN1_SEQUENCE) ||
+        !CBB_add_asn1_uint64(&pkcs8, 0) ||
+        !CBB_add_asn1(&pkcs8, &algorithm, CBS_ASN1_SEQUENCE) ||
+        !OBJ_nid2cbb(&algorithm, nid) ||
+        !CBB_add_asn1(&pkcs8, &priv, CBS_ASN1_OCTETSTRING) ||
+        !CBB_add_asn1(&priv, &expanded, CBS_ASN1_OCTETSTRING) ||
+        !CBB_add_bytes(&expanded, raw_expanded, raw_len)) {
+        throw_java_ex(EX_RUNTIME_CRYPTO, "Error serializing expanded ML-KEM key");
+    }
+    // spotless:on
+    size_t out_len;
+    if (!CBB_finish(&cbb, out, &out_len)) {
+        OPENSSL_free(*out);
+        throw_java_ex(EX_RUNTIME_CRYPTO, "Error finalizing expanded ML-KEM key");
+    }
+    return out_len;
+}
 #endif // !defined(FIPS_BUILD) || defined(EXPERIMENTAL_FIPS_BUILD)
 
 size_t encodeRfc5915EcPrivateKey(const EVP_PKEY* key, uint8_t** out)

--- a/csrc/keyutils.h
+++ b/csrc/keyutils.h
@@ -150,6 +150,11 @@ RSA* new_private_RSA_key_with_no_e(BIGNUM const* n, BIGNUM const* d);
 // |*out|, and returns the size of |*out| on success and throws an unchecked exception on failure. The caller takes
 // ownership of |*out|.
 size_t encodeExpandedMLDSAPrivateKey(const EVP_PKEY* key, uint8_t** out);
+
+// Expands ML-KEM |key|, allocates appropriately sized buffer to |*out|, writes the PKCS8-encoded expanded key to
+// |*out|, and returns the size of |*out| on success and throws an unchecked exception on failure. The caller takes
+// ownership of |*out|.
+size_t encodeExpandedMLKEMPrivateKey(const EVP_PKEY* key, uint8_t** out);
 #endif
 
 // Formats an EC private key with redundant curve identifier confromant to RFC

--- a/csrc/util_class.cpp
+++ b/csrc/util_class.cpp
@@ -135,6 +135,60 @@ JNIEXPORT jbyteArray JNICALL Java_com_amazon_corretto_crypto_utils_MlDsaUtils_ex
 }
 
 /*
+ * Class:     com_amazon_corretto_crypto_utils_MlKemUtils
+ * Method:    expandPrivateKeyInternal
+ * Signature: ([B)[B
+ *
+ * AWS-LC's kem_priv_decode automatically expands seed-format keys
+ * via KEM_KEY_set_raw_keypair_from_seed, and kem_priv_encode always writes the expanded
+ * format. So we just parse and re-encode.
+ */
+JNIEXPORT jbyteArray JNICALL Java_com_amazon_corretto_crypto_utils_MlKemUtils_expandPrivateKeyInternal(
+    JNIEnv* pEnv, jclass, jbyteArray keyBytes)
+{
+    jbyteArray result = NULL;
+    try {
+        raii_env env(pEnv);
+        jsize key_der_len = env->GetArrayLength(keyBytes);
+
+        // ML-KEM seed-format PKCS8 is 86 bytes for all parameter sets (64-byte seed + ASN.1 overhead).
+        // If the key is already expanded, return it as-is.
+        if (key_der_len > 86) {
+            return keyBytes;
+        }
+        CHECK_OPENSSL(key_der_len == 86); // seed-only keys are always 86 bytes when PKCS8-encoded
+        uint8_t* key_der = (uint8_t*)env->GetByteArrayElements(keyBytes, nullptr);
+        CHECK_OPENSSL(key_der);
+
+        // Parse the seed key — AWS-LC expands it during parsing
+        BIO* key_bio = BIO_new_mem_buf(key_der, key_der_len);
+        CHECK_OPENSSL(key_bio);
+        PKCS8_PRIV_KEY_INFO_auto pkcs8 = PKCS8_PRIV_KEY_INFO_auto::from(d2i_PKCS8_PRIV_KEY_INFO_bio(key_bio, nullptr));
+        BIO_free(key_bio);
+        env->ReleaseByteArrayElements(keyBytes, (jbyte*)key_der, JNI_ABORT);
+        CHECK_OPENSSL(pkcs8.isInitialized());
+        EVP_PKEY_auto key = EVP_PKEY_auto::from(EVP_PKCS82PKEY(pkcs8));
+        CHECK_OPENSSL(key.isInitialized());
+
+        // Re-encode — AWS-LC always writes the expanded format
+        OPENSSL_buffer_auto new_der;
+        PKCS8_PRIV_KEY_INFO_auto new_pkcs8 = PKCS8_PRIV_KEY_INFO_auto::from(EVP_PKEY2PKCS8(key));
+        CHECK_OPENSSL(new_pkcs8.isInitialized());
+        int new_der_len = i2d_PKCS8_PRIV_KEY_INFO(new_pkcs8, &new_der);
+        CHECK_OPENSSL(new_der_len > 0);
+
+        if (!(result = env->NewByteArray(new_der_len))) {
+            throw_java_ex(EX_OOM, "Unable to allocate DER array");
+        }
+        env->SetByteArrayRegion(result, 0, new_der_len, (const jbyte*)new_der);
+    } catch (java_ex& ex) {
+        ex.throw_to_java(pEnv);
+        return 0;
+    }
+    return result;
+}
+
+/*
  * Class:     com_amazon_corretto_crypto_utils_MlDsaUtils
  * Method:    computeMuInternal
  * Signature: ([B[B)[B

--- a/csrc/util_class.cpp
+++ b/csrc/util_class.cpp
@@ -140,8 +140,8 @@ JNIEXPORT jbyteArray JNICALL Java_com_amazon_corretto_crypto_utils_MlDsaUtils_ex
  * Signature: ([B)[B
  *
  * AWS-LC's kem_priv_decode automatically expands seed-format keys
- * via KEM_KEY_set_raw_keypair_from_seed, and kem_priv_encode always writes the expanded
- * format. So we just parse and re-encode.
+ * via KEM_KEY_set_raw_keypair_from_seed. We then use encodeExpandedMLKEMPrivateKey
+ * to manually build expanded-format PKCS8.
  */
 JNIEXPORT jbyteArray JNICALL Java_com_amazon_corretto_crypto_utils_MlKemUtils_expandPrivateKeyInternal(
     JNIEnv* pEnv, jclass, jbyteArray keyBytes)
@@ -170,11 +170,9 @@ JNIEXPORT jbyteArray JNICALL Java_com_amazon_corretto_crypto_utils_MlKemUtils_ex
         EVP_PKEY_auto key = EVP_PKEY_auto::from(EVP_PKCS82PKEY(pkcs8));
         CHECK_OPENSSL(key.isInitialized());
 
-        // Re-encode — AWS-LC always writes the expanded format
+        // Encode as expanded-format PKCS8
         OPENSSL_buffer_auto new_der;
-        PKCS8_PRIV_KEY_INFO_auto new_pkcs8 = PKCS8_PRIV_KEY_INFO_auto::from(EVP_PKEY2PKCS8(key));
-        CHECK_OPENSSL(new_pkcs8.isInitialized());
-        int new_der_len = i2d_PKCS8_PRIV_KEY_INFO(new_pkcs8, &new_der);
+        int new_der_len = encodeExpandedMLKEMPrivateKey(key, &new_der);
         CHECK_OPENSSL(new_der_len > 0);
 
         if (!(result = env->NewByteArray(new_der_len))) {

--- a/src/com/amazon/corretto/crypto/utils/MlKemUtils.java
+++ b/src/com/amazon/corretto/crypto/utils/MlKemUtils.java
@@ -1,0 +1,33 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package com.amazon.corretto.crypto.utils;
+
+import java.security.PrivateKey;
+
+/** Public utility methods for ML-KEM operations. */
+public final class MlKemUtils {
+  private MlKemUtils() {} // private constructor to prevent instantiation
+
+  private static native byte[] expandPrivateKeyInternal(byte[] key);
+
+  /**
+   * Returns an expanded ML-KEM private key, whether the key passed in is based on a seed or
+   * expanded. It returns the PKCS8-encoded expanded key.
+   *
+   * <p>The seed format is a 64-byte value (d || z) as defined in FIPS 203. The expanded
+   * decapsulation key is derived using ML-KEM.KeyGen_internal(d, z) (Algorithm 16).
+   *
+   * <p>See <a href="https://csrc.nist.gov/pubs/fips/203/final">FIPS 203</a>
+   *
+   * <p>See <a href="https://datatracker.ietf.org/doc/rfc9935/">RFC 9935</a>
+   *
+   * @param key an ML-KEM private key
+   * @return a byte[] containing the PKCS8-encoded expanded private key
+   */
+  public static byte[] expandPrivateKey(PrivateKey key) {
+    if (key == null || !key.getAlgorithm().startsWith("ML-KEM")) {
+      throw new IllegalArgumentException();
+    }
+    return expandPrivateKeyInternal(key.getEncoded());
+  }
+}

--- a/tst/com/amazon/corretto/crypto/provider/test/MlKemUtilsTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/MlKemUtilsTest.java
@@ -1,0 +1,104 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package com.amazon.corretto.crypto.provider.test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.amazon.corretto.crypto.provider.AmazonCorrettoCryptoProvider;
+import com.amazon.corretto.crypto.utils.MlKemUtils;
+import java.security.KeyFactory;
+import java.security.KeyPairGenerator;
+import java.security.PrivateKey;
+import java.security.Provider;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.util.Base64;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIf;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * Tests for MlKemUtils using Known Answer Tests from RFC 9935 Appendix C.1.
+ *
+ * @see <a href="https://www.rfc-editor.org/rfc/rfc9935#appendix-C.1">RFC 9935 Appendix C.1</a>
+ */
+@Execution(ExecutionMode.CONCURRENT)
+@ExtendWith(TestResultLogger.class)
+@ResourceLock(value = TestUtil.RESOURCE_GLOBAL, mode = ResourceAccessMode.READ)
+public class MlKemUtilsTest {
+  private static final Provider NATIVE_PROVIDER = AmazonCorrettoCryptoProvider.INSTANCE;
+
+  // RFC 9935 Appendix C.1 seed-format PKCS8 encodings.
+  // The seed (d||z) is 000102...3e3f for all parameter sets; only the algorithm OID differs.
+  private static String seedPem(String algorithm) {
+    switch (algorithm) {
+      case "ML-KEM-512":
+        return "MFQCAQAwCwYJYIZIAWUDBAQBBEKAQAABAgMEBQYHCAkKCwwNDg8QERITFBUWFxgZ"
+            + "GhscHR4fICEiIyQlJicoKSorLC0uLzAxMjM0NTY3ODk6Ozw9Pj8=";
+      case "ML-KEM-768":
+        return "MFQCAQAwCwYJYIZIAWUDBAQCBEKAQAABAgMEBQYHCAkKCwwNDg8QERITFBUWFxgZ"
+            + "GhscHR4fICEiIyQlJicoKSorLC0uLzAxMjM0NTY3ODk6Ozw9Pj8=";
+      case "ML-KEM-1024":
+        return "MFQCAQAwCwYJYIZIAWUDBAQDBEKAQAABAgMEBQYHCAkKCwwNDg8QERITFBUWFxgZ"
+            + "GhscHR4fICEiIyQlJicoKSorLC0uLzAxMjM0NTY3ODk6Ozw9Pj8=";
+      default:
+        throw new IllegalArgumentException(algorithm);
+    }
+  }
+
+  // Expected expanded PKCS8 sizes: raw key + 28 bytes PKCS8 overhead
+  private static int expandedSize(String algorithm) {
+    switch (algorithm) {
+      case "ML-KEM-512":
+        return 1660;
+      case "ML-KEM-768":
+        return 2428;
+      case "ML-KEM-1024":
+        return 3196;
+      default:
+        throw new IllegalArgumentException(algorithm);
+    }
+  }
+
+  private static boolean mlKemDisabled() {
+    try {
+      KeyPairGenerator.getInstance("ML-KEM-512", NATIVE_PROVIDER);
+      return false;
+    } catch (Exception e) {
+      return true;
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"ML-KEM-512", "ML-KEM-768", "ML-KEM-1024"})
+  @DisabledIf("mlKemDisabled")
+  public void testExpandSeedKey(String algorithm) throws Exception {
+    KeyFactory kf = KeyFactory.getInstance("ML-KEM", NATIVE_PROVIDER);
+    byte[] seedDer = Base64.getDecoder().decode(seedPem(algorithm));
+
+    PrivateKey seedKey = kf.generatePrivate(new PKCS8EncodedKeySpec(seedDer));
+    byte[] expanded = MlKemUtils.expandPrivateKey(seedKey);
+
+    assertEquals(expandedSize(algorithm), expanded.length);
+
+    // Expansion must be deterministic
+    PrivateKey seedKey2 = kf.generatePrivate(new PKCS8EncodedKeySpec(seedDer));
+    assertArrayEquals(expanded, MlKemUtils.expandPrivateKey(seedKey2));
+
+    // Re-expanding an already-expanded key must be idempotent
+    PrivateKey expandedKey = kf.generatePrivate(new PKCS8EncodedKeySpec(expanded));
+    assertArrayEquals(expanded, MlKemUtils.expandPrivateKey(expandedKey));
+  }
+
+  @Test
+  @DisabledIf("mlKemDisabled")
+  public void testExpandPrivateKeyInvalidArgs() {
+    TestUtil.assertThrows(IllegalArgumentException.class, () -> MlKemUtils.expandPrivateKey(null));
+  }
+}

--- a/tst/com/amazon/corretto/crypto/provider/test/jdk17plus/MlKemTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/jdk17plus/MlKemTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import com.amazon.corretto.crypto.provider.AmazonCorrettoCryptoProvider;
+import com.amazon.corretto.crypto.utils.MlKemUtils;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.KeyFactory;
 import java.security.KeyPair;
@@ -338,5 +339,35 @@ public class MlKemTest {
         encapsulated.key().getEncoded(),
         bcSecret.getEncoded(),
         "ACCP and BouncyCastle should produce identical shared secrets for " + paramSet);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"ML-KEM-512", "ML-KEM-768", "ML-KEM-1024"})
+  public void testDecapsulationEquivalenceSeedAndExpanded(String paramSet) throws Exception {
+    KeyPairGenerator keyGen = KeyPairGenerator.getInstance(paramSet, NATIVE_PROVIDER);
+    KeyPair keyPair = keyGen.generateKeyPair();
+
+    // Encapsulate against the public key
+    KEM kem = KEM.getInstance(paramSet, NATIVE_PROVIDER);
+    NamedParameterSpec paramSpec = new NamedParameterSpec(paramSet);
+    KEM.Encapsulated encapsulated =
+        kem.newEncapsulator(keyPair.getPublic(), paramSpec, null).encapsulate();
+    byte[] ciphertext = encapsulated.encapsulation();
+
+    // Decapsulate with the original (seed-format) private key
+    SecretKey secretFromSeed =
+        kem.newDecapsulator(keyPair.getPrivate(), paramSpec).decapsulate(ciphertext);
+
+    // Expand the private key and decapsulate with the expanded form
+    byte[] expandedDer = MlKemUtils.expandPrivateKey(keyPair.getPrivate());
+    KeyFactory kf = KeyFactory.getInstance("ML-KEM", NATIVE_PROVIDER);
+    PrivateKey expandedKey = kf.generatePrivate(new PKCS8EncodedKeySpec(expandedDer));
+    SecretKey secretFromExpanded =
+        kem.newDecapsulator(expandedKey, paramSpec).decapsulate(ciphertext);
+
+    assertArrayEquals(
+        secretFromSeed.getEncoded(),
+        secretFromExpanded.getEncoded(),
+        "Seed and expanded keys must produce identical shared secrets for " + paramSet);
   }
 }


### PR DESCRIPTION
*Issue #, if available:*
P407404249

*Description of changes:*
Add MlKemUtils.expandPrivateKey() utility that converts an ML-KEM
private key from the 64-byte seed format to the expanded decapsulation
key format, as defined in FIPS 203 and RFC 9935.

The implementation leverages AWS-LC's existing seed expansion support
in kem_priv_decode (KEM_KEY_set_raw_keypair_from_seed) which
automatically expands seed-format keys during PKCS8 parsing, and
kem_priv_encode which always writes the expanded format.

This mirrors the existing MlDsaUtils.expandPrivateKey() for ML-DSA.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
