### PR TITLE
Several small bug fixes

### DIFF
--- a/csrc/aes_ctr_drbg.cpp
+++ b/csrc/aes_ctr_drbg.cpp
@@ -59,6 +59,7 @@ bool drbg_getentropy(void *buffer, size_t length) {
     bool success = false;
     int mutex_error = 0;
     uint8_t *bufp = reinterpret_cast<uint8_t *>(buffer);
+    size_t original_length = length;
 
     if (unlikely(mutex_error = pthread_mutex_lock(&getentropy_mutex))) {
         errno = mutex_error;
@@ -83,12 +84,12 @@ bool drbg_getentropy(void *buffer, size_t length) {
 
                 urandom_fd = open("/dev/urandom", O_RDONLY);
                 if (urandom_fd >= 0) {
-                    flags = fcntl(F_GETFD, urandom_fd);
+                    flags = fcntl(urandom_fd, F_GETFD);
                     if (flags == -1) {
                         close(urandom_fd);
                         urandom_fd = -1;
                     } else {
-                        if (-1 == fcntl(F_SETFD, urandom_fd, flags | FD_CLOEXEC)) {
+                        if (-1 == fcntl(urandom_fd, F_SETFD, flags | FD_CLOEXEC)) {
                             close(urandom_fd);
                             urandom_fd = -1;
                         }
@@ -115,7 +116,7 @@ bool drbg_getentropy(void *buffer, size_t length) {
     success = true;
 out:
     if (!success) {
-        secureZero(buffer, length);
+        secureZero(buffer, original_length);
     }
 
     if (unlikely(mutex_error = pthread_mutex_unlock(&getentropy_mutex))) {

--- a/csrc/aes_gcm.cpp
+++ b/csrc/aes_gcm.cpp
@@ -340,7 +340,9 @@ JNIEXPORT jint JNICALL Java_com_amazon_corretto_crypto_provider_AesGcmSpi_encryp
 
         rv = outoffset + finalOffset;
     } catch (java_ex &ex) {
-        EVP_CIPHER_CTX_free(ctx.take());
+        if (releaseContext) {
+            EVP_CIPHER_CTX_free(ctx.take());
+        }
 
         ex.throw_to_java(pEnv);
         return -1;

--- a/csrc/agreement.cpp
+++ b/csrc/agreement.cpp
@@ -77,7 +77,7 @@ JNIEXPORT jbyteArray JNICALL Java_com_amazon_corretto_crypto_provider_EvpKeyAgre
         checkAgreementResult(EVP_PKEY_derive_set_peer(pctx, pubCtx.getKey()));
         
         size_t resultLen = 0;
-        std::vector<uint8_t> tmpResult;
+        std::vector<uint8_t, SecureAlloc<uint8_t> > tmpResult;
 
         checkAgreementResult(EVP_PKEY_derive(pctx, NULL, &resultLen));
         tmpResult.resize(resultLen);

--- a/csrc/buffer.h
+++ b/csrc/buffer.h
@@ -149,7 +149,7 @@ class java_buffer {
 
             jint true_length = context->GetArrayLength(array);
 
-            if (unlikely(true_length) < 0) {
+            if (unlikely(true_length < 0)) {
                 throw java_ex("java/lang/AssertionError", "Impossible: Negative array length");
             }
 
@@ -186,7 +186,7 @@ class java_buffer {
             buf.m_offset = offset;
             buf.m_length = context->GetArrayLength(array);
 
-            if (unlikely(buf.m_length) < 0) {
+            if (unlikely(buf.m_length < 0)) {
                 throw java_ex("java/lang/AssertionError", "Impossible: Negative array length");
             }
 
@@ -513,7 +513,7 @@ class bounce_buffer {
             m_buffer = buffer;
 
             if (unlikely(sizeof(T) != m_buffer.len())) {
-                throw new java_ex(EX_ILLEGAL_ARGUMENT, "Incorrect length for buffer");
+                throw java_ex(EX_ILLEGAL_ARGUMENT, "Incorrect length for buffer");
             }
 
             if (buffer.array() && !env.is_locked()) {

--- a/csrc/keyutils.cpp
+++ b/csrc/keyutils.cpp
@@ -79,9 +79,9 @@ EVP_PKEY* der2EvpPrivateKey(const unsigned char* der, const int derLen, const bo
             if (!RSA_set0_key(nulled_rsa, BN_dup(n), BN_dup(e), BN_dup(d))) {
               throw_openssl(javaExceptionClass, "Unable to set RSA key parameters");
             }
+            RSA_blinding_off(nulled_rsa);
             EVP_PKEY_set1_RSA(result, nulled_rsa);
             RSA_free(nulled_rsa); // Decrement reference counter
-            RSA_blinding_off(nulled_rsa);
           }
       }
   }

--- a/csrc/rand.cpp
+++ b/csrc/rand.cpp
@@ -40,7 +40,7 @@ RAND_METHOD drbg_rand_methods={
 
 void cleanup() {
     pthread_lock_auto lock(&drbg_lock);
-    if (drbg) {
+    if (!drbg) {
         return;
     }
     delete drbg;

--- a/csrc/rdrand.cpp
+++ b/csrc/rdrand.cpp
@@ -353,7 +353,7 @@ bool rd_into_buf(bool (*rng)(uint64_t *), unsigned char *buf, int len) {
         }
 
         memcpy(buf, &remain, len);
-        secureZero(&remain, 0);
+        secureZero(&remain, sizeof(remain));
     }
 #else
     goto fail;

--- a/src/com/amazon/corretto/crypto/provider/RsaCipher.java
+++ b/src/com/amazon/corretto/crypto/provider/RsaCipher.java
@@ -334,6 +334,8 @@ class RsaCipher extends CipherSpi {
               keySizeBytes_ = (key_.getModulus().bitLength() + 7) / 8;
               buffer_ = new AccessibleByteArrayOutputStream();
               parseKey();
+          } else {
+              buffer_ = new AccessibleByteArrayOutputStream();
           }
         }
     }


### PR DESCRIPTION
- Fix use-after-free in GCM encryptDoFinal error path for borrowed contexts
- Use SecureAlloc for ECDH shared secret vector
- Fix RSA_blinding_off called after RSA_free in key rebuild path
- Fix heap-allocated exception (throw new -> throw) in bounce_buffer
- Fix secureZero called with zero length in rdrand
- Fix inverted null check in DRBG cleanup
- Fix swapped fcntl arguments in entropy fallback path
- Fix incomplete buffer zeroing on entropy read error
- Fix unlikely() macro parenthesization in buffer bounds checks
- Reset RSA cipher buffer on same-key re-initialization

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
