### PR TITLE
Add/Refactor error path tests for NONEwith*

### DIFF
--- a/DIFFERENCES.md
+++ b/DIFFERENCES.md
@@ -76,10 +76,8 @@ Any time an instance of `SecureRandom` is used, ACCP routes the requests to the 
 Because the output of calls to `SecureRandom` is computationally indistinguishable from actual random data, this implementation detail has no impact on callers other than improving performance.
 
 ## NONEwithRSA pre-hashed signature
-ACCP's `NONEwithRSA` implements RSASSA-PKCS1-v1_5 (RFC 8017 Sec. 8.2) as a **pre-hashed, one-shot** signature algorithm. This differs from Sun and BouncyCastle's `NONEwithRSA` in several ways:
+ACCP's NONEwithRSA differs from Sun and BouncyCastle's `NONEwithRSA` in the following ways:
 
-- **Pre-hashed input only.** ACCP's `NONEwithRSA` expects a message digest (exactly matching the configured hash algorithm's output length) rather than arbitrary-length data. The caller must hash the message externally before calling `Signature.update()`.
-- **Digest algorithm selection via `PSSParameterSpec`.** The digest algorithm (which is only used to configure expected input length) defaults to SHA-256 and can be changed by calling `Signature.setParameter()` with a `PSSParameterSpec`. Only the digest algorithm field is used; the MGF, salt length, and trailer fields are ignored since they are PSS-specific. This differs from other providers where arbitrary input length is allowed. ACCP only supports "pre-hash" usages of `NONEwithRSA`, so restricts input length to digest length.
 - **One-shot semantics.** The complete digest must be provided in a single `update()` call. Byte-by-byte and incremental updates are not supported. Calling `update(byte)` always throws `SignatureException`.
 
 ## RSASSA-PSS Signature parameters may not be updated in-flight

--- a/csrc/sign.cpp
+++ b/csrc/sign.cpp
@@ -687,18 +687,19 @@ JNIEXPORT jbyteArray JNICALL Java_com_amazon_corretto_crypto_provider_NoneWithRs
                     throw_java_ex(EX_SIGNATURE_EXCEPTION, "Digest length mismatch");
                 }
                 const EVP_MD* mgf_md = reinterpret_cast<const EVP_MD*>(mgfMd);
-                if (RSA_sign_pss_mgf1(rsa, &sigLen, signature.data(), rsaSize, digest.data(), length, md, mgf_md, saltLen)
+                if (RSA_sign_pss_mgf1(
+                        rsa, &sigLen, signature.data(), rsaSize, digest.data(), length, md, mgf_md, saltLen)
                     != 1) {
                     throw_openssl("RSA_sign_pss_mgf1 failed");
                 }
                 break;
             }
             case RSA_PKCS1_PADDING: {
-                if ((size_t)length > (rsaSize - 11)) {  // PKCS1 padding is 11 bytes for raw NONEwithRSA
+                if ((size_t)length > (rsaSize - 11)) { // PKCS1 padding is 11 bytes for raw NONEwithRSA
                     throw_java_ex(EX_SIGNATURE_EXCEPTION, "Message too long for RSA key");
                 }
-                int rc = RSA_sign_raw(rsa, &sigLen, signature.data(), rsaSize,
-                    digest.data(), length, RSA_PKCS1_PADDING);
+                int rc
+                    = RSA_sign_raw(rsa, &sigLen, signature.data(), rsaSize, digest.data(), length, RSA_PKCS1_PADDING);
                 if (rc != 1) {
                     throw_openssl("RSA_sign_raw failed");
                 }
@@ -770,8 +771,7 @@ JNIEXPORT jboolean JNICALL Java_com_amazon_corretto_crypto_provider_NoneWithRsa_
             size_t outLen = 0;
             std::vector<uint8_t> buf(RSA_size(rsa));
             if (1 != RSA_verify_raw(rsa, &outLen, buf.data(), buf.size(), sig.data(), sig.len(), RSA_PKCS1_PADDING)
-                || (size_t)length != outLen
-                || 0 != CRYPTO_memcmp(buf.data(), digest.data(), outLen)) {
+                || (size_t)length != outLen || 0 != CRYPTO_memcmp(buf.data(), digest.data(), outLen)) {
                 break; // result stays 0
             }
             result = 1;

--- a/src/com/amazon/corretto/crypto/provider/NoneWithRsa.java
+++ b/src/com/amazon/corretto/crypto/provider/NoneWithRsa.java
@@ -43,12 +43,9 @@ class NoneWithRsa extends EvpSignatureBase {
   private final AccessibleByteArrayOutputStream buffer = new AccessibleByteArrayOutputStream();
 
   protected NoneWithRsa(final AmazonCorrettoCryptoProvider provider, final int paddingType) {
-    super(provider, EvpKeyType.RSA, paddingType, 0, false);
-  }
-
-  protected NoneWithRsa(
-      final AmazonCorrettoCryptoProvider provider, final int paddingType, final long digest) {
-    super(provider, EvpKeyType.RSA, paddingType, digest, false);
+    // For PSS, digest_ is set to JDK default in EvpSignatureBase. For Pkcs15, digest_
+    // is not needed. So, use ptr value of 0 in both cases.
+    super(provider, EvpKeyType.RSA, paddingType, /*digest*/ 0L, /*preHash*/ false);
   }
 
   @Override
@@ -259,7 +256,7 @@ class NoneWithRsa extends EvpSignatureBase {
 
   static final class Pkcs15 extends NoneWithRsa {
     Pkcs15(final AmazonCorrettoCryptoProvider provider) {
-      super(provider, RSA_PKCS1_PADDING, Utils.getMdPtr("SHA-256"));
+      super(provider, RSA_PKCS1_PADDING);
     }
   }
 }

--- a/tst/com/amazon/corretto/crypto/provider/test/EdDSATest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/EdDSATest.java
@@ -685,6 +685,105 @@ public class EdDSATest {
     }
   }
 
+  @Test
+  public void ed25519CorruptSignature() throws GeneralSecurityException {
+    corruptSignatureTests("Ed25519", false);
+  }
+
+  @Test
+  public void ed25519phCorruptSignature() throws GeneralSecurityException {
+    assumeTrue(ed25519phIsEnabled());
+    corruptSignatureTests("Ed25519ph", false);
+  }
+
+  @Test
+  public void noneWithEd25519phCorruptSignature() throws GeneralSecurityException {
+    assumeTrue(ed25519phIsEnabled());
+    corruptSignatureTests("NONEwithEd25519ph", true);
+  }
+
+  private void corruptSignatureTests(String algorithm, boolean preHashInput)
+      throws GeneralSecurityException {
+    final KeyPair kp = nativeGen.generateKeyPair();
+    final MessageDigest sha512 = MessageDigest.getInstance("SHA-512");
+    final Signature sig = Signature.getInstance(algorithm, NATIVE_PROVIDER);
+    final byte[] message = new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+    final byte[] input = preHashInput ? sha512.digest(message) : message;
+
+    sig.initSign(kp.getPrivate());
+    sig.update(input);
+    final byte[] validSig = sig.sign();
+    assertEquals(SHA512_DIGEST_BYTES, validSig.length);
+
+    // Sanity check: valid signature verifies
+    sig.initVerify(kp.getPublic());
+    sig.update(input);
+    assertTrue(sig.verify(validSig), algorithm + ": valid signature must verify");
+
+    // All zeroes
+    assertSigRejected(
+        sig, kp.getPublic(), input, new byte[SHA512_DIGEST_BYTES], algorithm + ": all-zeroes");
+
+    // All 0xFF
+    byte[] allOnes = new byte[SHA512_DIGEST_BYTES];
+    Arrays.fill(allOnes, (byte) 0xFF);
+    assertSigRejected(sig, kp.getPublic(), input, allOnes, algorithm + ": all-0xFF");
+
+    // Truncated (32 bytes)
+    assertSigRejected(
+        sig,
+        kp.getPublic(),
+        input,
+        Arrays.copyOf(validSig, 32),
+        algorithm + ": truncated to 32 bytes");
+
+    // Truncated (1 byte short)
+    assertSigRejected(
+        sig,
+        kp.getPublic(),
+        input,
+        Arrays.copyOf(validSig, 63),
+        algorithm + ": truncated by 1 byte");
+
+    // Oversized (65 bytes)
+    byte[] oversized = Arrays.copyOf(validSig, 65);
+    assertSigRejected(sig, kp.getPublic(), input, oversized, algorithm + ": oversized by 1 byte");
+
+    // Oversized (128 bytes)
+    byte[] way_oversized = Arrays.copyOf(validSig, 128);
+    assertSigRejected(
+        sig, kp.getPublic(), input, way_oversized, algorithm + ": oversized to 128 bytes");
+
+    // Empty
+    assertSigRejected(sig, kp.getPublic(), input, new byte[0], algorithm + ": empty");
+
+    // Flip each bit of the first byte
+    for (int bit = 0; bit < 8; bit++) {
+      byte[] flipped = validSig.clone();
+      flipped[0] ^= (1 << bit);
+      assertSigRejected(
+          sig, kp.getPublic(), input, flipped, algorithm + ": flip bit " + bit + " of byte 0");
+    }
+
+    // Flip single bit in the last byte
+    byte[] flippedLast = validSig.clone();
+    flippedLast[63] ^= 1;
+    assertSigRejected(
+        sig, kp.getPublic(), input, flippedLast, algorithm + ": flip bit 0 of last byte");
+  }
+
+  private static void assertSigRejected(
+      Signature sig, PublicKey pub, byte[] input, byte[] badSig, String label)
+      throws GeneralSecurityException {
+    sig.initVerify(pub);
+    sig.update(input);
+    try {
+      assertFalse(sig.verify(badSig), label);
+    } catch (SignatureException e) {
+      // JCA allows throwing SignatureException for malformed signatures
+    }
+  }
+
   private static void makeJceSignaturePh(Signature sig) {
     assertTrue(ed25519phIsEnabled());
     AlgorithmParameterSpec paramSpec = null;

--- a/tst/com/amazon/corretto/crypto/provider/test/NoneWithRsaTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/NoneWithRsaTest.java
@@ -212,29 +212,6 @@ public class NoneWithRsaTest {
   }
 
   @Test
-  public void testInvalidSignature() throws Exception {
-    KeyPair kp = generateKeyPair(2048);
-    MessageDigest md = MessageDigest.getInstance("SHA-256", ACCP);
-    byte[] digest = md.digest("test".getBytes());
-
-    Signature sig = Signature.getInstance("NONEwithRSASSA-PSS", ACCP);
-    PSSParameterSpec spec =
-        new PSSParameterSpec("SHA-256", "MGF1", MGF1ParameterSpec.SHA256, 32, 1);
-    sig.setParameter(spec);
-    sig.initSign(kp.getPrivate());
-    sig.update(digest);
-    byte[] signature = sig.sign();
-
-    // Corrupt the signature
-    signature[0] ^= 0xFF;
-
-    sig.initVerify(kp.getPublic());
-    sig.setParameter(spec);
-    sig.update(digest);
-    assertFalse(sig.verify(signature));
-  }
-
-  @Test
   public void testWrongDigest() throws Exception {
     KeyPair kp = generateKeyPair(2048);
     MessageDigest md = MessageDigest.getInstance("SHA-256", ACCP);
@@ -694,98 +671,109 @@ public class NoneWithRsaTest {
     assertThrows(InvalidKeyException.class, () -> sig.initVerify(ecKp.getPublic()));
   }
 
-  @Test
-  public void testVerifyAllZerosSignature() throws Exception {
-    KeyPair kp = generateKeyPair(2048);
-    MessageDigest md = MessageDigest.getInstance("SHA-256", ACCP);
-    byte[] digest = md.digest("test".getBytes());
+  // --- Unified bad-signature tests for both NONEwithRSA and NONEwithRSASSA-PSS ---
 
-    Signature sig = Signature.getInstance("NONEwithRSASSA-PSS", ACCP);
-    PSSParameterSpec spec =
-        new PSSParameterSpec("SHA-256", "MGF1", MGF1ParameterSpec.SHA256, 32, 1);
-    sig.setParameter(spec);
-    sig.initVerify(kp.getPublic());
-    sig.update(digest);
-
-    // All zeros signature should fail verification
-    byte[] zeroSig = new byte[256]; // 2048-bit key = 256-byte signature
-    assertFalse(sig.verify(zeroSig));
+  private static Stream<String> badSignatureAlgorithms() {
+    return Stream.of("NONEwithRSA", "NONEwithRSASSA-PSS");
   }
 
-  @Test
-  public void testVerifyTruncatedSignature() throws Exception {
-    KeyPair kp = generateKeyPair(2048);
-    MessageDigest md = MessageDigest.getInstance("SHA-256", ACCP);
-    byte[] digest = md.digest("test".getBytes());
-
-    Signature sig = Signature.getInstance("NONEwithRSASSA-PSS", ACCP);
-    PSSParameterSpec spec =
-        new PSSParameterSpec("SHA-256", "MGF1", MGF1ParameterSpec.SHA256, 32, 1);
-    sig.setParameter(spec);
-
-    // Create valid signature
+  private Signature initSignerForAlgorithm(String algorithm, KeyPair kp) throws Exception {
+    Signature sig = Signature.getInstance(algorithm, ACCP);
+    if (algorithm.equals("NONEwithRSASSA-PSS")) {
+      sig.setParameter(new PSSParameterSpec("SHA-256", "MGF1", MGF1ParameterSpec.SHA256, 32, 1));
+    }
     sig.initSign(kp.getPrivate());
-    sig.update(digest);
-    byte[] signature = sig.sign();
-
-    // Truncated signature should throw (sniffTest checks length matches key size)
-    byte[] truncated = new byte[signature.length / 2];
-    System.arraycopy(signature, 0, truncated, 0, truncated.length);
-
-    sig.initVerify(kp.getPublic());
-    sig.update(digest);
-    assertThrows(SignatureException.class, () -> sig.verify(truncated));
+    return sig;
   }
 
-  @Test
-  public void testVerifyOversizedSignature() throws Exception {
-    KeyPair kp = generateKeyPair(2048);
-    MessageDigest md = MessageDigest.getInstance("SHA-256", ACCP);
-    byte[] digest = md.digest("test".getBytes());
-
-    Signature sig = Signature.getInstance("NONEwithRSASSA-PSS", ACCP);
-    PSSParameterSpec spec =
-        new PSSParameterSpec("SHA-256", "MGF1", MGF1ParameterSpec.SHA256, 32, 1);
-    sig.setParameter(spec);
-
-    // Create valid signature
-    sig.initSign(kp.getPrivate());
-    sig.update(digest);
-    byte[] signature = sig.sign();
-
-    // Oversized signature should throw (sniffTest checks length matches key size)
-    byte[] oversized = new byte[signature.length + 1];
-    System.arraycopy(signature, 0, oversized, 0, signature.length);
-
+  private Signature initVerifierForAlgorithm(String algorithm, KeyPair kp) throws Exception {
+    Signature sig = Signature.getInstance(algorithm, ACCP);
+    if (algorithm.equals("NONEwithRSASSA-PSS")) {
+      sig.setParameter(new PSSParameterSpec("SHA-256", "MGF1", MGF1ParameterSpec.SHA256, 32, 1));
+    }
     sig.initVerify(kp.getPublic());
-    sig.update(digest);
-    assertThrows(SignatureException.class, () -> sig.verify(oversized));
+    return sig;
   }
 
-  @Test
-  public void testCorruptedSignatureAtVariousPositions() throws Exception {
+  private byte[] signDigest(String algorithm, KeyPair kp, byte[] digest) throws Exception {
+    Signature sig = initSignerForAlgorithm(algorithm, kp);
+    sig.update(digest);
+    return sig.sign();
+  }
+
+  @ParameterizedTest
+  @MethodSource("badSignatureAlgorithms")
+  public void testVerifyCorruptedSignatureAtVariousPositions(String algorithm) throws Exception {
     KeyPair kp = generateKeyPair(2048);
     MessageDigest md = MessageDigest.getInstance("SHA-256", ACCP);
     byte[] digest = md.digest("test".getBytes());
+    byte[] signature = signDigest(algorithm, kp, digest);
 
-    Signature sig = Signature.getInstance("NONEwithRSASSA-PSS", ACCP);
-    PSSParameterSpec spec =
-        new PSSParameterSpec("SHA-256", "MGF1", MGF1ParameterSpec.SHA256, 32, 1);
-    sig.setParameter(spec);
-    sig.initSign(kp.getPrivate());
-    sig.update(digest);
-    byte[] signature = sig.sign();
-
-    // Corrupt at first, middle, and last positions
     int[] positions = {0, signature.length / 4, signature.length / 2, signature.length - 1};
     for (int pos : positions) {
       byte[] corrupted = signature.clone();
       corrupted[pos] ^= 0xFF;
 
-      sig.initVerify(kp.getPublic());
-      sig.update(digest);
-      assertFalse(sig.verify(corrupted), "Should fail at corrupted position " + pos);
+      Signature verifier = initVerifierForAlgorithm(algorithm, kp);
+      verifier.update(digest);
+      assertFalse(
+          verifier.verify(corrupted), algorithm + " should fail at corrupted position " + pos);
     }
+  }
+
+  @ParameterizedTest
+  @MethodSource("badSignatureAlgorithms")
+  public void testVerifyTruncatedSignature(String algorithm) throws Exception {
+    KeyPair kp = generateKeyPair(2048);
+    MessageDigest md = MessageDigest.getInstance("SHA-256", ACCP);
+    byte[] digest = md.digest("test".getBytes());
+    byte[] signature = signDigest(algorithm, kp, digest);
+
+    byte[] truncated = Arrays.copyOf(signature, signature.length / 2);
+    Signature verifier = initVerifierForAlgorithm(algorithm, kp);
+    verifier.update(digest);
+    assertThrows(SignatureException.class, () -> verifier.verify(truncated));
+  }
+
+  @ParameterizedTest
+  @MethodSource("badSignatureAlgorithms")
+  public void testVerifyOversizedSignature(String algorithm) throws Exception {
+    KeyPair kp = generateKeyPair(2048);
+    MessageDigest md = MessageDigest.getInstance("SHA-256", ACCP);
+    byte[] digest = md.digest("test".getBytes());
+    byte[] signature = signDigest(algorithm, kp, digest);
+
+    byte[] oversized = new byte[signature.length + 1];
+    System.arraycopy(signature, 0, oversized, 0, signature.length);
+    Signature verifier = initVerifierForAlgorithm(algorithm, kp);
+    verifier.update(digest);
+    assertThrows(SignatureException.class, () -> verifier.verify(oversized));
+  }
+
+  @ParameterizedTest
+  @MethodSource("badSignatureAlgorithms")
+  public void testVerifyAllZerosSignature(String algorithm) throws Exception {
+    KeyPair kp = generateKeyPair(2048);
+    MessageDigest md = MessageDigest.getInstance("SHA-256", ACCP);
+    byte[] digest = md.digest("test".getBytes());
+
+    Signature verifier = initVerifierForAlgorithm(algorithm, kp);
+    verifier.update(digest);
+    assertFalse(verifier.verify(new byte[256]));
+  }
+
+  @ParameterizedTest
+  @MethodSource("badSignatureAlgorithms")
+  public void testVerifyRandomGarbage(String algorithm) throws Exception {
+    KeyPair kp = generateKeyPair(2048);
+    MessageDigest md = MessageDigest.getInstance("SHA-256", ACCP);
+    byte[] digest = md.digest("test".getBytes());
+
+    byte[] garbage = new byte[256];
+    new SecureRandom().nextBytes(garbage);
+    Signature verifier = initVerifierForAlgorithm(algorithm, kp);
+    verifier.update(digest);
+    assertFalse(verifier.verify(garbage));
   }
 
   @Test
@@ -1139,25 +1127,6 @@ public class NoneWithRsaTest {
         () ->
             sig.setParameter(
                 new PSSParameterSpec("SHA-512", "MGF1", MGF1ParameterSpec.SHA512, 191, 1)));
-  }
-
-  @Test
-  public void testVerifyWithRandomGarbage() throws Exception {
-    KeyPair kp = generateKeyPair(2048);
-    MessageDigest md = MessageDigest.getInstance("SHA-256", ACCP);
-    byte[] digest = md.digest("test".getBytes());
-
-    Signature sig = Signature.getInstance("NONEwithRSASSA-PSS", ACCP);
-    PSSParameterSpec spec =
-        new PSSParameterSpec("SHA-256", "MGF1", MGF1ParameterSpec.SHA256, 32, 1);
-    sig.setParameter(spec);
-    sig.initVerify(kp.getPublic());
-
-    // Random garbage bytes as signature
-    byte[] garbage = new byte[256];
-    new SecureRandom().nextBytes(garbage);
-    sig.update(digest);
-    assertFalse(sig.verify(garbage));
   }
 
   @Test
@@ -1628,29 +1597,6 @@ public class NoneWithRsaTest {
     // Empty - fails at sign time (no digest provided)
     sig.initSign(kp.getPrivate());
     assertThrows(SignatureException.class, sig::sign);
-  }
-
-  @Test
-  public void testNoneWithRsaCorruptedSignature() throws Exception {
-    KeyPair kp = generateKeyPair(2048);
-    MessageDigest md = MessageDigest.getInstance("SHA-256", ACCP);
-    byte[] digest = md.digest("test".getBytes());
-
-    Signature sig = Signature.getInstance("NONEwithRSA", ACCP);
-    sig.initSign(kp.getPrivate());
-    sig.update(digest);
-    byte[] signature = sig.sign();
-
-    // Corrupt at various positions
-    int[] positions = {0, signature.length / 4, signature.length / 2, signature.length - 1};
-    for (int pos : positions) {
-      byte[] corrupted = signature.clone();
-      corrupted[pos] ^= 0xFF;
-
-      sig.initVerify(kp.getPublic());
-      sig.update(digest);
-      assertFalse(sig.verify(corrupted), "Should fail at corrupted position " + pos);
-    }
   }
 
   @Test

--- a/tst/com/amazon/corretto/crypto/provider/test/NoneWithRsaTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/NoneWithRsaTest.java
@@ -20,6 +20,7 @@ import java.security.AlgorithmParameters;
 import java.security.GeneralSecurityException;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
+import java.security.InvalidParameterException;
 import java.security.KeyFactory;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
@@ -1543,7 +1544,20 @@ public class NoneWithRsaTest {
     PSSParameterSpec spec =
         new PSSParameterSpec("SHA-512", "MGF1", MGF1ParameterSpec.SHA512, 64, 1);
     final Signature sunSigner = Signature.getInstance("NONEwithRSA", "SunJCE");
-    assertThrows(UnsupportedOperationException.class, () -> sunSigner.setParameter(spec));
+    boolean ok = false;
+    try {
+      sunSigner.setParameter(spec);
+    } catch (Exception e) {
+      if (e instanceof UnsupportedOperationException) {
+        ok = true;
+      } else if (e instanceof InvalidParameterException) {
+        // Corretto 17.0.19 changed the exception thrown in this case
+        // https://github.com/openjdk/jdk17u/compare/jdk-17.0.18-ga...jdk-17.0.19+10#diff-da194714d6d714a5d1bcdd380e5b72862ab09b844a14061be2bac5898dc619f7R125-R145
+        assertTrue(TestUtil.JAVA_VERSION >= 17);
+        ok = true;
+      }
+    }
+    assertTrue(ok);
     final Signature bcSigner = Signature.getInstance("NONEwithRSA", TestUtil.BC_PROVIDER);
     assertThrows(UnsupportedOperationException.class, () -> bcSigner.setParameter(spec));
     final Signature accpSigner = Signature.getInstance("NONEwithRSA", ACCP);

--- a/tst/com/amazon/corretto/crypto/provider/test/NoneWithRsaTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/NoneWithRsaTest.java
@@ -62,7 +62,7 @@ public class NoneWithRsaTest {
   }
 
   @Test
-  public void testBasicSignVerify() throws Exception {
+  public void testNoneWithRsassaPssBasicSignVerify() throws Exception {
     KeyPair kp = generateKeyPair(2048);
     String message = "Hello, World!";
 
@@ -90,7 +90,7 @@ public class NoneWithRsaTest {
   }
 
   @Test
-  public void testDefaultParameters() throws Exception {
+  public void testNoneWithRsassaPssDefaultParameters() throws Exception {
     KeyPair kp = generateKeyPair(2048);
     String message = "Test message";
 
@@ -108,60 +108,9 @@ public class NoneWithRsaTest {
     assertTrue(sig.verify(signature));
   }
 
-  @Test
-  public void testInputExceedsDigestLength() throws Exception {
-    KeyPair kp = generateKeyPair(2048);
-
-    MessageDigest md = MessageDigest.getInstance("SHA-256", ACCP);
-    byte[] digest = md.digest("test".getBytes());
-
-    Signature sig = Signature.getInstance("NONEwithRSASSA-PSS", ACCP);
-    PSSParameterSpec spec =
-        new PSSParameterSpec("SHA-256", "MGF1", MGF1ParameterSpec.SHA256, 32, 1);
-    sig.setParameter(spec);
-    sig.initSign(kp.getPrivate());
-
-    // Try to update with more than digest length
-    sig.update(digest);
-    assertThrows(SignatureException.class, () -> sig.update((byte) 0xFF));
-  }
-
-  @Test
-  public void testInputLessThanDigestLength() throws Exception {
-    KeyPair kp = generateKeyPair(2048);
-
-    Signature sig = Signature.getInstance("NONEwithRSASSA-PSS", ACCP);
-    PSSParameterSpec spec =
-        new PSSParameterSpec("SHA-256", "MGF1", MGF1ParameterSpec.SHA256, 32, 1);
-    sig.setParameter(spec);
-    sig.initSign(kp.getPrivate());
-
-    // Update with less than digest length (32 bytes for SHA-256) should throw immediately
-    assertThrows(SignatureException.class, () -> sig.update(new byte[16]));
-  }
-
-  @Test
-  public void testInputExactlyDigestLength() throws Exception {
-    KeyPair kp = generateKeyPair(2048);
-
-    MessageDigest md = MessageDigest.getInstance("SHA-256", ACCP);
-    byte[] digest = md.digest("test".getBytes());
-    assertEquals(32, digest.length);
-
-    Signature sig = Signature.getInstance("NONEwithRSASSA-PSS", ACCP);
-    PSSParameterSpec spec =
-        new PSSParameterSpec("SHA-256", "MGF1", MGF1ParameterSpec.SHA256, 32, 1);
-    sig.setParameter(spec);
-    sig.initSign(kp.getPrivate());
-    sig.update(digest);
-    byte[] signature = sig.sign();
-
-    assertNotNull(signature);
-  }
-
   @ParameterizedTest
   @ValueSource(ints = {2048, 3072, 4096})
-  public void testVariousKeySizes(int keySize) throws Exception {
+  public void testNoneWithRsassaPssVariousKeySizes(int keySize) throws Exception {
     KeyPair kp = generateKeyPair(keySize);
     MessageDigest md = MessageDigest.getInstance("SHA-256", ACCP);
     byte[] digest = md.digest("test".getBytes());
@@ -180,7 +129,7 @@ public class NoneWithRsaTest {
   }
 
   @Test
-  public void testDifferentDigests() throws Exception {
+  public void testNoneWithRsassaPssDifferentDigests() throws Exception {
     String[] digests = {"SHA-1", "SHA-256", "SHA-384", "SHA-512"};
     MGF1ParameterSpec[] mgfSpecs = {
       MGF1ParameterSpec.SHA1,
@@ -212,29 +161,7 @@ public class NoneWithRsaTest {
   }
 
   @Test
-  public void testWrongDigest() throws Exception {
-    KeyPair kp = generateKeyPair(2048);
-    MessageDigest md = MessageDigest.getInstance("SHA-256", ACCP);
-    byte[] digest1 = md.digest("message1".getBytes());
-    byte[] digest2 = md.digest("message2".getBytes());
-
-    Signature sig = Signature.getInstance("NONEwithRSASSA-PSS", ACCP);
-    PSSParameterSpec spec =
-        new PSSParameterSpec("SHA-256", "MGF1", MGF1ParameterSpec.SHA256, 32, 1);
-    sig.setParameter(spec);
-    sig.initSign(kp.getPrivate());
-    sig.update(digest1);
-    byte[] signature = sig.sign();
-
-    // Verify with different digest
-    sig.initVerify(kp.getPublic());
-    sig.setParameter(spec);
-    sig.update(digest2);
-    assertFalse(sig.verify(signature));
-  }
-
-  @Test
-  public void testByteByByteUpdateThrows() throws Exception {
+  public void testNoneWithRsassaPssByteByByteUpdateThrows() throws Exception {
     KeyPair kp = generateKeyPair(2048);
 
     Signature sig = Signature.getInstance("NONEwithRSASSA-PSS", ACCP);
@@ -248,7 +175,7 @@ public class NoneWithRsaTest {
   }
 
   @Test
-  public void testByteBufferUpdate() throws Exception {
+  public void testNoneWithRsassaPssByteBufferUpdate() throws Exception {
     KeyPair kp = generateKeyPair(2048);
     MessageDigest md = MessageDigest.getInstance("SHA-256", ACCP);
     byte[] digest = md.digest("test".getBytes());
@@ -268,7 +195,7 @@ public class NoneWithRsaTest {
   }
 
   @Test
-  public void testDirectByteBuffer() throws Exception {
+  public void testNoneWithRsassaPssDirectByteBuffer() throws Exception {
     KeyPair kp = generateKeyPair(2048);
     MessageDigest md = MessageDigest.getInstance("SHA-256", ACCP);
     byte[] digest = md.digest("test".getBytes());
@@ -293,7 +220,7 @@ public class NoneWithRsaTest {
   }
 
   @Test
-  public void testReadOnlyByteBuffer() throws Exception {
+  public void testNoneWithRsassaPssReadOnlyByteBuffer() throws Exception {
     KeyPair kp = generateKeyPair(2048);
     MessageDigest md = MessageDigest.getInstance("SHA-256", ACCP);
     byte[] digest = md.digest("test".getBytes());
@@ -316,7 +243,7 @@ public class NoneWithRsaTest {
   }
 
   @Test
-  public void testParameterUpdateRestriction() throws Exception {
+  public void testNoneWithRsassaPssParameterUpdateRestriction() throws Exception {
     KeyPair kp = generateKeyPair(2048);
     MessageDigest md = MessageDigest.getInstance("SHA-256", ACCP);
     byte[] digest = md.digest("test".getBytes());
@@ -337,7 +264,7 @@ public class NoneWithRsaTest {
   }
 
   @Test
-  public void testCompatibilityWithRSASSA_PSS() throws Exception {
+  public void testNoneWithRsassaPssCompatibilityWithRSASSA_PSS() throws Exception {
     // Signatures created by RSASSA-PSS should be verifiable by NONEwithRSASSA-PSS and vice versa
     KeyPair kp = generateKeyPair(2048);
     String message = "Test message for compatibility";
@@ -373,7 +300,7 @@ public class NoneWithRsaTest {
   }
 
   @Test
-  public void testSignRsassaPssVerifyNoneWithRsaPss() throws Exception {
+  public void testNoneWithRsassaPssSignRsassaPssVerifyNoneWithRsaPss() throws Exception {
     KeyPair kp = generateKeyPair(2048);
     byte[] message = "Sign with RSASSA-PSS, verify with NONEwithRSASSA-PSS".getBytes();
     PSSParameterSpec spec =
@@ -398,7 +325,7 @@ public class NoneWithRsaTest {
   }
 
   @Test
-  public void testSignNoneWithRsaPssVerifyNoneWithRsassaPss() throws Exception {
+  public void testNoneWithRsassaPssSignNoneWithRsaPssVerifyNoneWithRsassaPss() throws Exception {
     KeyPair kp = generateKeyPair(2048);
     byte[] message = "Sign with NONEwithRSASSA-PSS, verify with RSASSA-PSS".getBytes();
     PSSParameterSpec spec =
@@ -423,7 +350,7 @@ public class NoneWithRsaTest {
   }
 
   @Test
-  public void testDifferentSaltLengths() throws Exception {
+  public void testNoneWithRsassaPssDifferentSaltLengths() throws Exception {
     KeyPair kp = generateKeyPair(2048);
     MessageDigest md = MessageDigest.getInstance("SHA-256", ACCP);
     byte[] digest = md.digest("test".getBytes());
@@ -447,7 +374,7 @@ public class NoneWithRsaTest {
   }
 
   @Test
-  public void testMultipleSignatures() throws Exception {
+  public void testNoneWithRsassaPssMultipleSignatures() throws Exception {
     KeyPair kp = generateKeyPair(2048);
     MessageDigest md = MessageDigest.getInstance("SHA-256", ACCP);
 
@@ -473,7 +400,7 @@ public class NoneWithRsaTest {
   }
 
   @Test
-  public void testVerifyOffsetLength() throws Exception {
+  public void testNoneWithRsassaPssVerifyOffsetLength() throws Exception {
     KeyPair kp = generateKeyPair(2048);
     MessageDigest md = MessageDigest.getInstance("SHA-256", ACCP);
     byte[] digest = md.digest("test".getBytes());
@@ -495,88 +422,8 @@ public class NoneWithRsaTest {
     assertTrue(sig.verify(paddedSig, 10, signature.length));
   }
 
-  // --- Negative / Error Tests ---
-
   @Test
-  public void testArrayUpdateExceedsDigestLength() throws Exception {
-    KeyPair kp = generateKeyPair(2048);
-
-    Signature sig = Signature.getInstance("NONEwithRSASSA-PSS", ACCP);
-    PSSParameterSpec spec =
-        new PSSParameterSpec("SHA-256", "MGF1", MGF1ParameterSpec.SHA256, 32, 1);
-    sig.setParameter(spec);
-    sig.initSign(kp.getPrivate());
-
-    // Array update with more than 32 bytes should throw
-    assertThrows(SignatureException.class, () -> sig.update(new byte[33]));
-  }
-
-  @Test
-  public void testArrayUpdateExceedsDigestLengthInTwoParts() throws Exception {
-    KeyPair kp = generateKeyPair(2048);
-
-    Signature sig = Signature.getInstance("NONEwithRSASSA-PSS", ACCP);
-    PSSParameterSpec spec =
-        new PSSParameterSpec("SHA-256", "MGF1", MGF1ParameterSpec.SHA256, 32, 1);
-    sig.setParameter(spec);
-    sig.initSign(kp.getPrivate());
-
-    // First update with wrong length should throw (one-shot: must be exactly 32 bytes)
-    assertThrows(SignatureException.class, () -> sig.update(new byte[20]));
-  }
-
-  @Test
-  public void testByteBufferUpdateExceedsDigestLength() throws Exception {
-    KeyPair kp = generateKeyPair(2048);
-
-    Signature sig = Signature.getInstance("NONEwithRSASSA-PSS", ACCP);
-    PSSParameterSpec spec =
-        new PSSParameterSpec("SHA-256", "MGF1", MGF1ParameterSpec.SHA256, 32, 1);
-    sig.setParameter(spec);
-    sig.initSign(kp.getPrivate());
-
-    // ByteBuffer with more than 32 bytes should throw (wrapped in RuntimeException)
-    ByteBuffer buf = ByteBuffer.wrap(new byte[33]);
-    assertThrows(RuntimeException.class, () -> sig.update(buf));
-  }
-
-  @Test
-  public void testByteBufferUpdateExceedsDigestLengthInTwoParts() throws Exception {
-    KeyPair kp = generateKeyPair(2048);
-
-    Signature sig = Signature.getInstance("NONEwithRSASSA-PSS", ACCP);
-    PSSParameterSpec spec =
-        new PSSParameterSpec("SHA-256", "MGF1", MGF1ParameterSpec.SHA256, 32, 1);
-    sig.setParameter(spec);
-    sig.initSign(kp.getPrivate());
-
-    // First update with wrong length should throw (one-shot: must be exactly 32 bytes)
-    assertThrows(RuntimeException.class, () -> sig.update(ByteBuffer.wrap(new byte[20])));
-  }
-
-  @Test
-  public void testVerifyWithShortInput() throws Exception {
-    KeyPair kp = generateKeyPair(2048);
-    MessageDigest md = MessageDigest.getInstance("SHA-256", ACCP);
-    byte[] digest = md.digest("test".getBytes());
-
-    Signature sig = Signature.getInstance("NONEwithRSASSA-PSS", ACCP);
-    PSSParameterSpec spec =
-        new PSSParameterSpec("SHA-256", "MGF1", MGF1ParameterSpec.SHA256, 32, 1);
-    sig.setParameter(spec);
-
-    // Create valid signature first
-    sig.initSign(kp.getPrivate());
-    sig.update(digest);
-    byte[] signature = sig.sign();
-
-    // Try to verify with too-short digest - should throw at update time
-    sig.initVerify(kp.getPublic());
-    assertThrows(SignatureException.class, () -> sig.update(new byte[16]));
-  }
-
-  @Test
-  public void testSignWithNoUpdate() throws Exception {
+  public void testNoneWithRsassaPssSignWithNoUpdate() throws Exception {
     KeyPair kp = generateKeyPair(2048);
 
     Signature sig = Signature.getInstance("NONEwithRSASSA-PSS", ACCP);
@@ -590,7 +437,7 @@ public class NoneWithRsaTest {
   }
 
   @Test
-  public void testVerifyWithNoUpdate() throws Exception {
+  public void testNoneWithRsassaPssVerifyWithNoUpdate() throws Exception {
     KeyPair kp = generateKeyPair(2048);
     MessageDigest md = MessageDigest.getInstance("SHA-256", ACCP);
     byte[] digest = md.digest("test".getBytes());
@@ -611,7 +458,21 @@ public class NoneWithRsaTest {
   }
 
   @Test
-  public void testSignWithoutInit() throws Exception {
+  public void testNoneWithRsassaPssSecondUpdateThrows() throws Exception {
+    KeyPair kp = generateKeyPair(2048);
+    final Signature sig = Signature.getInstance("NONEwithRSASSA-PSS", ACCP);
+
+    sig.initSign(kp.getPrivate());
+    sig.update(new byte[20]);
+    assertThrows(SignatureException.class, () -> sig.update(new byte[1]));
+
+    sig.initVerify(kp.getPublic());
+    sig.update(new byte[20]);
+    assertThrows(SignatureException.class, () -> sig.update(new byte[1]));
+  }
+
+  @Test
+  public void testNoneWithRsassaPssSignWithoutInit() throws Exception {
     Signature sig = Signature.getInstance("NONEwithRSASSA-PSS", ACCP);
     PSSParameterSpec spec =
         new PSSParameterSpec("SHA-256", "MGF1", MGF1ParameterSpec.SHA256, 32, 1);
@@ -622,7 +483,7 @@ public class NoneWithRsaTest {
   }
 
   @Test
-  public void testVerifyWithoutInit() throws Exception {
+  public void testNoneWithRsassaPssVerifyWithoutInit() throws Exception {
     Signature sig = Signature.getInstance("NONEwithRSASSA-PSS", ACCP);
     PSSParameterSpec spec =
         new PSSParameterSpec("SHA-256", "MGF1", MGF1ParameterSpec.SHA256, 32, 1);
@@ -633,7 +494,7 @@ public class NoneWithRsaTest {
   }
 
   @Test
-  public void testWrongKeyForVerification() throws Exception {
+  public void testNoneWithRsassaPssWrongKeyForVerification() throws Exception {
     KeyPair kp1 = generateKeyPair(2048);
     KeyPair kp2 = generateKeyPair(2048);
     MessageDigest md = MessageDigest.getInstance("SHA-256", ACCP);
@@ -656,7 +517,7 @@ public class NoneWithRsaTest {
   }
 
   @Test
-  public void testEcKeyWithNoneWithRsaPss() throws Exception {
+  public void testNoneWithRsassaPssEcKeyWithNoneWithRsaPss() throws Exception {
     KeyPairGenerator ecKpg = KeyPairGenerator.getInstance("EC", ACCP);
     ecKpg.initialize(new ECGenParameterSpec("secp256r1"));
     KeyPair ecKp = ecKpg.generateKeyPair();


### PR DESCRIPTION
*Issue #, if available:*

n/a

*Description of changes:*

This PR adds/refactors a few signature corruption negative test cases to the test suites relevant to PRs #536 and #537.

Summary:

  - Simplified NoneWithRsa constructors by removing the unnecessary digest-pointer overload, since PKCS#1 v1.5 doesn't need it and PSS gets it from JDK defaults.
  - Updated DIFFERENCES.md to remove documentation about the now-removed input-length restriction for NONEwithRSA.
  - Refactored NoneWithRsaTest to deduplicate bad-signature tests into parameterized tests that cover both NONEwithRSA and NONEwithRSASSA-PSS, and removed tests for the deleted digest-length enforcement.
  - Added comprehensive bad-signature rejection tests for Ed25519, Ed25519ph, and NONEwithEd25519ph in EdDSATest.
  - Formatting-only changes in sign.cpp (no functional impact).
  - Fix CI, account for Corretto 17.0.19 exception [change](https://github.com/openjdk/jdk17u/compare/jdk-17.0.18-ga...jdk-17.0.19+10#diff-da194714d6d714a5d1bcdd380e5b72862ab09b844a14061be2bac5898dc619f7R125-R145) in test

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
