### PR TITLE
Throw IllegalBlockSizeException for undersized RSA ciphertext

### DIFF
--- a/csrc/rsa_cipher.cpp
+++ b/csrc/rsa_cipher.cpp
@@ -132,6 +132,8 @@ JNIEXPORT jint JNICALL Java_com_amazon_corretto_crypto_provider_RsaCipher_cipher
                 if (err == RSA_R_DATA_TOO_LARGE_FOR_MODULUS || err == RSA_R_PADDING_CHECK_FAILED
                     || err == RSA_R_OAEP_DECODING_ERROR) {
                     throw_java_ex(EX_BADPADDING, formatOpensslError(err, "Bad Padding"));
+                } else if (err == RSA_R_DATA_LEN_NOT_EQUAL_TO_MOD_LEN) {
+                    throw_java_ex(EX_ILLEGAL_BLOCK_SIZE, formatOpensslError(err, "Illegal block size"));
                 } else {
                     throw_openssl(formatOpensslError(packed_err, "Unexpected exception").c_str());
                 }

--- a/csrc/util.h
+++ b/csrc/util.h
@@ -38,6 +38,7 @@ inline std::string opensslErrorWithDefault(const char* fallback)
 #define EX_ARRAYOOB            "java/lang/ArrayIndexOutOfBoundsException"
 #define EX_INDEXOOB            "java/lang/IndexOutOfBoundsException"
 #define EX_BADPADDING          "javax/crypto/BadPaddingException"
+#define EX_ILLEGAL_BLOCK_SIZE  "javax/crypto/IllegalBlockSizeException"
 #define EX_SHORTBUFFER         "javax/crypto/ShortBufferException"
 #define EX_RUNTIME_CRYPTO      "com/amazon/corretto/crypto/provider/RuntimeCryptoException"
 #define EX_ILLEGAL_ARGUMENT    "java/lang/IllegalArgumentException"

--- a/tst/com/amazon/corretto/crypto/provider/test/RsaCipherTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/RsaCipherTest.java
@@ -296,6 +296,22 @@ public class RsaCipherTest {
     assertThrows(IllegalBlockSizeException.class, () -> nativeEncrypt.doFinal(ciphertext));
   }
 
+  @ParameterizedTest
+  @MethodSource("paddingXlengthParams")
+  public void undersizedCiphertext(
+      final String padding,
+      final Integer keySize,
+      final OAEPParameterSpec oaep,
+      final String ignoredName)
+      throws GeneralSecurityException {
+    final Cipher dec = getNativeCipher(padding);
+    dec.init(Cipher.DECRYPT_MODE, getKeyPair(keySize).getPrivate(), oaep);
+
+    byte[] ciphertext = new byte[(keySize / 8) - 1];
+    Arrays.fill(ciphertext, (byte) 1);
+    assertThrows(IllegalBlockSizeException.class, () -> dec.doFinal(ciphertext));
+  }
+
   @Test
   public void oaepParamValidation() throws GeneralSecurityException {
     Cipher c = getNativeCipher(OAEP_PADDING);


### PR DESCRIPTION
*Description of changes:*
When decrypting an RSA ciphertext shorter than the key size, the native
layer hit RSA_R_DATA_LEN_NOT_EQUAL_TO_MOD_LEN and fell through to a
generic error path that threw RuntimeCryptoException. This violates the
JCE contract — Cipher.doFinal() declares IllegalBlockSizeException and
BadPaddingException, not RuntimeCryptoException.

The input length != modulus length condition is a block size mismatch,
not a padding error, so IllegalBlockSizeException is the right choice.
This is consistent with the Java-side guard that already throws
IllegalBlockSizeException when the input is longer than the key size.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
