### PR TITLE
Bump AWS-LC to v1.72.0 and add ML-KEM seed encoding test

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ ACCP did not track a FIPS branch/release version of AWS-LC until ACCP v2.3.0. Be
 | 2.4.0               | 1.30.1         | 2.0.13              |
 | 2.4.1               | 1.30.1         | 2.0.13              |
 | 2.5.0               | 1.47.0         | 3.0.0               |
-| 2.6.0               | 1.66.2         | 3.1.0               |
+| 2.6.0               | 1.72.0         | 3.1.0               |
 
 Notable differences between ACCP and ACCP-FIPS:
 * ACCP uses [the latest release of AWS-LC](https://github.com/aws/aws-lc/releases), whereas, ACCP-FIPS uses [a timestamped FIPS branch of AWS-LC](https://github.com/aws/aws-lc/branches).

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ plugins {
 
 group = 'software.amazon.cryptools'
 version = '2.6.0'
-ext.awsLcMainTag = 'v1.66.2'
+ext.awsLcMainTag = 'v1.72.0'
 ext.awsLcFipsTag = 'AWS-LC-FIPS-3.1.0'
 ext.isExperimentalFips = Boolean.getBoolean('EXPERIMENTAL_FIPS')
 ext.isFips = ext.isExperimentalFips || Boolean.getBoolean('FIPS')

--- a/tst/com/amazon/corretto/crypto/provider/test/jdk17plus/MlKemTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/jdk17plus/MlKemTest.java
@@ -363,7 +363,7 @@ public class MlKemTest {
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {"ML-KEM-512", "ML-KEM-768", "ML-KEM-1024"})
+  @MethodSource("mlKemParamSets")
   public void testDecapsulationEquivalenceSeedAndExpanded(String paramSet) throws Exception {
     KeyPairGenerator keyGen = KeyPairGenerator.getInstance(paramSet, NATIVE_PROVIDER);
     KeyPair keyPair = keyGen.generateKeyPair();

--- a/tst/com/amazon/corretto/crypto/provider/test/jdk17plus/MlKemTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/jdk17plus/MlKemTest.java
@@ -280,7 +280,7 @@ public class MlKemTest {
     assertEquals(
         expectedSeedEncodingLength,
         encoded.length,
-        paramSet + " private key should be seed-encoded (64-byte seed + PKCS#8 overhead)");
+        paramSet + " private key should be 86 bytes (64-byte seed + PKCS#8 overhead)");
   }
 
   @ParameterizedTest

--- a/tst/com/amazon/corretto/crypto/provider/test/jdk17plus/MlKemTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/jdk17plus/MlKemTest.java
@@ -34,7 +34,6 @@ import org.junit.jupiter.api.parallel.ResourceAccessMode;
 import org.junit.jupiter.api.parallel.ResourceLock;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.jupiter.params.provider.ValueSource;
 
 @Execution(ExecutionMode.CONCURRENT)
 @ExtendWith(TestResultLogger.class)
@@ -43,6 +42,11 @@ public class MlKemTest {
   private static final AmazonCorrettoCryptoProvider NATIVE_PROVIDER =
       AmazonCorrettoCryptoProvider.INSTANCE;
   private static final int SHARED_SECRET_SIZE = 32;
+  private static final String[] ML_KEM_PARAM_SETS = {"ML-KEM-512", "ML-KEM-768", "ML-KEM-1024"};
+
+  private static String[] mlKemParamSets() {
+    return ML_KEM_PARAM_SETS;
+  }
 
   private static int getCiphertextSizeForParamSet(String paramSet) throws Throwable {
     Class<?> mlKemParamClass = Class.forName("com.amazon.corretto.crypto.provider.MlKemParameter");
@@ -79,7 +83,7 @@ public class MlKemTest {
 
   private static List<TestParams> getParams() throws Exception {
     List<TestParams> params = new ArrayList<TestParams>();
-    for (String paramSet : new String[] {"ML-KEM-512", "ML-KEM-768", "ML-KEM-1024"}) {
+    for (String paramSet : ML_KEM_PARAM_SETS) {
       KeyPair keyPair = KeyPairGenerator.getInstance(paramSet, NATIVE_PROVIDER).generateKeyPair();
       PublicKey nativePub = keyPair.getPublic();
       PrivateKey nativePriv = keyPair.getPrivate();
@@ -125,7 +129,7 @@ public class MlKemTest {
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {"ML-KEM-512", "ML-KEM-768", "ML-KEM-1024"})
+  @MethodSource("mlKemParamSets")
   public void testKeyGeneration(String paramSet) throws Exception {
     KeyPairGenerator keyGen = KeyPairGenerator.getInstance(paramSet, NATIVE_PROVIDER);
     KeyPair keyPair = keyGen.generateKeyPair();
@@ -171,7 +175,7 @@ public class MlKemTest {
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {"ML-KEM-512", "ML-KEM-768", "ML-KEM-1024"})
+  @MethodSource("mlKemParamSets")
   public void testCiphertextSizes(String paramSet) throws Throwable {
     int expectedSize = getCiphertextSizeForParamSet(paramSet);
 
@@ -189,7 +193,7 @@ public class MlKemTest {
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {"ML-KEM-512", "ML-KEM-768", "ML-KEM-1024"})
+  @MethodSource("mlKemParamSets")
   public void testEncapsulatorProperties(String paramSet) throws Throwable {
     int expectedCiphertextSize = getCiphertextSizeForParamSet(paramSet);
 
@@ -207,7 +211,7 @@ public class MlKemTest {
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {"ML-KEM-512", "ML-KEM-768", "ML-KEM-1024"})
+  @MethodSource("mlKemParamSets")
   public void testGenericAlgorithmHandling(String paramSet) throws Exception {
     KeyPair pair = KeyPairGenerator.getInstance(paramSet, NATIVE_PROVIDER).generateKeyPair();
     KEM kem = KEM.getInstance(paramSet, NATIVE_PROVIDER);
@@ -263,7 +267,24 @@ public class MlKemTest {
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {"ML-KEM-512", "ML-KEM-768", "ML-KEM-1024"})
+  @MethodSource("mlKemParamSets")
+  public void testPrivateKeyEncodingIsSeedFormat(String paramSet) throws Exception {
+    // Seed format is 64 bytes (d || z) for all ML-KEM parameter sets.
+    // PKCS#8 DER wrapping adds 22 bytes of ASN.1 overhead, totaling 86 bytes.
+    // Expanded format would be 1632/2400/3168 bytes plus overhead.
+    final int expectedSeedEncodingLength = 86;
+
+    KeyPair kp = KeyPairGenerator.getInstance(paramSet, NATIVE_PROVIDER).generateKeyPair();
+    byte[] encoded = kp.getPrivate().getEncoded();
+
+    assertEquals(
+        expectedSeedEncodingLength,
+        encoded.length,
+        paramSet + " private key should be seed-encoded (64-byte seed + PKCS#8 overhead)");
+  }
+
+  @ParameterizedTest
+  @MethodSource("mlKemParamSets")
   public void testBouncyCastleInteroperability(String paramSet) throws Exception {
 
     KeyPair accpKeyPair = KeyPairGenerator.getInstance(paramSet, NATIVE_PROVIDER).generateKeyPair();


### PR DESCRIPTION
*Issue #, if available:*
P409194150

*Description of changes:*
Update AWS-LC from v1.66.2 to v1.72.0 in both the git submodule and
build.gradle awsLcMainTag. Update the version table in README.md.

Add testPrivateKeyEncodingIsSeedFormat to MlKemTest to verify that
ML-KEM private keys are encoded in the 64-byte seed format (d || z)
rather than the expanded format.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
