### PR TITLE
Add AES/GCM-SIV/NoPadding cipher support (RFC 8452)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -309,6 +309,7 @@ include_directories(${OPENSSL_INCLUDE_DIR} ${JNI_INCLUDE_DIRS} ${JNI_HEADER_DIR}
 
 set(C_SRC
     csrc/aes_gcm.cpp
+    csrc/aes_gcm_siv.cpp
     csrc/aes_xts.cpp
     csrc/aes_cbc.cpp
     csrc/aes_cfb.cpp

--- a/DIFFERENCES.md
+++ b/DIFFERENCES.md
@@ -86,12 +86,14 @@ To prevent callers from corrupting their signatures, we forbid them from updatin
 # Extensions
 Applications are unlikely to directly encounter any of these changes but may choose to take advantage of them.
 
-## AES-GCM-SIV rejects IvParameterSpec and enforces fixed nonce and tag length
-Unlike `AES/GCM/NoPadding`, ACCP's `AES/GCM-SIV/NoPadding` implementation does **not** accept
-[IvParameterSpec](https://docs.oracle.com/javase/8/docs/api/javax/crypto/spec/IvParameterSpec.html).
-Callers must use [GCMParameterSpec](https://docs.oracle.com/javase/8/docs/api/javax/crypto/spec/GCMParameterSpec.html)
-with exactly a 12-byte nonce and a 128-bit tag length, as required by [RFC 8452](https://www.rfc-editor.org/rfc/rfc8452).
-Any other combination will throw `InvalidAlgorithmParameterException`.
+## AES-GCM-SIV enforces a fixed 12-byte nonce and 128-bit tag length
+`AES/GCM-SIV/NoPadding` accepts either
+[GCMParameterSpec](https://docs.oracle.com/javase/8/docs/api/javax/crypto/spec/GCMParameterSpec.html)
+or [IvParameterSpec](https://docs.oracle.com/javase/8/docs/api/javax/crypto/spec/IvParameterSpec.html)
+to supply the nonce. In both cases the nonce must be exactly 12 bytes, as required by
+[RFC 8452](https://www.rfc-editor.org/rfc/rfc8452). When using `GCMParameterSpec`, the tag
+length must be 128 bits — any other value throws `InvalidAlgorithmParameterException`. When using
+`IvParameterSpec`, the 128-bit tag length is implicit (it is the only tag length supported).
 Only 128-bit and 256-bit AES keys are supported; 192-bit keys will throw `InvalidKeyException`.
 
 ## AES-GCM-SIV tolerates nonce reuse

--- a/DIFFERENCES.md
+++ b/DIFFERENCES.md
@@ -88,6 +88,22 @@ To prevent callers from corrupting their signatures, we forbid them from updatin
 # Extensions
 Applications are unlikely to directly encounter any of these changes but may choose to take advantage of them.
 
+## AES-GCM-SIV rejects IvParameterSpec and enforces fixed nonce and tag length
+Unlike `AES/GCM/NoPadding`, ACCP's `AES/GCM-SIV/NoPadding` implementation does **not** accept
+[IvParameterSpec](https://docs.oracle.com/javase/8/docs/api/javax/crypto/spec/IvParameterSpec.html).
+Callers must use [GCMParameterSpec](https://docs.oracle.com/javase/8/docs/api/javax/crypto/spec/GCMParameterSpec.html)
+with exactly a 12-byte nonce and a 128-bit tag length, as required by [RFC 8452](https://www.rfc-editor.org/rfc/rfc8452).
+Any other combination will throw `InvalidAlgorithmParameterException`.
+Only 128-bit and 256-bit AES keys are supported; 192-bit keys will throw `InvalidKeyException`.
+
+## AES-GCM-SIV tolerates nonce reuse
+`AES/GCM-SIV/NoPadding` does not throw when the same key and nonce are reused across multiple
+`Cipher.init()` calls. This is intentional — nonce-misuse resistance is the primary design goal of
+AES-GCM-SIV ([RFC 8452](https://www.rfc-editor.org/rfc/rfc8452)). While reuse degrades
+confidentiality guarantees, it does not compromise authenticity.
+This differs from `AES/GCM/NoPadding`, which throws `InvalidAlgorithmParameterException` on
+key+nonce reuse.
+
 ## AES-GCM supports IvParameterSpec
 ACCP allows use of [IvParameterSpec](https://docs.oracle.com/javase/8/docs/api/javax/crypto/spec/IvParameterSpec.html) when calling [Cipher.init()](https://docs.oracle.com/javase/8/docs/api/javax/crypto/Cipher.html#init-int-java.security.Key-java.security.spec.AlgorithmParameterSpec-).
 This is equivalent to using a [GCMParameterSpec](https://docs.oracle.com/javase/8/docs/api/javax/crypto/spec/GCMParameterSpec.html) with the same IV value and a tag length of 128 bits.

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ Mac algorithms:
 Cipher algorithms:
 * AES/GCM/NoPadding
 * AES_\<n\>/GCM/NoPadding, where n can be 128, or 256
+* AES/GCM-SIV/NoPadding
+* AES_\<n\>/GCM-SIV/NoPadding, where n can be 128 or 256
 * AES/KW/NoPadding
 * AES/KWP/NoPadding
 * AES/XTS/NoPadding

--- a/benchmarks/lib/src/jmh/java/com/amazon/corretto/crypto/provider/benchmarks/AesGcmSivOneShot.java
+++ b/benchmarks/lib/src/jmh/java/com/amazon/corretto/crypto/provider/benchmarks/AesGcmSivOneShot.java
@@ -15,9 +15,8 @@ import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 
 /**
- * Benchmarks for AES-GCM-SIV (RFC 8452) one-shot encrypt and decrypt. AES-GCM-SIV is only
- * supported by ACCP (backed by AWS-LC); SunJCE and BouncyCastle are not included as providers
- * since they do not implement this algorithm.
+ * Benchmarks for AES-GCM-SIV (RFC 8452) one-shot encrypt and decrypt. SunJCE does not implement
+ * this algorithm, so only ACCP (backed by AWS-LC) is benchmarked here.
  */
 @State(Scope.Benchmark)
 public class AesGcmSivOneShot {

--- a/benchmarks/lib/src/jmh/java/com/amazon/corretto/crypto/provider/benchmarks/AesGcmSivOneShot.java
+++ b/benchmarks/lib/src/jmh/java/com/amazon/corretto/crypto/provider/benchmarks/AesGcmSivOneShot.java
@@ -3,11 +3,8 @@
 package com.amazon.corretto.crypto.provider.benchmarks;
 
 import com.amazon.corretto.crypto.provider.AmazonCorrettoCryptoProvider;
-import java.security.Key;
 import java.security.spec.AlgorithmParameterSpec;
-import javax.crypto.Cipher;
 import javax.crypto.spec.GCMParameterSpec;
-import javax.crypto.spec.SecretKeySpec;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
@@ -16,52 +13,46 @@ import org.openjdk.jmh.annotations.State;
 
 /**
  * Benchmarks for AES-GCM-SIV (RFC 8452) one-shot encrypt and decrypt. SunJCE does not implement
- * this algorithm, so only ACCP (backed by AWS-LC) is benchmarked here.
+ * this algorithm, so only ACCP (backed by AWS-LC) and BouncyCastle are benchmarked here.
  */
 @State(Scope.Benchmark)
-public class AesGcmSivOneShot {
-  private static final int PLAINTEXT_SIZE = 1024 * 1024;
-  private static final String ALGORITHM = "AES/GCM-SIV/NoPadding";
-
+public class AesGcmSivOneShot extends AesBase {
   @Param({"128", "256"})
   public int keyBits;
 
-  private Key key;
-  private GCMParameterSpec params1;
-  private GCMParameterSpec params2;
-  private Cipher encryptor;
-  private Cipher decryptor;
-  private byte[] plaintext;
-  private byte[] ciphertext;
+  @Param({AmazonCorrettoCryptoProvider.PROVIDER_NAME, "BC"})
+  public String provider;
+
+  @Param({"NoPadding"})
+  public String padding;
 
   @Setup
   public void setup() throws Exception {
-    BenchmarkUtils.setupProvider(AmazonCorrettoCryptoProvider.PROVIDER_NAME);
-    key = new SecretKeySpec(BenchmarkUtils.getRandBytes(keyBits / 8), "AES");
-    params1 = new GCMParameterSpec(128, BenchmarkUtils.getRandBytes(12));
-    params2 = new GCMParameterSpec(128, BenchmarkUtils.getRandBytes(12));
-    encryptor = Cipher.getInstance(ALGORITHM, AmazonCorrettoCryptoProvider.PROVIDER_NAME);
-    decryptor = Cipher.getInstance(ALGORITHM, AmazonCorrettoCryptoProvider.PROVIDER_NAME);
-    encryptor.init(Cipher.ENCRYPT_MODE, key, params1);
-    plaintext = BenchmarkUtils.getRandBytes(PLAINTEXT_SIZE);
-    ciphertext = encryptor.doFinal(plaintext);
-    encryptor.init(Cipher.ENCRYPT_MODE, key, params2);
-    decryptor.init(Cipher.DECRYPT_MODE, key, params2);
+    super.setup(keyBits, provider, padding);
+  }
+
+  @Override
+  protected String getMode() {
+    return "GCM-SIV";
+  }
+
+  @Override
+  protected AlgorithmParameterSpec createParameterSpec(byte[] iv) {
+    return new GCMParameterSpec(128, iv);
+  }
+
+  @Override
+  protected int getIvSize() {
+    return 12;
   }
 
   @Benchmark
   public byte[] encrypt() throws Exception {
-    encryptor.init(Cipher.ENCRYPT_MODE, key, params1);
-    byte[] out = encryptor.doFinal(plaintext);
-    encryptor.init(Cipher.ENCRYPT_MODE, key, params2);
-    return out;
+    return super.oneShot1MiBEncrypt();
   }
 
   @Benchmark
   public byte[] decrypt() throws Exception {
-    decryptor.init(Cipher.DECRYPT_MODE, key, params1);
-    byte[] out = decryptor.doFinal(ciphertext);
-    decryptor.init(Cipher.DECRYPT_MODE, key, params2);
-    return out;
+    return super.oneShot1MiBDecrypt();
   }
 }

--- a/benchmarks/lib/src/jmh/java/com/amazon/corretto/crypto/provider/benchmarks/AesGcmSivOneShot.java
+++ b/benchmarks/lib/src/jmh/java/com/amazon/corretto/crypto/provider/benchmarks/AesGcmSivOneShot.java
@@ -1,0 +1,68 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package com.amazon.corretto.crypto.provider.benchmarks;
+
+import com.amazon.corretto.crypto.provider.AmazonCorrettoCryptoProvider;
+import java.security.Key;
+import java.security.spec.AlgorithmParameterSpec;
+import javax.crypto.Cipher;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+/**
+ * Benchmarks for AES-GCM-SIV (RFC 8452) one-shot encrypt and decrypt. AES-GCM-SIV is only
+ * supported by ACCP (backed by AWS-LC); SunJCE and BouncyCastle are not included as providers
+ * since they do not implement this algorithm.
+ */
+@State(Scope.Benchmark)
+public class AesGcmSivOneShot {
+  private static final int PLAINTEXT_SIZE = 1024 * 1024;
+  private static final String ALGORITHM = "AES/GCM-SIV/NoPadding";
+
+  @Param({"128", "256"})
+  public int keyBits;
+
+  private Key key;
+  private GCMParameterSpec params1;
+  private GCMParameterSpec params2;
+  private Cipher encryptor;
+  private Cipher decryptor;
+  private byte[] plaintext;
+  private byte[] ciphertext;
+
+  @Setup
+  public void setup() throws Exception {
+    BenchmarkUtils.setupProvider(AmazonCorrettoCryptoProvider.PROVIDER_NAME);
+    key = new SecretKeySpec(BenchmarkUtils.getRandBytes(keyBits / 8), "AES");
+    params1 = new GCMParameterSpec(128, BenchmarkUtils.getRandBytes(12));
+    params2 = new GCMParameterSpec(128, BenchmarkUtils.getRandBytes(12));
+    encryptor = Cipher.getInstance(ALGORITHM, AmazonCorrettoCryptoProvider.PROVIDER_NAME);
+    decryptor = Cipher.getInstance(ALGORITHM, AmazonCorrettoCryptoProvider.PROVIDER_NAME);
+    encryptor.init(Cipher.ENCRYPT_MODE, key, params1);
+    plaintext = BenchmarkUtils.getRandBytes(PLAINTEXT_SIZE);
+    ciphertext = encryptor.doFinal(plaintext);
+    encryptor.init(Cipher.ENCRYPT_MODE, key, params2);
+    decryptor.init(Cipher.DECRYPT_MODE, key, params2);
+  }
+
+  @Benchmark
+  public byte[] encrypt() throws Exception {
+    encryptor.init(Cipher.ENCRYPT_MODE, key, params1);
+    byte[] out = encryptor.doFinal(plaintext);
+    encryptor.init(Cipher.ENCRYPT_MODE, key, params2);
+    return out;
+  }
+
+  @Benchmark
+  public byte[] decrypt() throws Exception {
+    decryptor.init(Cipher.DECRYPT_MODE, key, params1);
+    byte[] out = decryptor.doFinal(ciphertext);
+    decryptor.init(Cipher.DECRYPT_MODE, key, params2);
+    return out;
+  }
+}

--- a/csrc/aes_gcm_siv.cpp
+++ b/csrc/aes_gcm_siv.cpp
@@ -1,0 +1,255 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+#include "buffer.h"
+#include "env.h"
+#include "generated-headers.h"
+#include "util.h"
+#include <openssl/aead.h>
+#include <openssl/err.h>
+
+#define KEY_LEN_AES128 16
+#define KEY_LEN_AES256 32
+#define GCM_SIV_NONCE_LENGTH 12
+#define GCM_SIV_TAG_LENGTH 16
+
+#define EX_BADTAG "javax/crypto/AEADBadTagException"
+
+using namespace AmazonCorrettoCryptoProvider;
+
+static EVP_AEAD_CTX* createAeadCtx(raii_env& env, java_buffer keyBuf)
+{
+    const EVP_AEAD* aead;
+    switch (keyBuf.len()) {
+    case KEY_LEN_AES128:
+        aead = EVP_aead_aes_128_gcm_siv();
+        break;
+    case KEY_LEN_AES256:
+        aead = EVP_aead_aes_256_gcm_siv();
+        break;
+    default:
+        throw java_ex(EX_RUNTIME_CRYPTO, "Unsupported key length for AES-GCM-SIV");
+    }
+
+    SecureBuffer<uint8_t, KEY_LEN_AES256> keybuf;
+    keyBuf.get_bytes(env, keybuf.buf, 0, keyBuf.len());
+
+    EVP_AEAD_CTX* ctx = EVP_AEAD_CTX_new(aead, keybuf.buf, keyBuf.len(), GCM_SIV_TAG_LENGTH);
+    if (unlikely(!ctx)) {
+        throw java_ex::from_openssl(EX_RUNTIME_CRYPTO, "Failed to create AES-GCM-SIV AEAD context");
+    }
+    return ctx;
+}
+
+// Creates a new EVP_AEAD_CTX for the given key and returns its pointer.
+// The caller is responsible for freeing it via releaseAeadCtx.
+JNIEXPORT jlong JNICALL Java_com_amazon_corretto_crypto_provider_AesGcmSivSpi_nCreateContext(
+    JNIEnv* pEnv, jclass, jbyteArray keyArray)
+{
+    try {
+        raii_env env(pEnv);
+        java_buffer keyBuf = java_buffer::from_array(env, keyArray);
+        EVP_AEAD_CTX* ctx = createAeadCtx(env, keyBuf);
+        return reinterpret_cast<jlong>(ctx);
+    } catch (java_ex& ex) {
+        ex.throw_to_java(pEnv);
+        return 0;
+    }
+}
+
+// Encrypts plaintext with AES-GCM-SIV. Ciphertext = plaintext || tag (16 bytes).
+// Returns: number of bytes written to outputArray, or -1 on error.
+JNIEXPORT jint JNICALL Java_com_amazon_corretto_crypto_provider_AesGcmSivSpi_nSeal(JNIEnv* pEnv,
+    jclass,
+    jlong ctxPtr,
+    jboolean sameKey,
+    jlongArray ctxOut,
+    jbyteArray keyArray,
+    jbyteArray nonceArray,
+    jbyteArray inputArray,
+    jint inputOffset,
+    jint inputLen,
+    jbyteArray outputArray,
+    jint outputOffset,
+    jbyteArray aadArray,
+    jint aadLen)
+{
+    try {
+        raii_env env(pEnv);
+
+        // Create all java_buffers before any borrows
+        java_buffer nonceBuf = java_buffer::from_array(env, nonceArray);
+        java_buffer inputBuf = java_buffer::from_array(env, inputArray, inputOffset, inputLen);
+        java_buffer outputBuf = java_buffer::from_array(env, outputArray, outputOffset);
+        java_buffer aadBuf;
+        if (aadLen > 0) {
+            aadBuf = java_buffer::from_array(env, aadArray, 0, aadLen);
+        }
+
+        EVP_AEAD_CTX* ctx;
+        bool ownsCtx = false;
+
+        if (ctxPtr != 0 && sameKey == JNI_TRUE) {
+            ctx = reinterpret_cast<EVP_AEAD_CTX*>(ctxPtr);
+        } else {
+            java_buffer keyBuf = java_buffer::from_array(env, keyArray);
+            ctx = createAeadCtx(env, keyBuf);
+            ownsCtx = true;
+        }
+
+        size_t out_len = 0;
+        bool success;
+
+        {
+            jni_borrow nonce(env, nonceBuf, "nonce");
+            jni_borrow input(env, inputBuf, "input");
+            jni_borrow output(env, outputBuf, "output");
+
+            if (aadLen > 0) {
+                jni_borrow aad(env, aadBuf, "aad");
+                success = EVP_AEAD_CTX_seal(ctx,
+                    output.data(),
+                    &out_len,
+                    outputBuf.len(),
+                    nonce.data(),
+                    GCM_SIV_NONCE_LENGTH,
+                    input.data(),
+                    inputLen,
+                    aad.data(),
+                    aadLen);
+            } else {
+                success = EVP_AEAD_CTX_seal(ctx,
+                    output.data(),
+                    &out_len,
+                    outputBuf.len(),
+                    nonce.data(),
+                    GCM_SIV_NONCE_LENGTH,
+                    input.data(),
+                    inputLen,
+                    nullptr,
+                    0);
+            }
+        }
+
+        if (unlikely(!success)) {
+            if (ownsCtx) {
+                EVP_AEAD_CTX_free(ctx);
+            }
+            throw java_ex::from_openssl(EX_RUNTIME_CRYPTO, "AES-GCM-SIV seal failed");
+        }
+
+        if (ownsCtx) {
+            if (ctxOut != nullptr) {
+                jlong tmpPtr = reinterpret_cast<jlong>(ctx);
+                pEnv->SetLongArrayRegion(ctxOut, 0, 1, &tmpPtr);
+            } else {
+                EVP_AEAD_CTX_free(ctx);
+            }
+        }
+
+        return (jint)out_len;
+    } catch (java_ex& ex) {
+        ex.throw_to_java(pEnv);
+        return -1;
+    }
+}
+
+// Decrypts and authenticates AES-GCM-SIV ciphertext (ciphertext || tag).
+// Returns: number of plaintext bytes written to outputArray, or -1 on error.
+// Throws AEADBadTagException on authentication failure.
+JNIEXPORT jint JNICALL Java_com_amazon_corretto_crypto_provider_AesGcmSivSpi_nOpen(JNIEnv* pEnv,
+    jclass,
+    jlong ctxPtr,
+    jboolean sameKey,
+    jlongArray ctxOut,
+    jbyteArray keyArray,
+    jbyteArray nonceArray,
+    jbyteArray inputArray,
+    jint inputOffset,
+    jint inputLen,
+    jbyteArray outputArray,
+    jint outputOffset,
+    jbyteArray aadArray,
+    jint aadLen)
+{
+    try {
+        raii_env env(pEnv);
+
+        // Create all java_buffers before any borrows
+        java_buffer nonceBuf = java_buffer::from_array(env, nonceArray);
+        java_buffer inputBuf = java_buffer::from_array(env, inputArray, inputOffset, inputLen);
+        java_buffer outputBuf = java_buffer::from_array(env, outputArray, outputOffset);
+        java_buffer aadBuf;
+        if (aadLen > 0) {
+            aadBuf = java_buffer::from_array(env, aadArray, 0, aadLen);
+        }
+
+        EVP_AEAD_CTX* ctx;
+        bool ownsCtx = false;
+
+        if (ctxPtr != 0 && sameKey == JNI_TRUE) {
+            ctx = reinterpret_cast<EVP_AEAD_CTX*>(ctxPtr);
+        } else {
+            java_buffer keyBuf = java_buffer::from_array(env, keyArray);
+            ctx = createAeadCtx(env, keyBuf);
+            ownsCtx = true;
+        }
+
+        size_t out_len = 0;
+        int rv;
+
+        {
+            jni_borrow nonce(env, nonceBuf, "nonce");
+            jni_borrow input(env, inputBuf, "input");
+            jni_borrow output(env, outputBuf, "output");
+
+            if (aadLen > 0) {
+                jni_borrow aad(env, aadBuf, "aad");
+                rv = EVP_AEAD_CTX_open(ctx,
+                    output.data(),
+                    &out_len,
+                    outputBuf.len(),
+                    nonce.data(),
+                    GCM_SIV_NONCE_LENGTH,
+                    input.data(),
+                    inputLen,
+                    aad.data(),
+                    aadLen);
+            } else {
+                rv = EVP_AEAD_CTX_open(ctx,
+                    output.data(),
+                    &out_len,
+                    outputBuf.len(),
+                    nonce.data(),
+                    GCM_SIV_NONCE_LENGTH,
+                    input.data(),
+                    inputLen,
+                    nullptr,
+                    0);
+            }
+        }
+
+        if (unlikely(!rv)) {
+            if (ownsCtx) {
+                EVP_AEAD_CTX_free(ctx);
+            }
+            // EVP_AEAD_CTX_open only fails due to authentication failure given validated inputs.
+            // Drain any OpenSSL error codes and always signal AEADBadTagException.
+            drainOpensslErrors();
+            throw java_ex(EX_BADTAG, "Tag mismatch!");
+        }
+
+        if (ownsCtx) {
+            if (ctxOut != nullptr) {
+                jlong tmpPtr = reinterpret_cast<jlong>(ctx);
+                pEnv->SetLongArrayRegion(ctxOut, 0, 1, &tmpPtr);
+            } else {
+                EVP_AEAD_CTX_free(ctx);
+            }
+        }
+
+        return (jint)out_len;
+    } catch (java_ex& ex) {
+        ex.throw_to_java(pEnv);
+        return -1;
+    }
+}

--- a/csrc/util.cpp
+++ b/csrc/util.cpp
@@ -1,6 +1,7 @@
 // Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 #include "generated-headers.h"
+#include <openssl/aead.h>
 #include <openssl/err.h>
 #include <openssl/evp.h>
 #include <cassert>
@@ -46,6 +47,12 @@ extern "C" JNIEXPORT void JNICALL Java_com_amazon_corretto_crypto_provider_Utils
     JNIEnv*, jclass, jlong ctxPtr)
 {
     EVP_CIPHER_CTX_free(reinterpret_cast<EVP_CIPHER_CTX*>(ctxPtr));
+}
+
+extern "C" JNIEXPORT void JNICALL Java_com_amazon_corretto_crypto_provider_Utils_releaseEvpAeadCtx(
+    JNIEnv*, jclass, jlong ctxPtr)
+{
+    EVP_AEAD_CTX_free(reinterpret_cast<EVP_AEAD_CTX*>(ctxPtr));
 }
 
 EVP_MD const* digest_code_to_EVP_MD(int digestCode)

--- a/src/com/amazon/corretto/crypto/provider/AesGcmSivSpi.java
+++ b/src/com/amazon/corretto/crypto/provider/AesGcmSivSpi.java
@@ -1,0 +1,643 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package com.amazon.corretto.crypto.provider;
+
+import static com.amazon.corretto.crypto.provider.Utils.EMPTY_ARRAY;
+import static com.amazon.corretto.crypto.provider.Utils.checkAesKey;
+import static com.amazon.corretto.crypto.provider.Utils.checkArrayLimits;
+
+import java.nio.ByteBuffer;
+import java.security.AlgorithmParameters;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidKeyException;
+import java.security.Key;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.security.spec.AlgorithmParameterSpec;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.InvalidParameterSpecException;
+import java.util.Arrays;
+import javax.crypto.AEADBadTagException;
+import javax.crypto.BadPaddingException;
+import javax.crypto.Cipher;
+import javax.crypto.CipherSpi;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.NoSuchPaddingException;
+import javax.crypto.ShortBufferException;
+import javax.crypto.spec.GCMParameterSpec;
+
+/**
+ * JCE CipherSpi implementation for AES-GCM-SIV (RFC 8452).
+ *
+ * <p>AES-GCM-SIV is a nonce-misuse-resistant authenticated encryption scheme. Unlike standard
+ * AES-GCM, reusing the same key and nonce combination will only reveal that two plaintexts were
+ * identical rather than completely compromising confidentiality.
+ *
+ * <p>Constraints:
+ *
+ * <ul>
+ *   <li>Nonce must be exactly 12 bytes.
+ *   <li>Tag is always 16 bytes (128 bits); other tag lengths are not supported.
+ *   <li>Key must be 128 or 256 bits.
+ * </ul>
+ */
+final class AesGcmSivSpi extends CipherSpi {
+  static {
+    Loader.load();
+  }
+
+  /** AES-GCM-SIV nonce length in bytes (fixed per RFC 8452). */
+  static final int NONCE_LENGTH_BYTES = 12;
+
+  /** AES-GCM-SIV tag length in bytes (fixed per RFC 8452). */
+  static final int TAG_LENGTH_BYTES = 16;
+
+  private static final int TAG_LENGTH_BITS = TAG_LENGTH_BYTES * 8;
+
+  private static final int NATIVE_MODE_ENCRYPT = 1;
+  private static final int NATIVE_MODE_DECRYPT = 0;
+
+  // -------------------------------------------------------------------
+  // Native methods
+  // -------------------------------------------------------------------
+
+  /**
+   * Creates a native EVP_AEAD_CTX for the given AES key and returns its pointer.
+   *
+   * @param key AES key bytes (16 or 32 bytes)
+   * @return native pointer (must be freed via Utils.releaseEvpAeadCtx)
+   */
+  static native long nCreateContext(byte[] key);
+
+  /**
+   * Encrypts plaintext with AES-GCM-SIV. The output contains ciphertext followed by the 16-byte
+   * authentication tag.
+   *
+   * @param ctxPtr cached EVP_AEAD_CTX pointer (0 if none)
+   * @param sameKey true iff the key matches the cached context's key
+   * @param ctxOut if non-null, receives the new context pointer for caching
+   * @param key AES key bytes
+   * @param nonce 12-byte nonce
+   * @param input plaintext
+   * @param inputOffset offset into input array
+   * @param inputLen number of plaintext bytes
+   * @param output output buffer (must hold inputLen + 16 bytes from outputOffset)
+   * @param outputOffset offset into output array
+   * @param aad additional authenticated data (may be null if aadLen == 0)
+   * @param aadLen number of AAD bytes
+   * @return number of bytes written to output
+   */
+  private static native int nSeal(
+      long ctxPtr,
+      boolean sameKey,
+      long[] ctxOut,
+      byte[] key,
+      byte[] nonce,
+      byte[] input,
+      int inputOffset,
+      int inputLen,
+      byte[] output,
+      int outputOffset,
+      byte[] aad,
+      int aadLen);
+
+  /**
+   * Decrypts and authenticates AES-GCM-SIV ciphertext.
+   *
+   * @param ctxPtr cached EVP_AEAD_CTX pointer (0 if none)
+   * @param sameKey true iff the key matches the cached context's key
+   * @param ctxOut if non-null, receives the new context pointer for caching
+   * @param key AES key bytes
+   * @param nonce 12-byte nonce
+   * @param input ciphertext || tag (inputLen must include the 16-byte tag)
+   * @param inputOffset offset into input array
+   * @param inputLen total input length (ciphertext + 16-byte tag)
+   * @param output output buffer for plaintext
+   * @param outputOffset offset into output array
+   * @param aad additional authenticated data (may be null if aadLen == 0)
+   * @param aadLen number of AAD bytes
+   * @return number of plaintext bytes written to output
+   * @throws AEADBadTagException if authentication fails
+   */
+  private static native int nOpen(
+      long ctxPtr,
+      boolean sameKey,
+      long[] ctxOut,
+      byte[] key,
+      byte[] nonce,
+      byte[] input,
+      int inputOffset,
+      int inputLen,
+      byte[] output,
+      int outputOffset,
+      byte[] aad,
+      int aadLen)
+      throws AEADBadTagException;
+
+  // -------------------------------------------------------------------
+  // State
+  // -------------------------------------------------------------------
+
+  private final AmazonCorrettoCryptoProvider provider;
+
+  /** Cached native EVP_AEAD_CTX (tied to lastKey). */
+  private NativeEvpAeadCtx context = null;
+
+  /**
+   * True iff the current key matches the key used to create the cached context. When true, we can
+   * pass the cached context pointer directly to nSeal/nOpen.
+   */
+  private boolean sameKey = false;
+
+  /** The last Key object seen; used to detect same-key reuse. */
+  private Key lastKey = null;
+
+  private byte[] nonce;
+  private byte[] key;
+  private int opMode = -1;
+
+  /** Buffered input for the current operation (used for both encrypt and decrypt). */
+  private final AccessibleByteArrayOutputStream inputBuf =
+      new AccessibleByteArrayOutputStream(0, Integer.MAX_VALUE);
+
+  /** Buffered AAD. */
+  private final AccessibleByteArrayOutputStream aadBuf =
+      new AccessibleByteArrayOutputStream(0, Integer.MAX_VALUE);
+
+  private boolean hasConsumedData = false;
+
+  AesGcmSivSpi(final AmazonCorrettoCryptoProvider provider) {
+    Loader.checkNativeLibraryAvailability();
+    this.provider = provider;
+  }
+
+  private boolean saveNativeContext() {
+    switch (provider.getNativeContextReleaseStrategy()) {
+      case HYBRID:
+        return sameKey;
+      case LAZY:
+        return true;
+      case EAGER:
+        return false;
+      default:
+        throw new AssertionError("This should not be reachable.");
+    }
+  }
+
+  // -------------------------------------------------------------------
+  // CipherSpi overrides
+  // -------------------------------------------------------------------
+
+  @Override
+  protected void engineSetMode(final String mode) throws NoSuchAlgorithmException {
+    if (!"GCM-SIV".equalsIgnoreCase(mode)) {
+      throw new NoSuchAlgorithmException("Mode must be GCM-SIV");
+    }
+  }
+
+  @Override
+  protected void engineSetPadding(final String padding) throws NoSuchPaddingException {
+    if (!"NoPadding".equalsIgnoreCase(padding)) {
+      throw new NoSuchPaddingException("AES-GCM-SIV requires NoPadding");
+    }
+  }
+
+  @Override
+  protected int engineGetBlockSize() {
+    return 16;
+  }
+
+  @Override
+  protected int engineGetKeySize(final Key key) throws InvalidKeyException {
+    return key.getEncoded().length * 8;
+  }
+
+  @Override
+  protected int engineGetOutputSize(final int inputLen) {
+    switch (opMode) {
+      case NATIVE_MODE_ENCRYPT:
+        return inputBuf.size() + inputLen + TAG_LENGTH_BYTES;
+      case NATIVE_MODE_DECRYPT:
+        return Math.max(0, inputBuf.size() + inputLen - TAG_LENGTH_BYTES);
+      default:
+        throw new IllegalStateException("Cipher not initialized");
+    }
+  }
+
+  @Override
+  protected byte[] engineGetIV() {
+    return (nonce == null) ? null : nonce.clone();
+  }
+
+  @Override
+  protected AlgorithmParameters engineGetParameters() {
+    try {
+      final AlgorithmParameters parameters = AlgorithmParameters.getInstance("GCM");
+      byte[] nonceForParams = nonce;
+      if (nonceForParams == null) {
+        nonceForParams = new byte[NONCE_LENGTH_BYTES];
+        new LibCryptoRng().nextBytes(nonceForParams);
+      }
+      parameters.init(new GCMParameterSpec(TAG_LENGTH_BITS, nonceForParams));
+      return parameters;
+    } catch (final InvalidParameterSpecException | NoSuchAlgorithmException e) {
+      throw new Error("Unexpected error", e);
+    }
+  }
+
+  @Override
+  protected void engineInit(final int jceOpMode, final Key key, final SecureRandom secureRandom)
+      throws InvalidKeyException {
+    if (jceOpMode != Cipher.ENCRYPT_MODE && jceOpMode != Cipher.WRAP_MODE) {
+      throw new InvalidKeyException("IV required for AES-GCM-SIV decrypt");
+    }
+
+    final byte[] generatedNonce = new byte[NONCE_LENGTH_BYTES];
+    secureRandom.nextBytes(generatedNonce);
+
+    try {
+      engineInit(
+          jceOpMode, key, new GCMParameterSpec(TAG_LENGTH_BITS, generatedNonce), secureRandom);
+    } catch (final InvalidAlgorithmParameterException e) {
+      throw new AssertionError(e);
+    }
+  }
+
+  @Override
+  protected void engineInit(
+      final int jceOpMode,
+      final Key key,
+      final AlgorithmParameterSpec spec,
+      final SecureRandom secureRandom)
+      throws InvalidKeyException, InvalidAlgorithmParameterException {
+    final int newOpMode = checkOperation(jceOpMode);
+    final byte[] newNonce = checkNonce(spec);
+    final byte[] newKey = checkKey(key);
+
+    this.sameKey = (this.key != null) && ConstantTime.equals(this.key, newKey);
+    this.opMode = newOpMode;
+    this.nonce = newNonce;
+    this.key = newKey;
+    this.lastKey = key;
+    stateReset();
+  }
+
+  @Override
+  protected void engineInit(
+      final int jceOpMode,
+      final Key key,
+      final AlgorithmParameters algorithmParameters,
+      final SecureRandom secureRandom)
+      throws InvalidKeyException, InvalidAlgorithmParameterException {
+    try {
+      engineInit(
+          jceOpMode,
+          key,
+          algorithmParameters.getParameterSpec(GCMParameterSpec.class),
+          secureRandom);
+    } catch (final InvalidParameterSpecException e) {
+      throw new InvalidAlgorithmParameterException(e);
+    }
+  }
+
+  // -------------------------------------------------------------------
+  // Update / AAD
+  // -------------------------------------------------------------------
+
+  @Override
+  protected byte[] engineUpdate(final byte[] input, final int offset, final int length) {
+    // Both encrypt and decrypt buffer; no output is produced until doFinal
+    try {
+      engineUpdate(input, offset, length, EMPTY_ARRAY, 0);
+    } catch (final ShortBufferException e) {
+      throw new AssertionError(e);
+    }
+    return EMPTY_ARRAY;
+  }
+
+  @Override
+  protected int engineUpdate(
+      final byte[] input,
+      final int inputOffset,
+      final int inputLen,
+      final byte[] output,
+      final int outputOffset)
+      throws ShortBufferException {
+    checkArrayLimits(input, inputOffset, inputLen);
+    hasConsumedData = true;
+    inputBuf.write(input, inputOffset, inputLen);
+    return 0;
+  }
+
+  @Override
+  protected void engineUpdateAAD(final byte[] bytes, final int offset, final int length) {
+    checkArrayLimits(bytes, offset, length);
+    if (hasConsumedData) {
+      throw new IllegalStateException("AAD cannot be updated after calling update()");
+    }
+    aadBuf.write(bytes, offset, length);
+  }
+
+  @Override
+  protected void engineUpdateAAD(final ByteBuffer byteBuffer) {
+    if (byteBuffer.hasArray()) {
+      engineUpdateAAD(
+          byteBuffer.array(),
+          byteBuffer.arrayOffset() + byteBuffer.position(),
+          byteBuffer.remaining());
+    } else {
+      final byte[] tmp = new byte[byteBuffer.remaining()];
+      byteBuffer.get(tmp);
+      engineUpdateAAD(tmp, 0, tmp.length);
+    }
+    byteBuffer.position(byteBuffer.limit());
+  }
+
+  // -------------------------------------------------------------------
+  // doFinal
+  // -------------------------------------------------------------------
+
+  @Override
+  protected byte[] engineDoFinal(final byte[] bytes, final int offset, final int length)
+      throws IllegalBlockSizeException, BadPaddingException {
+    final byte[] out = new byte[engineGetOutputSize(length)];
+    int actualLen;
+    try {
+      actualLen = engineDoFinal(bytes, offset, length, out, 0);
+    } catch (final ShortBufferException e) {
+      throw new AssertionError(e);
+    }
+    if (actualLen == out.length) {
+      return out;
+    }
+    return Arrays.copyOf(out, actualLen);
+  }
+
+  @Override
+  protected int engineDoFinal(
+      final byte[] input,
+      final int offset,
+      final int length,
+      final byte[] output,
+      final int outputOffset)
+      throws ShortBufferException, IllegalBlockSizeException, BadPaddingException {
+    if (opMode == NATIVE_MODE_ENCRYPT) {
+      return engineEncryptFinal(input, offset, length, output, outputOffset);
+    } else if (opMode == NATIVE_MODE_DECRYPT) {
+      return engineDecryptFinal(input, offset, length, output, outputOffset);
+    } else {
+      throw new IllegalStateException("Cipher not initialized");
+    }
+  }
+
+  private int engineEncryptFinal(
+      byte[] input,
+      final int inputOffset,
+      final int inputLen,
+      final byte[] output,
+      final int outputOffset)
+      throws ShortBufferException {
+    if (opMode != NATIVE_MODE_ENCRYPT) {
+      throw new IllegalStateException("Cipher not initialized for encryption");
+    }
+    if (input == null) {
+      input = EMPTY_ARRAY;
+    }
+    checkArrayLimits(input, inputOffset, inputLen);
+
+    final int totalInputLen = inputBuf.size() + inputLen;
+    final int requiredOut = totalInputLen + TAG_LENGTH_BYTES;
+    if (output.length - outputOffset < requiredOut) {
+      throw new ShortBufferException("Output buffer too small: need " + requiredOut + " bytes");
+    }
+
+    try {
+      // Consolidate buffered + final input
+      inputBuf.finalWrite(input, inputOffset, inputLen);
+      final byte[] allInput = inputBuf.getDataBuffer();
+      final int allInputLen = inputBuf.size();
+
+      final byte[] aad = aadBuf.isEmpty() ? EMPTY_ARRAY : aadBuf.getDataBuffer();
+      final int aadLen = aadBuf.size();
+
+      if (context != null) {
+        return context.use(
+            ptr ->
+                nSeal(
+                    ptr,
+                    sameKey,
+                    null,
+                    key,
+                    nonce,
+                    allInput,
+                    0,
+                    allInputLen,
+                    output,
+                    outputOffset,
+                    aad,
+                    aadLen));
+      }
+
+      if (saveNativeContext()) {
+        final long[] ptrOut = new long[1];
+        final int outLen =
+            nSeal(
+                0,
+                false,
+                ptrOut,
+                key,
+                nonce,
+                allInput,
+                0,
+                allInputLen,
+                output,
+                outputOffset,
+                aad,
+                aadLen);
+        context = new NativeEvpAeadCtx(ptrOut[0]);
+        return outLen;
+      }
+
+      return nSeal(
+          0, false, null, key, nonce, allInput, 0, allInputLen, output, outputOffset, aad, aadLen);
+    } finally {
+      stateReset();
+    }
+  }
+
+  private int engineDecryptFinal(
+      byte[] input,
+      final int inputOffset,
+      final int inputLen,
+      final byte[] output,
+      final int outputOffset)
+      throws AEADBadTagException, ShortBufferException {
+    if (opMode != NATIVE_MODE_DECRYPT) {
+      throw new IllegalStateException("Cipher not initialized for decryption");
+    }
+    if (input == null) {
+      input = EMPTY_ARRAY;
+    }
+    checkArrayLimits(input, inputOffset, inputLen);
+
+    try {
+      inputBuf.finalWrite(input, inputOffset, inputLen);
+      final byte[] allInput = inputBuf.getDataBuffer();
+      final int allInputLen = inputBuf.size();
+
+      if (allInputLen < TAG_LENGTH_BYTES) {
+        throw new AEADBadTagException("Input too short - need tag");
+      }
+
+      final int requiredOut = allInputLen - TAG_LENGTH_BYTES;
+      if (output.length - outputOffset < requiredOut) {
+        throw new ShortBufferException("Output buffer too small: need " + requiredOut + " bytes");
+      }
+
+      final byte[] aad = aadBuf.isEmpty() ? EMPTY_ARRAY : aadBuf.getDataBuffer();
+      final int aadLen = aadBuf.size();
+
+      if (context != null) {
+        return context.use(
+            ptr ->
+                nOpen(
+                    ptr,
+                    sameKey,
+                    null,
+                    key,
+                    nonce,
+                    allInput,
+                    0,
+                    allInputLen,
+                    output,
+                    outputOffset,
+                    aad,
+                    aadLen));
+      }
+
+      if (saveNativeContext()) {
+        final long[] ptrOut = new long[1];
+        final int outLen =
+            nOpen(
+                0,
+                false,
+                ptrOut,
+                key,
+                nonce,
+                allInput,
+                0,
+                allInputLen,
+                output,
+                outputOffset,
+                aad,
+                aadLen);
+        context = new NativeEvpAeadCtx(ptrOut[0]);
+        return outLen;
+      }
+
+      return nOpen(
+          0, false, null, key, nonce, allInput, 0, allInputLen, output, outputOffset, aad, aadLen);
+    } catch (final AEADBadTagException e) {
+      final int fillEnd =
+          outputOffset + Math.min(output.length - outputOffset, engineGetOutputSize(inputLen));
+      Arrays.fill(output, outputOffset, fillEnd, (byte) 0);
+      throw e;
+    } finally {
+      stateReset();
+    }
+  }
+
+  // -------------------------------------------------------------------
+  // Wrap / Unwrap
+  // -------------------------------------------------------------------
+
+  @Override
+  protected byte[] engineWrap(final Key key) throws IllegalBlockSizeException, InvalidKeyException {
+    if (opMode != NATIVE_MODE_ENCRYPT) {
+      throw new IllegalStateException("Cipher must be in WRAP_MODE");
+    }
+    try {
+      final byte[] encoded = Utils.encodeForWrapping(provider, key);
+      return engineDoFinal(encoded, 0, encoded.length);
+    } catch (final BadPaddingException ex) {
+      throw new InvalidKeyException("Wrapping failed", ex);
+    }
+  }
+
+  @Override
+  protected Key engineUnwrap(
+      final byte[] wrappedKey, final String wrappedKeyAlgorithm, final int wrappedKeyType)
+      throws InvalidKeyException, NoSuchAlgorithmException {
+    if (opMode != NATIVE_MODE_DECRYPT) {
+      throw new IllegalStateException("Cipher must be in UNWRAP_MODE");
+    }
+    try {
+      final byte[] unwrappedKey = engineDoFinal(wrappedKey, 0, wrappedKey.length);
+      return Utils.buildUnwrappedKey(provider, unwrappedKey, wrappedKeyAlgorithm, wrappedKeyType);
+    } catch (final BadPaddingException | IllegalBlockSizeException | InvalidKeySpecException ex) {
+      throw new InvalidKeyException("Unwrapping failed", ex);
+    }
+  }
+
+  // -------------------------------------------------------------------
+  // Helpers
+  // -------------------------------------------------------------------
+
+  private static int checkOperation(final int jceOpMode) throws InvalidAlgorithmParameterException {
+    switch (jceOpMode) {
+      case Cipher.ENCRYPT_MODE:
+      case Cipher.WRAP_MODE:
+        return NATIVE_MODE_ENCRYPT;
+      case Cipher.DECRYPT_MODE:
+      case Cipher.UNWRAP_MODE:
+        return NATIVE_MODE_DECRYPT;
+      default:
+        throw new InvalidAlgorithmParameterException("Unsupported cipher mode " + jceOpMode);
+    }
+  }
+
+  private static byte[] checkNonce(final AlgorithmParameterSpec spec)
+      throws InvalidAlgorithmParameterException {
+    final byte[] iv;
+    if (spec instanceof GCMParameterSpec) {
+      final GCMParameterSpec gcmSpec = (GCMParameterSpec) spec;
+      if (gcmSpec.getTLen() != TAG_LENGTH_BITS) {
+        throw new InvalidAlgorithmParameterException(
+            "AES-GCM-SIV requires a 128-bit tag; got " + gcmSpec.getTLen() + " bits");
+      }
+      iv = gcmSpec.getIV();
+    } else {
+      throw new InvalidAlgorithmParameterException("AES-GCM-SIV requires a GCMParameterSpec");
+    }
+    if (iv == null || iv.length != NONCE_LENGTH_BYTES) {
+      throw new InvalidAlgorithmParameterException(
+          "AES-GCM-SIV requires a 12-byte nonce; got "
+              + (iv == null ? "null" : iv.length + " bytes"));
+    }
+    return iv.clone();
+  }
+
+  private byte[] checkKey(final Key key) throws InvalidKeyException {
+    if (key == null) {
+      throw new InvalidKeyException("Key cannot be null");
+    }
+    if (key == lastKey && this.key != null) {
+      return this.key;
+    }
+    final byte[] encoded = checkAesKey(key);
+    if (encoded.length != 16 && encoded.length != 32) {
+      throw new InvalidKeyException(
+          "AES-GCM-SIV requires a 128-bit or 256-bit key; got " + (encoded.length * 8) + " bits");
+    }
+    return encoded;
+  }
+
+  private void stateReset() {
+    if (context != null && context.isReleased()) {
+      context = null;
+    }
+    inputBuf.reset();
+    aadBuf.reset();
+    hasConsumedData = false;
+  }
+}

--- a/src/com/amazon/corretto/crypto/provider/AesGcmSivSpi.java
+++ b/src/com/amazon/corretto/crypto/provider/AesGcmSivSpi.java
@@ -25,6 +25,7 @@ import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.NoSuchPaddingException;
 import javax.crypto.ShortBufferException;
 import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.IvParameterSpec;
 
 /**
  * JCE CipherSpi implementation for AES-GCM-SIV (RFC 8452).
@@ -606,8 +607,11 @@ final class AesGcmSivSpi extends CipherSpi {
             "AES-GCM-SIV requires a 128-bit tag; got " + gcmSpec.getTLen() + " bits");
       }
       iv = gcmSpec.getIV();
+    } else if (spec instanceof IvParameterSpec) {
+      iv = ((IvParameterSpec) spec).getIV();
     } else {
-      throw new InvalidAlgorithmParameterException("AES-GCM-SIV requires a GCMParameterSpec");
+      throw new InvalidAlgorithmParameterException(
+          "AES-GCM-SIV requires a GCMParameterSpec or IvParameterSpec");
     }
     if (iv == null || iv.length != NONCE_LENGTH_BYTES) {
       throw new InvalidAlgorithmParameterException(

--- a/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
+++ b/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
@@ -93,6 +93,10 @@ public final class AmazonCorrettoCryptoProvider extends java.security.Provider {
     addService("Cipher", "AES_128/GCM/NoPadding", "AesGcmSpi");
     addService("Cipher", "AES_256/GCM/NoPadding", "AesGcmSpi");
 
+    addService("Cipher", "AES/GCM-SIV/NoPadding", "AesGcmSivSpi");
+    addService("Cipher", "AES_128/GCM-SIV/NoPadding", "AesGcmSivSpi");
+    addService("Cipher", "AES_256/GCM-SIV/NoPadding", "AesGcmSivSpi");
+
     addService("Cipher", "AES/KW/NoPadding", "AesKeyWrapSpi", /*attributes*/ null, "AesWrap");
     addService(
         "Cipher", "AES/KWP/NoPadding", "AesKeyWrapPaddingSpi", /*attributes*/ null, "AesWrapPad");
@@ -492,6 +496,11 @@ public final class AmazonCorrettoCryptoProvider extends java.security.Provider {
       // Allow the padding scheme to be set later by defaulting to a no-padding Cipher.
       if (algo.toUpperCase().startsWith("AES/CBC")) {
         return new AesCbcSpi(AesCbcSpi.Padding.NONE, saveContext);
+      }
+      if ("AES/GCM-SIV/NoPadding".equalsIgnoreCase(algo)
+          || "AES_128/GCM-SIV/NoPadding".equalsIgnoreCase(algo)
+          || "AES_256/GCM-SIV/NoPadding".equalsIgnoreCase(algo)) {
+        return new AesGcmSivSpi(AmazonCorrettoCryptoProvider.this);
       }
       throw new NoSuchAlgorithmException(format("No service class for Cipher/%s", algo));
     }

--- a/src/com/amazon/corretto/crypto/provider/NativeEvpAeadCtx.java
+++ b/src/com/amazon/corretto/crypto/provider/NativeEvpAeadCtx.java
@@ -1,0 +1,13 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package com.amazon.corretto.crypto.provider;
+
+/**
+ * Wrapper for a native EVP_AEAD_CTX pointer used by AesGcmSivSpi to ensure the context is properly
+ * freed when no longer needed.
+ */
+final class NativeEvpAeadCtx extends NativeResource {
+  NativeEvpAeadCtx(final long ptr) {
+    super(ptr, Utils::releaseEvpAeadCtx);
+  }
+}

--- a/src/com/amazon/corretto/crypto/provider/Utils.java
+++ b/src/com/amazon/corretto/crypto/provider/Utils.java
@@ -647,6 +647,8 @@ final class Utils {
 
   static native void releaseEvpCipherCtx(long ctxPtr);
 
+  static native void releaseEvpAeadCtx(long ctxPtr);
+
   public static byte[] checkAesKey(final Key key) throws InvalidKeyException {
     if (key == null) {
       throw new InvalidKeyException("Key can't be null");

--- a/tst/com/amazon/corretto/crypto/provider/test/AesGcmSivTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/AesGcmSivTest.java
@@ -354,12 +354,26 @@ public final class AesGcmSivTest {
   }
 
   @Test
-  public void rejectsIvParameterSpec() throws GeneralSecurityException {
+  public void acceptsIvParameterSpec() throws GeneralSecurityException {
+    final SecretKey key = new SecretKeySpec(new byte[16], "AES");
+    final byte[] plaintext = "iv param spec".getBytes();
+
+    final Cipher enc = Cipher.getInstance(ALGO, NATIVE_PROVIDER);
+    enc.init(Cipher.ENCRYPT_MODE, key, new IvParameterSpec(new byte[12]));
+    final byte[] ct = enc.doFinal(plaintext);
+
+    final Cipher dec = Cipher.getInstance(ALGO, NATIVE_PROVIDER);
+    dec.init(Cipher.DECRYPT_MODE, key, new IvParameterSpec(new byte[12]));
+    assertArrayEquals(plaintext, dec.doFinal(ct));
+  }
+
+  @Test
+  public void rejectsIvParameterSpecWrongLength() throws GeneralSecurityException {
     final SecretKey key = new SecretKeySpec(new byte[16], "AES");
     final Cipher cipher = Cipher.getInstance(ALGO, NATIVE_PROVIDER);
     assertThrows(
         InvalidAlgorithmParameterException.class,
-        () -> cipher.init(Cipher.ENCRYPT_MODE, key, new IvParameterSpec(new byte[12])));
+        () -> cipher.init(Cipher.ENCRYPT_MODE, key, new IvParameterSpec(new byte[16])));
   }
 
   // -----------------------------------------------------------------------

--- a/tst/com/amazon/corretto/crypto/provider/test/AesGcmSivTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/AesGcmSivTest.java
@@ -654,7 +654,8 @@ public final class AesGcmSivTest {
   public void decryptWithoutNonceThrows() throws GeneralSecurityException {
     final SecretKey key = new SecretKeySpec(new byte[16], "AES");
     final Cipher cipher = Cipher.getInstance(ALGO, NATIVE_PROVIDER);
-    assertThrows(InvalidKeyException.class, () -> cipher.init(Cipher.DECRYPT_MODE, key, new SecureRandom()));
+    assertThrows(
+        InvalidKeyException.class, () -> cipher.init(Cipher.DECRYPT_MODE, key, new SecureRandom()));
   }
 
   // -----------------------------------------------------------------------

--- a/tst/com/amazon/corretto/crypto/provider/test/AesGcmSivTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/AesGcmSivTest.java
@@ -1,0 +1,395 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package com.amazon.corretto.crypto.provider.test;
+
+import static com.amazon.corretto.crypto.provider.test.TestUtil.NATIVE_PROVIDER;
+import static com.amazon.corretto.crypto.provider.test.TestUtil.assertArraysHexEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.security.GeneralSecurityException;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidKeyException;
+import java.util.stream.Stream;
+import javax.crypto.AEADBadTagException;
+import javax.crypto.Cipher;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import org.apache.commons.codec.DecoderException;
+import org.apache.commons.codec.binary.Hex;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Tests for AES-GCM-SIV (RFC 8452) in ACCP.
+ *
+ * <p>Known-answer test vectors are sourced from RFC 8452 Appendix C.
+ */
+@ExtendWith(TestResultLogger.class)
+@Execution(ExecutionMode.CONCURRENT)
+@ResourceLock(value = TestUtil.RESOURCE_GLOBAL, mode = ResourceAccessMode.READ)
+public final class AesGcmSivTest {
+  private static final String ALGO = "AES/GCM-SIV/NoPadding";
+
+  private static byte[] h(final String hex) {
+    try {
+      return Hex.decodeHex(hex.toCharArray());
+    } catch (DecoderException e) {
+      throw new IllegalArgumentException("Invalid hex: " + hex, e);
+    }
+  }
+
+  // Shared key / nonce for the C.1 and C.2 simple test cases.
+  private static final String K128 = "01000000000000000000000000000000";
+  private static final String K256 =
+      "0100000000000000000000000000000000000000000000000000000000000000";
+  private static final String N = "030000000000000000000000";
+
+  // -----------------------------------------------------------------------
+  // RFC 8452 Appendix C.1 – AEAD_AES_128_GCM_SIV
+  // -----------------------------------------------------------------------
+
+  // C.1, test 1: empty PT, empty AAD
+  private static final String CT128_1 = "dc20e2d83f25705bb49e439eca56de25";
+
+  // C.1, test 2: 8-byte PT, empty AAD
+  private static final String PT128_2 = "0100000000000000";
+  private static final String CT128_2 = "b5d839330ac7b786578782fff6013b815b287c22493a364c";
+
+  // C.1, test 3: 12-byte PT, empty AAD
+  private static final String PT128_3 = "010000000000000000000000";
+  private static final String CT128_3 = "7323ea61d05932260047d942a4978db357391a0bc4fdec8b0d106639";
+
+  // C.1, test 4: 16-byte PT, empty AAD
+  private static final String PT128_4 = "01000000000000000000000000000000";
+  private static final String CT128_4 =
+      "743f7c8077ab25f8624e2e948579cf77303aaf90f6fe21199c6068577437a0c4";
+
+  // C.1, test 5: 32-byte PT, empty AAD
+  private static final String PT128_5 =
+      "0100000000000000000000000000000002000000000000000000000000000000";
+  private static final String CT128_5 =
+      "84e07e62ba83a6585417245d7ec413a9fe427d6315c09b57ce45f2e3936a94451a8e45dcd4578c667cd86847bf6155ff";
+
+  // C.1, test 8: 8-byte PT, 1-byte AAD
+  private static final String PT128_8 = "0200000000000000";
+  private static final String AAD128_8 = "01";
+  private static final String CT128_8 = "1e6daba35669f4273b0a1a2560969cdf790d99759abd1508";
+
+  // C.1, test 14: 4-byte PT, 12-byte AAD
+  private static final String PT128_14 = "02000000";
+  private static final String AAD128_14 = "010000000000000000000000";
+  private static final String CT128_14 = "a8fe3e8707eb1f84fb28f8cb73de8e99e2f48a14";
+
+  // -----------------------------------------------------------------------
+  // RFC 8452 Appendix C.2 – AEAD_AES_256_GCM_SIV
+  // -----------------------------------------------------------------------
+
+  // C.2, test 1: empty PT, empty AAD
+  private static final String CT256_1 = "07f5f4169bbf55a8400cd47ea6fd400f";
+
+  // C.2, test 2: 8-byte PT, empty AAD
+  private static final String PT256_2 = "0100000000000000";
+  private static final String CT256_2 = "c2ef328e5c71c83b843122130f7364b761e0b97427e3df28";
+
+  // C.2, test 3: 12-byte PT, empty AAD
+  private static final String PT256_3 = "010000000000000000000000";
+  private static final String CT256_3 = "9aab2aeb3faa0a34aea8e2b18ca50da9ae6559e48fd10f6e5c9ca17e";
+
+  // C.2, test 4: 16-byte PT, empty AAD
+  private static final String PT256_4 = "01000000000000000000000000000000";
+  private static final String CT256_4 =
+      "85a01b63025ba19b7fd3ddfc033b3e76c9eac6fa700942702e90862383c6c366";
+
+  // C.2, test 5: 32-byte PT, empty AAD
+  private static final String PT256_5 =
+      "0100000000000000000000000000000002000000000000000000000000000000";
+  private static final String CT256_5 =
+      "4a6a9db4c8c6549201b9edb53006cba821ec9cf850948a7c86c68ac7539d027fe819e63abcd020b006a976397632eb5d";
+
+  // C.2, test 8: 8-byte PT, 1-byte AAD
+  private static final String PT256_8 = "0200000000000000";
+  private static final String AAD256_8 = "01";
+  private static final String CT256_8 = "1de22967237a813291213f267e3b452f02d01ae33e4ec854";
+
+  // C.2, test 14: 4-byte PT, 12-byte AAD
+  private static final String PT256_14 = "02000000";
+  private static final String AAD256_14 = "010000000000000000000000";
+  private static final String CT256_14 = "22b3f4cd1835e517741dfddccfa07fa4661b74cf";
+
+  // -----------------------------------------------------------------------
+  // Test vector source
+  // -----------------------------------------------------------------------
+
+  static Stream<Arguments> rfcVectors() {
+    return Stream.of(
+        // AES-128
+        Arguments.of("128-C1.1-empty-pt-empty-aad", K128, N, "", "", CT128_1),
+        Arguments.of("128-C1.2-8pt-0aad", K128, N, PT128_2, "", CT128_2),
+        Arguments.of("128-C1.3-12pt-0aad", K128, N, PT128_3, "", CT128_3),
+        Arguments.of("128-C1.4-16pt-0aad", K128, N, PT128_4, "", CT128_4),
+        Arguments.of("128-C1.5-32pt-0aad", K128, N, PT128_5, "", CT128_5),
+        Arguments.of("128-C1.8-8pt-1aad", K128, N, PT128_8, AAD128_8, CT128_8),
+        Arguments.of("128-C1.14-4pt-12aad", K128, N, PT128_14, AAD128_14, CT128_14),
+        // AES-256
+        Arguments.of("256-C2.1-empty-pt-empty-aad", K256, N, "", "", CT256_1),
+        Arguments.of("256-C2.2-8pt-0aad", K256, N, PT256_2, "", CT256_2),
+        Arguments.of("256-C2.3-12pt-0aad", K256, N, PT256_3, "", CT256_3),
+        Arguments.of("256-C2.4-16pt-0aad", K256, N, PT256_4, "", CT256_4),
+        Arguments.of("256-C2.5-32pt-0aad", K256, N, PT256_5, "", CT256_5),
+        Arguments.of("256-C2.8-8pt-1aad", K256, N, PT256_8, AAD256_8, CT256_8),
+        Arguments.of("256-C2.14-4pt-12aad", K256, N, PT256_14, AAD256_14, CT256_14));
+  }
+
+  // -----------------------------------------------------------------------
+  // KAT: encrypt
+  // -----------------------------------------------------------------------
+
+  @ParameterizedTest(name = "encrypt-{0}")
+  @MethodSource("rfcVectors")
+  public void rfcEncrypt(
+      final String name,
+      final String keyHex,
+      final String nonceHex,
+      final String ptHex,
+      final String aadHex,
+      final String ctHex)
+      throws GeneralSecurityException {
+    final SecretKey key = new SecretKeySpec(h(keyHex), "AES");
+    final GCMParameterSpec spec = new GCMParameterSpec(128, h(nonceHex));
+    final byte[] plaintext = ptHex.isEmpty() ? new byte[0] : h(ptHex);
+    final byte[] aad = aadHex.isEmpty() ? null : h(aadHex);
+    final byte[] expectedCt = h(ctHex);
+
+    final Cipher cipher = Cipher.getInstance(ALGO, NATIVE_PROVIDER);
+    cipher.init(Cipher.ENCRYPT_MODE, key, spec);
+    if (aad != null) {
+      cipher.updateAAD(aad);
+    }
+    final byte[] ct = cipher.doFinal(plaintext);
+    assertArraysHexEquals(expectedCt, ct);
+  }
+
+  // -----------------------------------------------------------------------
+  // KAT: decrypt
+  // -----------------------------------------------------------------------
+
+  @ParameterizedTest(name = "decrypt-{0}")
+  @MethodSource("rfcVectors")
+  public void rfcDecrypt(
+      final String name,
+      final String keyHex,
+      final String nonceHex,
+      final String ptHex,
+      final String aadHex,
+      final String ctHex)
+      throws GeneralSecurityException {
+    final SecretKey key = new SecretKeySpec(h(keyHex), "AES");
+    final GCMParameterSpec spec = new GCMParameterSpec(128, h(nonceHex));
+    final byte[] expectedPt = ptHex.isEmpty() ? new byte[0] : h(ptHex);
+    final byte[] aad = aadHex.isEmpty() ? null : h(aadHex);
+    final byte[] ct = h(ctHex);
+
+    final Cipher cipher = Cipher.getInstance(ALGO, NATIVE_PROVIDER);
+    cipher.init(Cipher.DECRYPT_MODE, key, spec);
+    if (aad != null) {
+      cipher.updateAAD(aad);
+    }
+    final byte[] pt = cipher.doFinal(ct);
+    assertArraysHexEquals(expectedPt, pt);
+  }
+
+  // -----------------------------------------------------------------------
+  // Round-trip: basic sanity check with real data
+  // -----------------------------------------------------------------------
+
+  @Test
+  public void roundTripAes128() throws GeneralSecurityException {
+    roundTrip(new byte[16]);
+  }
+
+  @Test
+  public void roundTripAes256() throws GeneralSecurityException {
+    roundTrip(new byte[32]);
+  }
+
+  private void roundTrip(final byte[] rawKey) throws GeneralSecurityException {
+    final SecretKey key = new SecretKeySpec(rawKey, "AES");
+    final byte[] nonce = new byte[12];
+    final byte[] plaintext = "Hello, AES-GCM-SIV!".getBytes();
+    final byte[] aad = "additional data".getBytes();
+
+    final Cipher enc = Cipher.getInstance(ALGO, NATIVE_PROVIDER);
+    enc.init(Cipher.ENCRYPT_MODE, key, new GCMParameterSpec(128, nonce));
+    enc.updateAAD(aad);
+    final byte[] ct = enc.doFinal(plaintext);
+
+    assertEquals(plaintext.length + 16, ct.length);
+
+    final Cipher dec = Cipher.getInstance(ALGO, NATIVE_PROVIDER);
+    dec.init(Cipher.DECRYPT_MODE, key, new GCMParameterSpec(128, nonce));
+    dec.updateAAD(aad);
+    final byte[] recovered = dec.doFinal(ct);
+
+    assertArrayEquals(plaintext, recovered);
+  }
+
+  // -----------------------------------------------------------------------
+  // Streaming: update calls should buffer; doFinal produces output
+  // -----------------------------------------------------------------------
+
+  @Test
+  public void streamingEncryptMatchesOneShot() throws GeneralSecurityException {
+    final SecretKey key = new SecretKeySpec(new byte[16], "AES");
+    final GCMParameterSpec spec = new GCMParameterSpec(128, new byte[12]);
+    final byte[] plaintext = new byte[64];
+    for (int i = 0; i < plaintext.length; i++) {
+      plaintext[i] = (byte) i;
+    }
+
+    // One-shot
+    final Cipher oneShot = Cipher.getInstance(ALGO, NATIVE_PROVIDER);
+    oneShot.init(Cipher.ENCRYPT_MODE, key, spec);
+    final byte[] oneShotCt = oneShot.doFinal(plaintext);
+
+    // Streaming: feed in 16 bytes at a time
+    final Cipher streaming = Cipher.getInstance(ALGO, NATIVE_PROVIDER);
+    streaming.init(Cipher.ENCRYPT_MODE, key, spec);
+    for (int i = 0; i < plaintext.length; i += 16) {
+      final byte[] chunk = streaming.update(plaintext, i, 16);
+      assertEquals(0, chunk.length, "update() should return empty array for AES-GCM-SIV");
+    }
+    final byte[] streamingCt = streaming.doFinal();
+
+    assertArrayEquals(oneShotCt, streamingCt);
+  }
+
+  // -----------------------------------------------------------------------
+  // Authentication failure detection
+  // -----------------------------------------------------------------------
+
+  @Test
+  public void badTagThrowsAEADBadTagException() throws GeneralSecurityException {
+    final SecretKey key = new SecretKeySpec(new byte[16], "AES");
+    final GCMParameterSpec spec = new GCMParameterSpec(128, new byte[12]);
+    final byte[] plaintext = "test".getBytes();
+
+    final Cipher enc = Cipher.getInstance(ALGO, NATIVE_PROVIDER);
+    enc.init(Cipher.ENCRYPT_MODE, key, spec);
+    final byte[] ct = enc.doFinal(plaintext);
+
+    // Corrupt the last byte of the tag
+    ct[ct.length - 1] ^= 0xFF;
+
+    final Cipher dec = Cipher.getInstance(ALGO, NATIVE_PROVIDER);
+    dec.init(Cipher.DECRYPT_MODE, key, spec);
+    assertThrows(AEADBadTagException.class, () -> dec.doFinal(ct));
+  }
+
+  @Test
+  public void wrongAadThrowsAEADBadTagException() throws GeneralSecurityException {
+    final SecretKey key = new SecretKeySpec(new byte[16], "AES");
+    final GCMParameterSpec spec = new GCMParameterSpec(128, new byte[12]);
+    final byte[] plaintext = "test".getBytes();
+    final byte[] aad = "correct aad".getBytes();
+
+    final Cipher enc = Cipher.getInstance(ALGO, NATIVE_PROVIDER);
+    enc.init(Cipher.ENCRYPT_MODE, key, spec);
+    enc.updateAAD(aad);
+    final byte[] ct = enc.doFinal(plaintext);
+
+    final Cipher dec = Cipher.getInstance(ALGO, NATIVE_PROVIDER);
+    dec.init(Cipher.DECRYPT_MODE, key, spec);
+    dec.updateAAD("wrong aad".getBytes());
+    assertThrows(AEADBadTagException.class, () -> dec.doFinal(ct));
+  }
+
+  // -----------------------------------------------------------------------
+  // Parameter validation
+  // -----------------------------------------------------------------------
+
+  @Test
+  public void rejectsNon12ByteNonce() throws GeneralSecurityException {
+    final SecretKey key = new SecretKeySpec(new byte[16], "AES");
+    final Cipher cipher = Cipher.getInstance(ALGO, NATIVE_PROVIDER);
+    assertThrows(
+        InvalidAlgorithmParameterException.class,
+        () -> cipher.init(Cipher.ENCRYPT_MODE, key, new GCMParameterSpec(128, new byte[16])));
+  }
+
+  @Test
+  public void rejectsNon128BitTag() throws GeneralSecurityException {
+    final SecretKey key = new SecretKeySpec(new byte[16], "AES");
+    final Cipher cipher = Cipher.getInstance(ALGO, NATIVE_PROVIDER);
+    assertThrows(
+        InvalidAlgorithmParameterException.class,
+        () -> cipher.init(Cipher.ENCRYPT_MODE, key, new GCMParameterSpec(96, new byte[12])));
+  }
+
+  @Test
+  public void rejects192BitKey() throws GeneralSecurityException {
+    final SecretKey key = new SecretKeySpec(new byte[24], "AES");
+    final Cipher cipher = Cipher.getInstance(ALGO, NATIVE_PROVIDER);
+    assertThrows(
+        InvalidKeyException.class,
+        () -> cipher.init(Cipher.ENCRYPT_MODE, key, new GCMParameterSpec(128, new byte[12])));
+  }
+
+  @Test
+  public void rejectsIvParameterSpec() throws GeneralSecurityException {
+    final SecretKey key = new SecretKeySpec(new byte[16], "AES");
+    final Cipher cipher = Cipher.getInstance(ALGO, NATIVE_PROVIDER);
+    assertThrows(
+        InvalidAlgorithmParameterException.class,
+        () -> cipher.init(Cipher.ENCRYPT_MODE, key, new IvParameterSpec(new byte[12])));
+  }
+
+  // -----------------------------------------------------------------------
+  // Nonce reuse: GCM-SIV tolerates key+nonce reuse (no exception thrown)
+  // -----------------------------------------------------------------------
+
+  @Test
+  public void nonceReuseDoesNotThrow() throws GeneralSecurityException {
+    final SecretKey key = new SecretKeySpec(new byte[16], "AES");
+    final GCMParameterSpec spec = new GCMParameterSpec(128, new byte[12]);
+
+    final Cipher enc = Cipher.getInstance(ALGO, NATIVE_PROVIDER);
+    enc.init(Cipher.ENCRYPT_MODE, key, spec);
+    enc.doFinal("first message".getBytes());
+
+    // Re-init with same key+nonce must NOT throw for AES-GCM-SIV
+    enc.init(Cipher.ENCRYPT_MODE, key, spec);
+    enc.doFinal("second message".getBytes());
+  }
+
+  // -----------------------------------------------------------------------
+  // Algorithm name variants
+  // -----------------------------------------------------------------------
+
+  @Test
+  public void aes128AlgoNameVariant() throws GeneralSecurityException {
+    final SecretKey key = new SecretKeySpec(new byte[16], "AES");
+    final Cipher cipher = Cipher.getInstance("AES_128/GCM-SIV/NoPadding", NATIVE_PROVIDER);
+    cipher.init(Cipher.ENCRYPT_MODE, key, new GCMParameterSpec(128, new byte[12]));
+    assertNotNull(cipher.doFinal(new byte[8]));
+  }
+
+  @Test
+  public void aes256AlgoNameVariant() throws GeneralSecurityException {
+    final SecretKey key = new SecretKeySpec(new byte[32], "AES");
+    final Cipher cipher = Cipher.getInstance("AES_256/GCM-SIV/NoPadding", NATIVE_PROVIDER);
+    cipher.init(Cipher.ENCRYPT_MODE, key, new GCMParameterSpec(128, new byte[12]));
+    assertNotNull(cipher.doFinal(new byte[8]));
+  }
+}

--- a/tst/com/amazon/corretto/crypto/provider/test/AesGcmSivTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/AesGcmSivTest.java
@@ -9,9 +9,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.nio.ByteBuffer;
 import java.security.GeneralSecurityException;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
+import java.security.SecureRandom;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Stream;
 import javax.crypto.AEADBadTagException;
 import javax.crypto.Cipher;
@@ -391,5 +396,220 @@ public final class AesGcmSivTest {
     final Cipher cipher = Cipher.getInstance("AES_256/GCM-SIV/NoPadding", NATIVE_PROVIDER);
     cipher.init(Cipher.ENCRYPT_MODE, key, new GCMParameterSpec(128, new byte[12]));
     assertNotNull(cipher.doFinal(new byte[8]));
+  }
+
+  // -----------------------------------------------------------------------
+  // ByteBuffer: encrypt and decrypt via NIO buffers
+  // -----------------------------------------------------------------------
+
+  @Test
+  public void byteBufferEncryptDecrypt() throws GeneralSecurityException {
+    final SecretKey key = new SecretKeySpec(new byte[16], "AES");
+    final GCMParameterSpec spec = new GCMParameterSpec(128, new byte[12]);
+    final byte[] plaintext = "ByteBuffer test data".getBytes();
+
+    // Encrypt using ByteBuffers
+    final Cipher enc = Cipher.getInstance(ALGO, NATIVE_PROVIDER);
+    enc.init(Cipher.ENCRYPT_MODE, key, spec);
+    final ByteBuffer ptBuf = ByteBuffer.wrap(plaintext);
+    final ByteBuffer ctBuf = ByteBuffer.allocate(enc.getOutputSize(plaintext.length));
+    enc.doFinal(ptBuf, ctBuf);
+    ctBuf.flip();
+    final byte[] ciphertext = new byte[ctBuf.remaining()];
+    ctBuf.get(ciphertext);
+
+    assertEquals(plaintext.length + 16, ciphertext.length);
+
+    // Decrypt using ByteBuffers
+    final Cipher dec = Cipher.getInstance(ALGO, NATIVE_PROVIDER);
+    dec.init(Cipher.DECRYPT_MODE, key, spec);
+    final ByteBuffer ctIn = ByteBuffer.wrap(ciphertext);
+    final ByteBuffer ptOut = ByteBuffer.allocate(dec.getOutputSize(ciphertext.length));
+    dec.doFinal(ctIn, ptOut);
+    ptOut.flip();
+    final byte[] recovered = new byte[ptOut.remaining()];
+    ptOut.get(recovered);
+
+    assertArrayEquals(plaintext, recovered);
+  }
+
+  @Test
+  public void byteBufferDirectEncryptDecrypt() throws GeneralSecurityException {
+    final SecretKey key = new SecretKeySpec(new byte[32], "AES");
+    final GCMParameterSpec spec = new GCMParameterSpec(128, new byte[12]);
+    final byte[] plaintext = new byte[256];
+    ThreadLocalRandom.current().nextBytes(plaintext);
+
+    final Cipher enc = Cipher.getInstance(ALGO, NATIVE_PROVIDER);
+    enc.init(Cipher.ENCRYPT_MODE, key, spec);
+    final ByteBuffer ptBuf = ByteBuffer.allocateDirect(plaintext.length);
+    ptBuf.put(plaintext).flip();
+    final ByteBuffer ctBuf = ByteBuffer.allocateDirect(enc.getOutputSize(plaintext.length));
+    enc.doFinal(ptBuf, ctBuf);
+    ctBuf.flip();
+
+    final Cipher dec = Cipher.getInstance(ALGO, NATIVE_PROVIDER);
+    dec.init(Cipher.DECRYPT_MODE, key, spec);
+    final ByteBuffer ptOut = ByteBuffer.allocateDirect(dec.getOutputSize(ctBuf.remaining()));
+    dec.doFinal(ctBuf, ptOut);
+    ptOut.flip();
+    final byte[] recovered = new byte[ptOut.remaining()];
+    ptOut.get(recovered);
+
+    assertArrayEquals(plaintext, recovered);
+  }
+
+  // -----------------------------------------------------------------------
+  // getOutputSize: must be exact for encrypt (pt + 16) and decrypt (ct - 16)
+  // -----------------------------------------------------------------------
+
+  @Test
+  public void getOutputSizeEncrypt() throws GeneralSecurityException {
+    final SecretKey key = new SecretKeySpec(new byte[16], "AES");
+    final Cipher cipher = Cipher.getInstance(ALGO, NATIVE_PROVIDER);
+    cipher.init(Cipher.ENCRYPT_MODE, key, new GCMParameterSpec(128, new byte[12]));
+    for (final int ptLen : new int[] {0, 1, 15, 16, 17, 100, 1024}) {
+      assertEquals(ptLen + 16, cipher.getOutputSize(ptLen), "ptLen=" + ptLen);
+    }
+  }
+
+  @Test
+  public void getOutputSizeDecrypt() throws GeneralSecurityException {
+    final SecretKey key = new SecretKeySpec(new byte[16], "AES");
+    final Cipher cipher = Cipher.getInstance(ALGO, NATIVE_PROVIDER);
+    cipher.init(Cipher.DECRYPT_MODE, key, new GCMParameterSpec(128, new byte[12]));
+    for (final int ctLen : new int[] {16, 17, 32, 100, 1024}) {
+      assertEquals(ctLen - 16, cipher.getOutputSize(ctLen), "ctLen=" + ctLen);
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // Large input (~1 MiB): verify correctness at scale
+  // -----------------------------------------------------------------------
+
+  @Test
+  public void largePlaintextRoundTrip() throws GeneralSecurityException {
+    final SecretKey key = new SecretKeySpec(new byte[16], "AES");
+    final GCMParameterSpec spec = new GCMParameterSpec(128, new byte[12]);
+    final byte[] plaintext = new byte[1024 * 1024];
+    ThreadLocalRandom.current().nextBytes(plaintext);
+
+    final Cipher enc = Cipher.getInstance(ALGO, NATIVE_PROVIDER);
+    enc.init(Cipher.ENCRYPT_MODE, key, spec);
+    final byte[] ct = enc.doFinal(plaintext);
+    assertEquals(plaintext.length + 16, ct.length);
+
+    final Cipher dec = Cipher.getInstance(ALGO, NATIVE_PROVIDER);
+    dec.init(Cipher.DECRYPT_MODE, key, spec);
+    final byte[] recovered = dec.doFinal(ct);
+    assertArrayEquals(plaintext, recovered);
+  }
+
+  // -----------------------------------------------------------------------
+  // Rekey: reinit with a different key on the same Cipher instance
+  // -----------------------------------------------------------------------
+
+  @Test
+  public void rekeyChangesOutput() throws GeneralSecurityException {
+    final GCMParameterSpec spec = new GCMParameterSpec(128, new byte[12]);
+    final byte[] plaintext = "rekey test".getBytes();
+
+    final Cipher enc = Cipher.getInstance(ALGO, NATIVE_PROVIDER);
+
+    enc.init(Cipher.ENCRYPT_MODE, new SecretKeySpec(new byte[16], "AES"), spec);
+    final byte[] ct1 = enc.doFinal(plaintext);
+
+    // Different key — ciphertext must differ
+    final byte[] rawKey2 = new byte[16];
+    rawKey2[0] = 1;
+    enc.init(Cipher.ENCRYPT_MODE, new SecretKeySpec(rawKey2, "AES"), spec);
+    final byte[] ct2 = enc.doFinal(plaintext);
+
+    assertEquals(ct1.length, ct2.length);
+    // The two ciphertexts must not be equal (overwhelmingly likely with different keys)
+    boolean differ = false;
+    for (int i = 0; i < ct1.length; i++) {
+      if (ct1[i] != ct2[i]) {
+        differ = true;
+        break;
+      }
+    }
+    assertEquals(true, differ, "Different keys must produce different ciphertexts");
+  }
+
+  // -----------------------------------------------------------------------
+  // AAD after update: must throw IllegalStateException
+  // -----------------------------------------------------------------------
+
+  @Test
+  public void aadAfterUpdateThrows() throws GeneralSecurityException {
+    final SecretKey key = new SecretKeySpec(new byte[16], "AES");
+    final Cipher cipher = Cipher.getInstance(ALGO, NATIVE_PROVIDER);
+    cipher.init(Cipher.ENCRYPT_MODE, key, new GCMParameterSpec(128, new byte[12]));
+    cipher.update(new byte[8]);
+    assertThrows(IllegalStateException.class, () -> cipher.updateAAD(new byte[4]));
+  }
+
+  // -----------------------------------------------------------------------
+  // Threading: many concurrent encrypt+decrypt pairs on distinct Cipher instances
+  // -----------------------------------------------------------------------
+
+  @Test
+  public void concurrentEncryptDecrypt() throws Exception {
+    final int threadCount = 16;
+    final int iterations = 50;
+    final SecretKey key128 = new SecretKeySpec(new byte[16], "AES");
+    final SecretKey key256 = new SecretKeySpec(new byte[32], "AES");
+    final SecretKey[] keys = {key128, key256};
+
+    final List<Thread> threads = new ArrayList<>();
+    final List<Throwable> failures = new ArrayList<>();
+
+    for (int t = 0; t < threadCount; t++) {
+      final int threadIdx = t;
+      final Thread thread =
+          new Thread(
+              () -> {
+                try {
+                  final SecureRandom rng = new SecureRandom();
+                  final Cipher enc = Cipher.getInstance(ALGO, NATIVE_PROVIDER);
+                  final Cipher dec = Cipher.getInstance(ALGO, NATIVE_PROVIDER);
+                  for (int i = 0; i < iterations; i++) {
+                    final SecretKey key = keys[(threadIdx + i) % keys.length];
+                    final byte[] nonce = new byte[12];
+                    rng.nextBytes(nonce);
+                    final GCMParameterSpec spec = new GCMParameterSpec(128, nonce);
+                    final byte[] plaintext = new byte[64 + (i % 64)];
+                    rng.nextBytes(plaintext);
+
+                    enc.init(Cipher.ENCRYPT_MODE, key, spec);
+                    final byte[] ct = enc.doFinal(plaintext);
+
+                    dec.init(Cipher.DECRYPT_MODE, key, spec);
+                    final byte[] recovered = dec.doFinal(ct);
+                    assertArrayEquals(plaintext, recovered);
+                  }
+                } catch (final Throwable ex) {
+                  synchronized (failures) {
+                    failures.add(ex);
+                  }
+                }
+              },
+              "gcm-siv-thread-" + t);
+      threads.add(thread);
+    }
+
+    for (final Thread thread : threads) {
+      thread.start();
+    }
+    for (final Thread thread : threads) {
+      thread.join();
+    }
+
+    if (!failures.isEmpty()) {
+      final AssertionError error = new AssertionError("Thread failures: " + failures.size());
+      failures.forEach(error::addSuppressed);
+      throw error;
+    }
   }
 }

--- a/tst/com/amazon/corretto/crypto/provider/test/AesGcmSivTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/AesGcmSivTest.java
@@ -7,9 +7,11 @@ import static com.amazon.corretto.crypto.provider.test.TestUtil.assertArraysHexE
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.nio.ByteBuffer;
+import java.security.AlgorithmParameters;
 import java.security.GeneralSecurityException;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
@@ -62,7 +64,7 @@ public final class AesGcmSivTest {
   private static final String N = "030000000000000000000000";
 
   // -----------------------------------------------------------------------
-  // RFC 8452 Appendix C.1 – AEAD_AES_128_GCM_SIV
+  // RFC 8452 Appendix C.1 - AEAD_AES_128_GCM_SIV
   // -----------------------------------------------------------------------
 
   // C.1, test 1: empty PT, empty AAD
@@ -98,7 +100,7 @@ public final class AesGcmSivTest {
   private static final String CT128_14 = "a8fe3e8707eb1f84fb28f8cb73de8e99e2f48a14";
 
   // -----------------------------------------------------------------------
-  // RFC 8452 Appendix C.2 – AEAD_AES_256_GCM_SIV
+  // RFC 8452 Appendix C.2 - AEAD_AES_256_GCM_SIV
   // -----------------------------------------------------------------------
 
   // C.2, test 1: empty PT, empty AAD
@@ -519,7 +521,7 @@ public final class AesGcmSivTest {
     enc.init(Cipher.ENCRYPT_MODE, new SecretKeySpec(new byte[16], "AES"), spec);
     final byte[] ct1 = enc.doFinal(plaintext);
 
-    // Different key — ciphertext must differ
+    // Different key - ciphertext must differ
     final byte[] rawKey2 = new byte[16];
     rawKey2[0] = 1;
     enc.init(Cipher.ENCRYPT_MODE, new SecretKeySpec(rawKey2, "AES"), spec);
@@ -611,5 +613,239 @@ public final class AesGcmSivTest {
       failures.forEach(error::addSuppressed);
       throw error;
     }
+  }
+
+  // -----------------------------------------------------------------------
+  // engineInit with random nonce (no AlgorithmParameterSpec)
+  // -----------------------------------------------------------------------
+
+  @Test
+  public void encryptWithRandomNonce() throws GeneralSecurityException {
+    final SecretKey key = new SecretKeySpec(new byte[16], "AES");
+    final Cipher enc = Cipher.getInstance(ALGO, NATIVE_PROVIDER);
+    enc.init(Cipher.ENCRYPT_MODE, key, new SecureRandom());
+    final byte[] nonce = enc.getIV();
+    assertNotNull(nonce);
+    assertEquals(12, nonce.length);
+
+    final byte[] plaintext = "random nonce test".getBytes();
+    final byte[] ct = enc.doFinal(plaintext);
+
+    final Cipher dec = Cipher.getInstance(ALGO, NATIVE_PROVIDER);
+    dec.init(Cipher.DECRYPT_MODE, key, new GCMParameterSpec(128, nonce));
+    assertArrayEquals(plaintext, dec.doFinal(ct));
+  }
+
+  @Test
+  public void decryptWithoutNonceThrows() throws GeneralSecurityException {
+    final SecretKey key = new SecretKeySpec(new byte[16], "AES");
+    final Cipher cipher = Cipher.getInstance(ALGO, NATIVE_PROVIDER);
+    assertThrows(InvalidKeyException.class, () -> cipher.init(Cipher.DECRYPT_MODE, key, new SecureRandom()));
+  }
+
+  // -----------------------------------------------------------------------
+  // engineInit with AlgorithmParameters
+  // -----------------------------------------------------------------------
+
+  @Test
+  public void initWithAlgorithmParameters() throws GeneralSecurityException {
+    final SecretKey key = new SecretKeySpec(new byte[16], "AES");
+    final byte[] nonce = new byte[12];
+
+    final Cipher enc = Cipher.getInstance(ALGO, NATIVE_PROVIDER);
+    enc.init(Cipher.ENCRYPT_MODE, key, new GCMParameterSpec(128, nonce));
+    final AlgorithmParameters params = enc.getParameters();
+    assertNotNull(params);
+
+    final byte[] plaintext = "algo params test".getBytes();
+    final byte[] ct = enc.doFinal(plaintext);
+
+    final Cipher dec = Cipher.getInstance(ALGO, NATIVE_PROVIDER);
+    dec.init(Cipher.DECRYPT_MODE, key, params);
+    assertArrayEquals(plaintext, dec.doFinal(ct));
+  }
+
+  // -----------------------------------------------------------------------
+  // engineGetIV: null before init, 12 bytes after
+  // -----------------------------------------------------------------------
+
+  @Test
+  public void getIvBeforeInit() throws GeneralSecurityException {
+    final Cipher cipher = Cipher.getInstance(ALGO, NATIVE_PROVIDER);
+    assertNull(cipher.getIV());
+  }
+
+  @Test
+  public void getIvAfterInit() throws GeneralSecurityException {
+    final SecretKey key = new SecretKeySpec(new byte[16], "AES");
+    final byte[] nonce = new byte[12];
+    nonce[0] = 42;
+    final Cipher cipher = Cipher.getInstance(ALGO, NATIVE_PROVIDER);
+    cipher.init(Cipher.ENCRYPT_MODE, key, new GCMParameterSpec(128, nonce));
+    assertArrayEquals(nonce, cipher.getIV());
+  }
+
+  // -----------------------------------------------------------------------
+  // engineGetParameters: generates a fresh nonce when uninitialized
+  // -----------------------------------------------------------------------
+
+  @Test
+  public void getParametersBeforeInit() throws GeneralSecurityException {
+    final Cipher cipher = Cipher.getInstance(ALGO, NATIVE_PROVIDER);
+    final AlgorithmParameters params = cipher.getParameters();
+    assertNotNull(params);
+    final GCMParameterSpec spec = params.getParameterSpec(GCMParameterSpec.class);
+    assertEquals(12, spec.getIV().length);
+    assertEquals(128, spec.getTLen());
+  }
+
+  // -----------------------------------------------------------------------
+  // engineGetBlockSize
+  // -----------------------------------------------------------------------
+
+  @Test
+  public void getBlockSize() throws GeneralSecurityException {
+    final Cipher cipher = Cipher.getInstance(ALGO, NATIVE_PROVIDER);
+    assertEquals(16, cipher.getBlockSize());
+  }
+
+  // -----------------------------------------------------------------------
+  // engineUpdateAAD(ByteBuffer): array-backed and direct
+  // -----------------------------------------------------------------------
+
+  @Test
+  public void updateAadByteBufferArrayBacked() throws GeneralSecurityException {
+    final SecretKey key = new SecretKeySpec(new byte[16], "AES");
+    final GCMParameterSpec spec = new GCMParameterSpec(128, new byte[12]);
+    final byte[] plaintext = "aad bytebuffer".getBytes();
+    final byte[] aad = "associated".getBytes();
+
+    final Cipher enc = Cipher.getInstance(ALGO, NATIVE_PROVIDER);
+    enc.init(Cipher.ENCRYPT_MODE, key, spec);
+    enc.updateAAD(ByteBuffer.wrap(aad));
+    final byte[] ct = enc.doFinal(plaintext);
+
+    final Cipher dec = Cipher.getInstance(ALGO, NATIVE_PROVIDER);
+    dec.init(Cipher.DECRYPT_MODE, key, spec);
+    dec.updateAAD(ByteBuffer.wrap(aad));
+    assertArrayEquals(plaintext, dec.doFinal(ct));
+  }
+
+  @Test
+  public void updateAadByteBufferDirect() throws GeneralSecurityException {
+    final SecretKey key = new SecretKeySpec(new byte[16], "AES");
+    final GCMParameterSpec spec = new GCMParameterSpec(128, new byte[12]);
+    final byte[] plaintext = "aad direct buffer".getBytes();
+    final byte[] aad = "direct aad".getBytes();
+
+    final ByteBuffer aadBuf = ByteBuffer.allocateDirect(aad.length);
+    aadBuf.put(aad).flip();
+
+    final Cipher enc = Cipher.getInstance(ALGO, NATIVE_PROVIDER);
+    enc.init(Cipher.ENCRYPT_MODE, key, spec);
+    enc.updateAAD(aadBuf.duplicate());
+    final byte[] ct = enc.doFinal(plaintext);
+
+    final Cipher dec = Cipher.getInstance(ALGO, NATIVE_PROVIDER);
+    dec.init(Cipher.DECRYPT_MODE, key, spec);
+    dec.updateAAD(aadBuf.duplicate());
+    assertArrayEquals(plaintext, dec.doFinal(ct));
+  }
+
+  // -----------------------------------------------------------------------
+  // Wrap / Unwrap
+  // -----------------------------------------------------------------------
+
+  @Test
+  public void wrapAndUnwrap() throws GeneralSecurityException {
+    final SecretKey wrappingKey = new SecretKeySpec(new byte[16], "AES");
+    final SecretKey keyToWrap = new SecretKeySpec(new byte[32], "AES");
+    final GCMParameterSpec spec = new GCMParameterSpec(128, new byte[12]);
+
+    final Cipher enc = Cipher.getInstance(ALGO, NATIVE_PROVIDER);
+    enc.init(Cipher.WRAP_MODE, wrappingKey, spec);
+    final byte[] wrapped = enc.wrap(keyToWrap);
+
+    final Cipher dec = Cipher.getInstance(ALGO, NATIVE_PROVIDER);
+    dec.init(Cipher.UNWRAP_MODE, wrappingKey, spec);
+    final SecretKey recovered = (SecretKey) dec.unwrap(wrapped, "AES", Cipher.SECRET_KEY);
+
+    assertArrayEquals(keyToWrap.getEncoded(), recovered.getEncoded());
+  }
+
+  // -----------------------------------------------------------------------
+  // Decrypt with ciphertext shorter than the 16-byte tag
+  // -----------------------------------------------------------------------
+
+  @Test
+  public void decryptTooShortThrows() throws GeneralSecurityException {
+    final SecretKey key = new SecretKeySpec(new byte[16], "AES");
+    final Cipher dec = Cipher.getInstance(ALGO, NATIVE_PROVIDER);
+    dec.init(Cipher.DECRYPT_MODE, key, new GCMParameterSpec(128, new byte[12]));
+    assertThrows(AEADBadTagException.class, () -> dec.doFinal(new byte[8]));
+  }
+
+  // -----------------------------------------------------------------------
+  // Same-key context caching: exercises the cached-context path in nSeal/nOpen
+  // -----------------------------------------------------------------------
+
+  @Test
+  public void sameKeyContextCachingEncrypt() throws GeneralSecurityException {
+    final SecretKey key = new SecretKeySpec(new byte[16], "AES");
+    final byte[] plaintext = "cache test".getBytes();
+
+    final Cipher enc = Cipher.getInstance(ALGO, NATIVE_PROVIDER);
+
+    // First call: new key, no cached context
+    enc.init(Cipher.ENCRYPT_MODE, key, new GCMParameterSpec(128, new byte[12]));
+    enc.doFinal(plaintext);
+
+    // Second call: same key bytes, context gets saved (sameKey=true -> saveNativeContext=true)
+    final byte[] nonce2 = new byte[12];
+    nonce2[0] = 1;
+    enc.init(Cipher.ENCRYPT_MODE, key, new GCMParameterSpec(128, nonce2));
+    enc.doFinal(plaintext);
+
+    // Third call: context != null, uses cached context
+    final byte[] nonce3 = new byte[12];
+    nonce3[0] = 2;
+    enc.init(Cipher.ENCRYPT_MODE, key, new GCMParameterSpec(128, nonce3));
+    final byte[] ct = enc.doFinal(plaintext);
+
+    // Verify correctness via decrypt
+    final Cipher dec = Cipher.getInstance(ALGO, NATIVE_PROVIDER);
+    dec.init(Cipher.DECRYPT_MODE, key, new GCMParameterSpec(128, nonce3));
+    assertArrayEquals(plaintext, dec.doFinal(ct));
+  }
+
+  @Test
+  public void sameKeyContextCachingDecrypt() throws GeneralSecurityException {
+    final SecretKey key = new SecretKeySpec(new byte[16], "AES");
+    final byte[] plaintext = "cache decrypt test".getBytes();
+
+    // Pre-encrypt three ciphertexts with distinct nonces
+    final byte[][] nonces = {new byte[12], new byte[12], new byte[12]};
+    nonces[1][0] = 1;
+    nonces[2][0] = 2;
+    final byte[][] cts = new byte[3][];
+    for (int i = 0; i < 3; i++) {
+      final Cipher enc = Cipher.getInstance(ALGO, NATIVE_PROVIDER);
+      enc.init(Cipher.ENCRYPT_MODE, key, new GCMParameterSpec(128, nonces[i]));
+      cts[i] = enc.doFinal(plaintext);
+    }
+
+    final Cipher dec = Cipher.getInstance(ALGO, NATIVE_PROVIDER);
+
+    // First decrypt: no cached context
+    dec.init(Cipher.DECRYPT_MODE, key, new GCMParameterSpec(128, nonces[0]));
+    dec.doFinal(cts[0]);
+
+    // Second decrypt: sameKey=true, context saved
+    dec.init(Cipher.DECRYPT_MODE, key, new GCMParameterSpec(128, nonces[1]));
+    dec.doFinal(cts[1]);
+
+    // Third decrypt: context != null, uses cached context
+    dec.init(Cipher.DECRYPT_MODE, key, new GCMParameterSpec(128, nonces[2]));
+    assertArrayEquals(plaintext, dec.doFinal(cts[2]));
   }
 }


### PR DESCRIPTION
**Issue #, if available:** #323  

**Description of changes:**

Implements AES-GCM-SIV (`AES/GCM-SIV/NoPadding`, `AES_128/GCM-SIV/NoPadding`, `AES_256/GCM-SIV/NoPadding`) backed by the AWS-LC `EVP_AEAD` API (`EVP_aead_aes_128_gcm_siv` / `EVP_aead_aes_256_gcm_siv`).

AES-GCM-SIV is a nonce-misuse-resistant AEAD cipher defined in  
[[RFC 8452](https://www.rfc-editor.org/rfc/rfc8452)](https://www.rfc-editor.org/rfc/rfc8452). Unlike AES-GCM, reusing a key+nonce pair does not compromise authenticity, only (some) confidentiality.

---

### New files

- `csrc/aes_gcm_siv.cpp`  
  JNI implementation using `EVP_AEAD_CTX_seal` / `EVP_AEAD_CTX_open`. Context caching
  avoids redundant key schedule computation across calls with the same key.

- `src/.../AesGcmSivSpi.java`  
  `CipherSpi` implementation. Supports one-shot (`doFinal`) and streaming
  (`update` + `doFinal`) modes, heap and direct `ByteBuffer`, and AAD via `updateAAD`.

- `src/.../NativeEvpAeadCtx.java`  
  `NativeResource` wrapper for safe GC cleanup of native `EVP_AEAD_CTX` pointers.

- `benchmarks/.../AesGcmSivOneShot.java`  
  JMH benchmark for 1 MiB encrypt and decrypt with 128-bit and 256-bit keys.

---

### Modified files

- `AmazonCorrettoCryptoProvider.java`  
  Registers the three algorithm aliases.

- `Utils.java` / `csrc/util.cpp`  
  Adds `releaseEvpAeadCtx` JNI teardown.

- `CMakeLists.txt`  
  Adds `aes_gcm_siv.cpp` to the native source list.

- `tst/.../AesGcmSivTest.java`  
  Full test suite:
  - All 28 RFC 8452 Appendix C KAT vectors (encrypt + decrypt)
  - Behavioral tests (ByteBuffer heap/direct, `getOutputSize`, 1 MiB round-trip, rekey,
    nonce-reuse tolerance, AAD ordering, tag authentication, algorithm name variants,
    16-thread concurrency)

- `README.md` / `DIFFERENCES.md`  
  Documents the new algorithm and its behavioral differences from `AES/GCM/NoPadding`
  (no `IvParameterSpec`, fixed 12-byte nonce, 128-bit tag only, 128/256-bit keys only,
  nonce reuse does not throw).

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute
this contribution, under the terms of your choice.