### PR TITLE
Remove NONEwithRSA input length restriction, DigestInfo

### DIFF
--- a/csrc/sign.cpp
+++ b/csrc/sign.cpp
@@ -648,14 +648,10 @@ JNIEXPORT jbyteArray JNICALL Java_com_amazon_corretto_crypto_provider_NoneWithRs
             throw_java_ex(EX_SIGNATURE_EXCEPTION, "Failed to get RSA key");
         }
 
-        const size_t rsaSize = RSA_size(rsa);
-        if ((size_t)length > (rsaSize - 11)) {  // PKCS1 padding is 11 bytes for raw NONEwithRSA
-            throw_java_ex(EX_SIGNATURE_EXCEPTION, "Message too long for RSA key");
-        }
-
         java_buffer digestBuf = java_buffer::from_array(env, digestArr, offset, length);
 
         // Allocate output buffer for signature
+        const size_t rsaSize = RSA_size(rsa);
         std::vector<uint8_t, SecureAlloc<uint8_t> > signature(rsaSize);
 
         // Borrow digest for the crypto call, release before creating Java array
@@ -676,6 +672,9 @@ JNIEXPORT jbyteArray JNICALL Java_com_amazon_corretto_crypto_provider_NoneWithRs
                 break;
             }
             case RSA_PKCS1_PADDING: {
+                if ((size_t)length > (rsaSize - 11)) {  // PKCS1 padding is 11 bytes for raw NONEwithRSA
+                    throw_java_ex(EX_SIGNATURE_EXCEPTION, "Message too long for RSA key");
+                }
                 int rc = RSA_sign_raw(rsa, &sigLen, signature.data(), rsaSize,
                     digest.data(), length, RSA_PKCS1_PADDING);
                 if (rc != 1) {
@@ -743,7 +742,9 @@ JNIEXPORT jboolean JNICALL Java_com_amazon_corretto_crypto_provider_NoneWithRsa_
             break;
         }
         case RSA_PKCS1_PADDING: {
-            // Decrypt signature and strip PKCS1 padding
+            if ((size_t)length > (RSA_size(rsa) - 11)) {
+                throw_java_ex(EX_SIGNATURE_EXCEPTION, "Message too long for RSA key");
+            }
             size_t outLen = 0;
             std::vector<uint8_t> buf(RSA_size(rsa));
             if (1 != RSA_verify_raw(rsa, &outLen, buf.data(), buf.size(), sig.data(), sig.len(), RSA_PKCS1_PADDING)

--- a/csrc/sign.cpp
+++ b/csrc/sign.cpp
@@ -648,39 +648,39 @@ JNIEXPORT jbyteArray JNICALL Java_com_amazon_corretto_crypto_provider_NoneWithRs
             throw_java_ex(EX_SIGNATURE_EXCEPTION, "Failed to get RSA key");
         }
 
-        size_t hLen = EVP_MD_size(md);
-
-        if (static_cast<size_t>(length) != hLen) {
-            throw_java_ex(EX_SIGNATURE_EXCEPTION, "Digest length mismatch");
+        const size_t rsaSize = RSA_size(rsa);
+        if ((size_t)length > (rsaSize - 11)) {  // PKCS1 padding is 11 bytes for raw NONEwithRSA
+            throw_java_ex(EX_SIGNATURE_EXCEPTION, "Message too long for RSA key");
         }
 
         java_buffer digestBuf = java_buffer::from_array(env, digestArr, offset, length);
 
         // Allocate output buffer for signature
-        size_t maxOut = RSA_size(rsa);
-        std::vector<uint8_t, SecureAlloc<uint8_t> > signature(maxOut);
+        std::vector<uint8_t, SecureAlloc<uint8_t> > signature(rsaSize);
 
         // Borrow digest for the crypto call, release before creating Java array
+        size_t sigLen = 0;
         {
             jni_borrow digest(env, digestBuf, "digest");
 
             switch (paddingType) {
             case RSA_PKCS1_PSS_PADDING: {
+                if (static_cast<size_t>(length) != EVP_MD_size(md)) {
+                    throw_java_ex(EX_SIGNATURE_EXCEPTION, "Digest length mismatch");
+                }
                 const EVP_MD* mgf_md = reinterpret_cast<const EVP_MD*>(mgfMd);
-                size_t sigLen = 0;
-                if (RSA_sign_pss_mgf1(rsa, &sigLen, signature.data(), maxOut, digest.data(), hLen, md, mgf_md, saltLen)
+                if (RSA_sign_pss_mgf1(rsa, &sigLen, signature.data(), rsaSize, digest.data(), length, md, mgf_md, saltLen)
                     != 1) {
                     throw_openssl("RSA_sign_pss_mgf1 failed");
                 }
-                signature.resize(sigLen);
                 break;
             }
             case RSA_PKCS1_PADDING: {
-                unsigned int sigLen = 0;
-                if (RSA_sign(EVP_MD_type(md), digest.data(), hLen, signature.data(), &sigLen, rsa) != 1) {
-                    throw_openssl("RSA_sign failed");
+                int rc = RSA_sign_raw(rsa, &sigLen, signature.data(), rsaSize,
+                    digest.data(), length, RSA_PKCS1_PADDING);
+                if (rc != 1) {
+                    throw_openssl("RSA_sign_raw failed");
                 }
-                signature.resize(sigLen);
                 break;
             }
             default:
@@ -688,6 +688,7 @@ JNIEXPORT jbyteArray JNICALL Java_com_amazon_corretto_crypto_provider_NoneWithRs
             }
         }
 
+        signature.resize(sigLen);
         return vecToArray(env, signature);
 
     } catch (java_ex& ex) {
@@ -725,12 +726,6 @@ JNIEXPORT jboolean JNICALL Java_com_amazon_corretto_crypto_provider_NoneWithRsa_
             throw_java_ex(EX_SIGNATURE_EXCEPTION, "Failed to get RSA key");
         }
 
-        size_t hLen = EVP_MD_size(md);
-
-        if (static_cast<size_t>(length) != hLen) {
-            throw_java_ex(EX_SIGNATURE_EXCEPTION, "Digest length mismatch");
-        }
-
         java_buffer digestBuf = java_buffer::from_array(env, digestArr, offset, length);
         java_buffer signatureBuf = java_buffer::from_array(env, signatureArr, sigOffset, sigLength);
 
@@ -740,13 +735,25 @@ JNIEXPORT jboolean JNICALL Java_com_amazon_corretto_crypto_provider_NoneWithRsa_
         int result = 0;
         switch (paddingType) {
         case RSA_PKCS1_PSS_PADDING: {
+            if (static_cast<size_t>(length) != EVP_MD_size(md)) {
+                throw_java_ex(EX_SIGNATURE_EXCEPTION, "Digest length mismatch");
+            }
             const EVP_MD* mgf_md = reinterpret_cast<const EVP_MD*>(mgfMd);
-            result = RSA_verify_pss_mgf1(rsa, digest.data(), hLen, md, mgf_md, saltLen, sig.data(), sig.len());
+            result = RSA_verify_pss_mgf1(rsa, digest.data(), length, md, mgf_md, saltLen, sig.data(), sig.len());
             break;
         }
-        case RSA_PKCS1_PADDING:
-            result = RSA_verify(EVP_MD_type(md), digest.data(), hLen, sig.data(), sig.len(), rsa);
+        case RSA_PKCS1_PADDING: {
+            // Decrypt signature and strip PKCS1 padding
+            size_t outLen = 0;
+            std::vector<uint8_t> buf(RSA_size(rsa));
+            if (1 != RSA_verify_raw(rsa, &outLen, buf.data(), buf.size(), sig.data(), sig.len(), RSA_PKCS1_PADDING)
+                || (size_t)length != outLen
+                || 0 != CRYPTO_memcmp(buf.data(), digest.data(), outLen)) {
+                break; // result stays 0
+            }
+            result = 1;
             break;
+        }
         default:
             throw_java_ex(EX_RUNTIME_CRYPTO, "Unexpected padding type");
         }

--- a/src/com/amazon/corretto/crypto/provider/NoneWithRsa.java
+++ b/src/com/amazon/corretto/crypto/provider/NoneWithRsa.java
@@ -40,8 +40,7 @@ import java.security.spec.PSSParameterSpec;
  * @see PSSParameterSpec
  */
 class NoneWithRsa extends EvpSignatureBase {
-  private final AccessibleByteArrayOutputStream buffer =
-      new AccessibleByteArrayOutputStream(64, 64);
+  private final AccessibleByteArrayOutputStream buffer = new AccessibleByteArrayOutputStream();
 
   protected NoneWithRsa(final AmazonCorrettoCryptoProvider provider, final int paddingType) {
     super(provider, EvpKeyType.RSA, paddingType, 0, false);
@@ -82,10 +81,12 @@ class NoneWithRsa extends EvpSignatureBase {
     if (!isBufferEmpty()) {
       throw new SignatureException("Digest already provided; one-shot signature allows one update");
     }
-    final int expectedDigestLen = Utils.getMdLen(digest_);
-    if (len != expectedDigestLen) {
-      throw new SignatureException(
-          "Input must equal digest length. Expected " + expectedDigestLen + " bytes, got " + len);
+    if (paddingType_ == RSA_PKCS1_PSS_PADDING) {
+      final int expectedDigestLen = Utils.getMdLen(digest_);
+      if (len != expectedDigestLen) {
+        throw new SignatureException(
+            "Input must equal digest length. Expected " + expectedDigestLen + " bytes, got " + len);
+      }
     }
     buffer.write(b, off, len);
   }
@@ -105,15 +106,17 @@ class NoneWithRsa extends EvpSignatureBase {
       throw new RuntimeException(
           new SignatureException("Digest already provided; one-shot signature allows one update"));
     }
-    final int expectedDigestLen = Utils.getMdLen(digest_);
-    final int len = input.remaining();
-    if (len != expectedDigestLen) {
-      throw new RuntimeException(
-          new SignatureException(
-              "Input must equal digest length. Expected "
-                  + expectedDigestLen
-                  + " bytes, got "
-                  + len));
+    if (paddingType_ == RSA_PKCS1_PSS_PADDING) {
+      final int expectedDigestLen = Utils.getMdLen(digest_);
+      final int len = input.remaining();
+      if (len != expectedDigestLen) {
+        throw new RuntimeException(
+            new SignatureException(
+                "Input must equal digest length. Expected "
+                    + expectedDigestLen
+                    + " bytes, got "
+                    + len));
+      }
     }
     buffer.write(input);
   }
@@ -185,12 +188,6 @@ class NoneWithRsa extends EvpSignatureBase {
    * <p>For {@code NONEwithRSASSA-PSS}, delegates to {@link EvpSignatureBase} which fully validates
    * and applies all PSS parameters (digest, MGF, salt length, trailer).
    *
-   * <p>For {@code NONEwithRSA} (RSASSA-PKCS1-v1_5), accepts {@link PSSParameterSpec} but only
-   * extracts the digest algorithm name to determine the expected digest length and DigestInfo OID.
-   * The MGF, salt length, and trailer fields are ignored since they are PSS-specific and have no
-   * meaning for RSASSA-PKCS1-v1_5 signatures. This allows callers to use a uniform parameter
-   * interface across both padding modes.
-   *
    * @throws InvalidAlgorithmParameterException if the parameter type is not supported or the digest
    *     algorithm is unrecognized
    * @throws IllegalStateException if called while the buffer contains data
@@ -198,28 +195,26 @@ class NoneWithRsa extends EvpSignatureBase {
   @Override
   protected synchronized void engineSetParameter(final AlgorithmParameterSpec params)
       throws InvalidAlgorithmParameterException {
-    if (paddingType_ == RSA_PKCS1_PADDING) {
-      if (params instanceof PSSParameterSpec) {
-        // For PKCS#1 v1.5, accept PSSParameterSpec but only extract the digest algorithm.
-        // MGF, salt length, and trailer are ignored since they are PSS-specific.
-        final PSSParameterSpec pssParams = (PSSParameterSpec) params;
-        if (!isBufferEmpty()) {
-          throw new IllegalStateException(
-              "Cannot update parameters with buffered data, reset Signature.");
-        }
-        try {
-          digest_ = Utils.getMdPtr(pssParams.getDigestAlgorithm());
-        } catch (Exception e) {
-          throw new InvalidAlgorithmParameterException(
-              "Unsupported digest: " + pssParams.getDigestAlgorithm());
-        }
-      } else {
+    if (paddingType_ == RSA_PKCS1_PSS_PADDING) {
+      if (!(params instanceof PSSParameterSpec)) {
         throw new InvalidAlgorithmParameterException(
-            "Only PSSParameterSpec is accepted (to select digest algorithm)");
+            "Only PSSParameterSpec is accepted for NONEwithRSASSA-PSS");
       }
-    } else {
-      super.engineSetParameter(params);
+      if (!isBufferEmpty()) {
+        throw new IllegalStateException(
+            "Cannot update parameters with buffered data, reset Signature.");
+      }
+      final PSSParameterSpec pssParams = (PSSParameterSpec) params;
+      try {
+        digest_ = Utils.getMdPtr(pssParams.getDigestAlgorithm());
+      } catch (Exception e) {
+        throw new InvalidAlgorithmParameterException(
+            "Unsupported digest: " + pssParams.getDigestAlgorithm());
+      }
+      super.engineSetParameter(pssParams);
+      return;
     }
+    throw new UnsupportedOperationException("setParameter is not supported for NONEwithRSA");
   }
 
   @Override

--- a/src/com/amazon/corretto/crypto/provider/NoneWithRsa.java
+++ b/src/com/amazon/corretto/crypto/provider/NoneWithRsa.java
@@ -29,11 +29,11 @@ import java.security.spec.PSSParameterSpec;
  *       {@code RSASSA-PSS} when the same parameters and digest are used. Equivalent to
  *       BouncyCastle's {@code NONEwithRSASSA-PSS}.
  *   <li>{@code NONEwithRSA} -- Applies RSASSA-PKCS1-v1_5 padding (RFC 8017 Sec. 8.2) to the
- *       pre-hashed digest via {@code RSA_sign}/{@code RSA_verify}. The digest algorithm (which
- *       determines the DigestInfo OID and expected input length) defaults to SHA-256 and can be
- *       changed via {@link PSSParameterSpec} (only the digest algorithm field is used; MGF, salt
- *       length, and trailer are ignored). Interoperable with {@code SHA*withRSA} algorithms when
- *       the same digest is used.
+ *       caller-supplied bytes via {@code RSA_sign_raw}/{@code RSA_verify_raw}. Accepts any input up
+ *       to {@code rsaSize - 11} bytes (the PKCS#1 v1.5 padding overhead). No DigestInfo wrapping is
+ *       performed; the raw bytes are signed directly. {@code setParameter} is not supported (throws
+ *       {@code UnsupportedOperationException}). Interoperable with SunJCE and BouncyCastle {@code
+ *       NONEwithRSA} implementations.
  * </ul>
  *
  * @see <a href="https://datatracker.ietf.org/doc/html/rfc8017">RFC 8017: PKCS #1</a>
@@ -69,11 +69,12 @@ class NoneWithRsa extends EvpSignatureBase {
   /**
    * Provides the pre-computed message digest for signing or verification.
    *
-   * <p>This method must be called exactly once with the complete digest. The digest length must
-   * match the output length of the configured hash algorithm.
+   * <p>This method must be called exactly once. For {@code NONEwithRSASSA-PSS}, the input length
+   * must match the configured hash algorithm's output length. For {@code NONEwithRSA}, any length
+   * up to {@code rsaSize - 11} bytes is accepted.
    *
    * @throws SignatureException if called more than once before sign/verify, or if the provided data
-   *     does not match the expected digest length
+   *     does not match the expected digest length (PSS only)
    */
   @Override
   protected void engineUpdate(final byte[] b, final int off, final int len)
@@ -94,11 +95,12 @@ class NoneWithRsa extends EvpSignatureBase {
   /**
    * Provides the pre-computed message digest for signing or verification.
    *
-   * <p>This method must be called exactly once with the complete digest. The digest length must
-   * match the output length of the configured hash algorithm.
+   * <p>This method must be called exactly once. For {@code NONEwithRSASSA-PSS}, the input length
+   * must match the configured hash algorithm's output length. For {@code NONEwithRSA}, any length
+   * up to {@code rsaSize - 11} bytes is accepted.
    *
    * @throws RuntimeException wrapping a {@link SignatureException} if called more than once before
-   *     sign/verify, or if the provided data does not match the expected digest length
+   *     sign/verify, or if the provided data does not match the expected digest length (PSS only)
    */
   @Override
   protected void engineUpdate(final ByteBuffer input) {

--- a/tst/com/amazon/corretto/crypto/provider/test/NoneWithRsaTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/NoneWithRsaTest.java
@@ -26,6 +26,7 @@ import java.security.KeyPairGenerator;
 import java.security.MessageDigest;
 import java.security.Provider;
 import java.security.SecureRandom;
+import java.security.Security;
 import java.security.Signature;
 import java.security.SignatureException;
 import java.security.interfaces.RSAPublicKey;
@@ -35,7 +36,9 @@ import java.security.spec.PSSParameterSpec;
 import java.security.spec.RSAPublicKeySpec;
 import java.util.Arrays;
 import java.util.Iterator;
+import java.util.stream.Stream;
 import java.util.zip.GZIPInputStream;
+import javax.crypto.Cipher;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.parallel.Execution;
@@ -43,6 +46,7 @@ import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.api.parallel.ResourceAccessMode;
 import org.junit.jupiter.api.parallel.ResourceLock;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 @Execution(ExecutionMode.CONCURRENT)
@@ -1561,7 +1565,6 @@ public class NoneWithRsaTest {
   @Test
   public void testNoneWithRsaDifferentDigests() throws Exception {
     KeyPair kp = generateKeyPair(2048);
-    // SHA-224 not available in ACCP's MessageDigest, use default JCE
     String[] digestAlgs = {"SHA-1", "SHA-224", "SHA-256", "SHA-384", "SHA-512"};
 
     for (String digestAlg : digestAlgs) {
@@ -1569,9 +1572,6 @@ public class NoneWithRsaTest {
       byte[] digest = md.digest("test different digests".getBytes());
 
       Signature sig = Signature.getInstance("NONEwithRSA", ACCP);
-      PSSParameterSpec spec =
-          new PSSParameterSpec(digestAlg, "MGF1", MGF1ParameterSpec.SHA256, 32, 1);
-      sig.setParameter(spec);
       sig.initSign(kp.getPrivate());
       sig.update(digest);
       byte[] signature = sig.sign();
@@ -1604,17 +1604,28 @@ public class NoneWithRsaTest {
     KeyPair kp = generateKeyPair(2048);
 
     Signature sig = Signature.getInstance("NONEwithRSA", ACCP);
+
+    // Longer than default digest length (32) should succeed and round-trip
     sig.initSign(kp.getPrivate());
+    byte[] input33 = new byte[33];
+    new SecureRandom().nextBytes(input33);
+    sig.update(input33);
+    byte[] signature = sig.sign();
+    sig.initVerify(kp.getPublic());
+    sig.update(input33);
+    assertTrue(sig.verify(signature));
 
-    // Default is SHA-256 (32 bytes). Wrong lengths should fail.
-    // Too long - fails at update time
-    assertThrows(SignatureException.class, () -> sig.update(new byte[33]));
-
-    // Too short - fails at update time
+    // Shorter than default digest length should succeed and round-trip
     sig.initSign(kp.getPrivate());
-    assertThrows(SignatureException.class, () -> sig.update(new byte[16]));
+    byte[] input16 = new byte[16];
+    new SecureRandom().nextBytes(input16);
+    sig.update(input16);
+    signature = sig.sign();
+    sig.initVerify(kp.getPublic());
+    sig.update(input16);
+    assertTrue(sig.verify(signature));
 
-    // Empty - fails at sign time
+    // Empty - fails at sign time (no digest provided)
     sig.initSign(kp.getPrivate());
     assertThrows(SignatureException.class, sig::sign);
   }
@@ -1664,19 +1675,14 @@ public class NoneWithRsaTest {
   }
 
   @Test
-  public void testNoneWithRsaSetParams() throws Exception {
+  public void testNoneWithRsaSignSha512Digest() throws Exception {
     KeyPair kp = generateKeyPair(2048);
-
-    // Change digest to SHA-512 via PSSParameterSpec
-    Signature sig = Signature.getInstance("NONEwithRSA", ACCP);
-    PSSParameterSpec spec =
-        new PSSParameterSpec("SHA-512", "MGF1", MGF1ParameterSpec.SHA512, 64, 1);
-    sig.setParameter(spec);
 
     MessageDigest md = MessageDigest.getInstance("SHA-512", ACCP);
     byte[] digest = md.digest("set params test".getBytes());
     assertEquals(64, digest.length);
 
+    Signature sig = Signature.getInstance("NONEwithRSA", ACCP);
     sig.initSign(kp.getPrivate());
     sig.update(digest);
     byte[] signature = sig.sign();
@@ -1686,67 +1692,55 @@ public class NoneWithRsaTest {
     assertTrue(sig.verify(signature));
   }
 
-  @Test
-  public void testNoneWithRsaInteropWithSunRsaSign() throws Exception {
+  private static Stream<Provider> noneWithRsaInteropProviders() {
+    return Stream.of(Security.getProvider("SunJCE"), TestUtil.BC_PROVIDER);
+  }
+
+  @ParameterizedTest
+  @MethodSource("noneWithRsaInteropProviders")
+  public void testNoneWithRsaInteropWithOtherProviders(Provider other) throws Exception {
     KeyPair kp = generateKeyPair(2048);
-    byte[] message = "SunRsaSign interop test".getBytes();
+    byte[] message = "NONEwithRSA interop test".getBytes();
 
-    // Sign with ACCP NONEwithRSA (pre-hashed SHA-256), verify with SunRsaSign SHA256withRSA
-    MessageDigest md = MessageDigest.getInstance("SHA-256", ACCP);
-    byte[] digest = md.digest(message);
-
+    // Both providers sign the same message, signatures must be identical
     Signature accpSigner = Signature.getInstance("NONEwithRSA", ACCP);
     accpSigner.initSign(kp.getPrivate());
-    accpSigner.update(digest);
+    accpSigner.update(message);
     byte[] accpSig = accpSigner.sign();
 
-    Signature sunVerifier = Signature.getInstance("SHA256withRSA", "SunRsaSign");
-    sunVerifier.initVerify(kp.getPublic());
-    sunVerifier.update(message);
-    assertTrue(sunVerifier.verify(accpSig), "SunRsaSign should verify ACCP NONEwithRSA signature");
+    Signature otherSigner = Signature.getInstance("NONEwithRSA", other);
+    otherSigner.initSign(kp.getPrivate());
+    otherSigner.update(message);
+    byte[] otherSig = otherSigner.sign();
 
-    // Sign with SunRsaSign SHA256withRSA, verify with ACCP NONEwithRSA (pre-hashed SHA-256)
-    Signature sunSigner = Signature.getInstance("SHA256withRSA", "SunRsaSign");
-    sunSigner.initSign(kp.getPrivate());
-    sunSigner.update(message);
-    byte[] sunSig = sunSigner.sign();
+    assertTrue(
+        Arrays.equals(accpSig, otherSig),
+        other.getName() + " and ACCP should produce identical signatures");
 
+    // Cross-verify: other verifies ACCP signature
+    Signature otherVerifier = Signature.getInstance("NONEwithRSA", other);
+    otherVerifier.initVerify(kp.getPublic());
+    otherVerifier.update(message);
+    assertTrue(otherVerifier.verify(accpSig), other.getName() + " should verify ACCP signature");
+
+    // Cross-verify: ACCP verifies other's signature
     Signature accpVerifier = Signature.getInstance("NONEwithRSA", ACCP);
     accpVerifier.initVerify(kp.getPublic());
-    accpVerifier.update(digest);
-    assertTrue(accpVerifier.verify(sunSig), "ACCP NONEwithRSA should verify SunRsaSign signature");
+    accpVerifier.update(message);
+    assertTrue(
+        accpVerifier.verify(otherSig), "ACCP should verify " + other.getName() + " signature");
   }
 
   @Test
-  public void testNoneWithRsaInteropWithBouncyCastle() throws Exception {
-    final Provider BC = TestUtil.BC_PROVIDER;
-    KeyPair kp = generateKeyPair(2048);
-    byte[] message = "BouncyCastle interop test".getBytes();
-
-    // Sign with ACCP NONEwithRSA (pre-hashed SHA-256), verify with BC SHA256withRSA
-    MessageDigest md = MessageDigest.getInstance("SHA-256", ACCP);
-    byte[] digest = md.digest(message);
-
-    Signature accpSigner = Signature.getInstance("NONEwithRSA", ACCP);
-    accpSigner.initSign(kp.getPrivate());
-    accpSigner.update(digest);
-    byte[] accpSig = accpSigner.sign();
-
-    Signature bcVerifier = Signature.getInstance("SHA256withRSA", BC);
-    bcVerifier.initVerify(kp.getPublic());
-    bcVerifier.update(message);
-    assertTrue(bcVerifier.verify(accpSig), "BC should verify ACCP NONEwithRSA signature");
-
-    // Sign with BC SHA256withRSA, verify with ACCP NONEwithRSA (pre-hashed SHA-256)
-    Signature bcSigner = Signature.getInstance("SHA256withRSA", BC);
-    bcSigner.initSign(kp.getPrivate());
-    bcSigner.update(message);
-    byte[] bcSig = bcSigner.sign();
-
-    Signature accpVerifier = Signature.getInstance("NONEwithRSA", ACCP);
-    accpVerifier.initVerify(kp.getPublic());
-    accpVerifier.update(digest);
-    assertTrue(accpVerifier.verify(bcSig), "ACCP NONEwithRSA should verify BC signature");
+  public void testNoneWithRsaSetParameterThrowsCompat() throws Exception {
+    PSSParameterSpec spec =
+        new PSSParameterSpec("SHA-512", "MGF1", MGF1ParameterSpec.SHA512, 64, 1);
+    final Signature sunSigner = Signature.getInstance("NONEwithRSA", "SunJCE");
+    assertThrows(UnsupportedOperationException.class, () -> sunSigner.setParameter(spec));
+    final Signature bcSigner = Signature.getInstance("NONEwithRSA", TestUtil.BC_PROVIDER);
+    assertThrows(UnsupportedOperationException.class, () -> bcSigner.setParameter(spec));
+    final Signature accpSigner = Signature.getInstance("NONEwithRSA", ACCP);
+    assertThrows(UnsupportedOperationException.class, () -> accpSigner.setParameter(spec));
   }
 
   @Test
@@ -1757,27 +1751,56 @@ public class NoneWithRsaTest {
     MessageDigest md = MessageDigest.getInstance("SHA-256", ACCP);
     byte[] digest = md.digest(message);
 
-    // Sign with ACCP NONEwithRSA, verify with ACCP SHA256withRSA
-    Signature signer = Signature.getInstance("NONEwithRSA", ACCP);
-    signer.initSign(kp.getPrivate());
-    signer.update(digest);
-    byte[] sig1 = signer.sign();
+    // Sign raw digest with NONEwithRSA (no DigestInfo wrapping)
+    Signature noneSigner = Signature.getInstance("NONEwithRSA", ACCP);
+    noneSigner.initSign(kp.getPrivate());
+    noneSigner.update(digest);
+    byte[] noneSig = noneSigner.sign();
 
-    Signature verifier = Signature.getInstance("SHA256withRSA", ACCP);
-    verifier.initVerify(kp.getPublic());
-    verifier.update(message);
-    assertTrue(verifier.verify(sig1), "SHA256withRSA should verify NONEwithRSA signature");
+    // Sign message with SHA256withRSA (hashes internally, wraps digest in DigestInfo)
+    Signature sha256Signer = Signature.getInstance("SHA256withRSA", ACCP);
+    sha256Signer.initSign(kp.getPrivate());
+    sha256Signer.update(message);
+    byte[] sha256Sig = sha256Signer.sign();
 
-    // Sign with ACCP SHA256withRSA, verify with ACCP NONEwithRSA
-    signer = Signature.getInstance("SHA256withRSA", ACCP);
-    signer.initSign(kp.getPrivate());
-    signer.update(message);
-    byte[] sig2 = signer.sign();
+    // Signatures differ because SHA256withRSA wraps the digest in a DigestInfo struct
+    assertFalse(Arrays.equals(noneSig, sha256Sig));
 
-    verifier = Signature.getInstance("NONEwithRSA", ACCP);
-    verifier.initVerify(kp.getPublic());
-    verifier.update(digest);
-    assertTrue(verifier.verify(sig2), "NONEwithRSA should verify SHA256withRSA signature");
+    // Cross-verification should fail
+    Signature sha256Verifier = Signature.getInstance("SHA256withRSA", ACCP);
+    sha256Verifier.initVerify(kp.getPublic());
+    sha256Verifier.update(message);
+    assertFalse(
+        sha256Verifier.verify(noneSig),
+        "SHA256withRSA should NOT verify NONEwithRSA signature (no DigestInfo)");
+
+    Signature noneVerifier = Signature.getInstance("NONEwithRSA", ACCP);
+    noneVerifier.initVerify(kp.getPublic());
+    noneVerifier.update(digest);
+    assertFalse(
+        noneVerifier.verify(sha256Sig),
+        "NONEwithRSA should NOT verify SHA256withRSA signature (has DigestInfo)");
+
+    // However, the underlying signed content shares the same digest bytes.
+    // Decrypt both signatures with raw RSA to recover plaintext, padding stripped.
+    Cipher rsa = Cipher.getInstance("RSA/ECB/PKCS1Padding", ACCP);
+    rsa.init(Cipher.DECRYPT_MODE, kp.getPublic());
+    byte[] nonePlain = rsa.doFinal(noneSig);
+    assertEquals(digest.length, nonePlain.length); // raw SHA-256 digest, 32 bytes
+    rsa.init(Cipher.DECRYPT_MODE, kp.getPublic());
+    byte[] sha256Plain = rsa.doFinal(sha256Sig);
+    assertEquals(digest.length + 19, sha256Plain.length); // +19 bytes for DigestInfo DER
+
+    // The SHA256withRSA plaintext ends with the same 32-byte digest as the NONEwithRSA plaintext
+    byte[] noneDigest =
+        Arrays.copyOfRange(nonePlain, nonePlain.length - digest.length, nonePlain.length);
+    byte[] sha256Digest =
+        Arrays.copyOfRange(sha256Plain, sha256Plain.length - digest.length, sha256Plain.length);
+    assertTrue(
+        Arrays.equals(noneDigest, sha256Digest),
+        "Last 32 bytes (the digest) should be identical in both plaintexts");
+    assertTrue(
+        Arrays.equals(digest, noneDigest), "Digest bytes should equal the original SHA-256 digest");
   }
 
   @Test
@@ -1794,14 +1817,54 @@ public class NoneWithRsaTest {
   }
 
   @Test
-  public void testNoneWithRsaSetParameterRejectsNonPssSpec() throws Exception {
+  public void testMessageLargerThanModulusThrows() throws Exception {
+    final int keyBits = 4096;
+    KeyPair kp = generateKeyPair(keyBits);
+    // NOTE: PKCS1 padding is 11 bytes for NONEwithRSA's raw signature
+    byte[] goodMsg = new byte[keyBits / 8 - 11];
+    byte[] badMsg = new byte[keyBits / 8 - 10];
+    new SecureRandom().nextBytes(goodMsg);
+    new SecureRandom().nextBytes(badMsg);
+
+    // ACCP: message size of modulus OK
+    Signature accpSig = Signature.getInstance("NONEwithRSA", ACCP);
+    accpSig.initSign(kp.getPrivate());
+    accpSig.update(goodMsg);
+    accpSig.sign();
+
+    // SunJCE: message size of modulus OK
+    Signature sunSig = Signature.getInstance("NONEwithRSA", "SunJCE");
+    sunSig.initSign(kp.getPrivate());
+    sunSig.update(goodMsg);
+    sunSig.sign();
+
+    // ACCP: accepts update() but rejects at sign(); data too large for key size
+    accpSig = Signature.getInstance("NONEwithRSA", ACCP);
+    accpSig.initSign(kp.getPrivate());
+    accpSig.update(badMsg);
+    assertThrows(SignatureException.class, accpSig::sign);
+
+    // SunJCE: accepts update() but rejects at sign(); data too large for key size
+    sunSig = Signature.getInstance("NONEwithRSA", "SunJCE");
+    sunSig.initSign(kp.getPrivate());
+    sunSig.update(badMsg);
+    assertThrows(SignatureException.class, sunSig::sign);
+  }
+
+  @Test
+  public void testNoneWithRsaSetParameterRejectsAllSpecs() throws Exception {
     Signature sig = Signature.getInstance("NONEwithRSA", ACCP);
 
-    // Non-PSSParameterSpec should be rejected
-    assertThrows(InvalidAlgorithmParameterException.class, () -> sig.setParameter(null));
+    // All setParameter calls should be rejected for NONEwithRSA
+    assertThrows(UnsupportedOperationException.class, () -> sig.setParameter(null));
     assertThrows(
-        InvalidAlgorithmParameterException.class,
+        UnsupportedOperationException.class,
         () -> sig.setParameter(new ECGenParameterSpec("secp256r1")));
+    assertThrows(
+        UnsupportedOperationException.class,
+        () ->
+            sig.setParameter(
+                new PSSParameterSpec("SHA-256", "MGF1", MGF1ParameterSpec.SHA256, 32, 1)));
   }
 
   @Test
@@ -1810,12 +1873,12 @@ public class NoneWithRsaTest {
 
     Signature sig = Signature.getInstance("NONEwithRSA", ACCP);
     sig.initSign(kp.getPrivate());
-    sig.update(new byte[32]); // buffer the default SHA-256 digest
+    sig.update(new byte[32]);
 
-    // Changing parameters with buffered data should throw
+    // setParameter is always rejected for NONEwithRSA, regardless of buffer state
     PSSParameterSpec spec =
         new PSSParameterSpec("SHA-512", "MGF1", MGF1ParameterSpec.SHA512, 64, 1);
-    assertThrows(IllegalStateException.class, () -> sig.setParameter(spec));
+    assertThrows(UnsupportedOperationException.class, () -> sig.setParameter(spec));
   }
 
   @Test


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*

# Summary

Our initial implementation of `NONEwithRSA` is compatible with hash-based signature implementations (e.g. `SHA256withRSA`) from JDK-default and BC implementations, but is incompatible with those providers' respective `NONEwithRSA` implementations in two important ways:

1. serialized/expected signatures wrapped in a `DigestInfo` DER structure rather than raw signature bytes
2. strict length input message length validation against configured digest algorithm, defaulting to SHA256

This change aligns behavior with SunJCE and BC providers, adding tests asserting that.

This issue initially surfaced via an internal integration test failure failing to negotiate TLSv1.0, the JSSE implementation of which relied on `NONEwithRSA` for its underlying cryptography. I posted an [internal CR](https://code.amazon.com/reviews/CR-268688190/) confirming the efficacy of this fix.

# Source changes

## sign.cpp

- PKCS1 sign path now uses `RSA_sign_raw` instead of `RSA_sign` signs raw bytes directly without `DigestInfo` wrapping
- PKCS1 verify path now uses `RSA_verify_raw` + `CRYPTO_memcmp` instead of `RSA_verify` compares raw bytes directly w/o `DigestInfo` DER wrapper
- Digest-length validation (`length != hLen`) moved from shared top-level check into PSS-only branch
- New top-level guard rejects input larger than `RSA_size - 11` (11 bytes PKCS1 padding overhead)

## NoneWithRsa.java

- Buffer changed from fixed 64-byte capacity to unbounded (new `AccessibleByteArrayOutputStream()`)
- `engineUpdate`: digest-length enforcement now conditional on `paddingType == RSA_PKCS1_PSS_PADDING`; PKCS1 accepts any message length small enough for RSA modulus
- `engineSetParameter`: throws `UnsupportedOperationException for `NONEwithRSA (matching SunJCE/BC); PSS path validates PSSParameterSpec and returns before the throw

# Test changes

## New tests

- `testMessageLargerThanModulusThrows` asserts `keySize/8 - 11` bytes (msg just small enough w/ padding) succeeds and `keySize/8 - 10` bytes (too large w/ padding) fails for both ACCP and SunJCE
- `testNoneWithRsaSetParameterThrowsCompat` confirms SunJCE, BC, and ACCP all throw `UnsupportedOperationException` on setParameter

## Modified tests

- `testNoneWithRsaInputValidation` now asserts arbitrary-length inputs (16, 33 bytes. much smaller than key modulus size.) sign and verify successfully
- `testNoneWithRsaDifferentDigests` / `testNoneWithRsaSignSha512Digest` removed `setParameter` calls; sign raw digests directly
- `testNoneWithRsaInteropWithSunRsaSign` and `testNoneWithRsaInteropWithBouncyCastle` refactored into single parameterized `testNoneWithRsaInteropWithOtherProviders` testing ACCP SunJCE/BC cross-verification
- `testNoneWithRsaCrossAlgorithmInterop` now asserts NONEwithRSA and SHA256withRSA are NOT interoperable (`DigestInfo` mismatch), but the trailing 32 digest bytes in the decrypted plaintext are identical
- `testNoneWithRsaSetParameterRejectsAllSpecs` updated to expect `UnsupportedOperationException` for all param types including `PSSParameterSpec`
- `testNoneWithRsaSetParameterWithBufferedData` updated to expect `UnsupportedOperationException` regardless of buffer state


---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
