### PR TITLE
Add DigestUtils.digestInfoWrap static utility

### DIFF
--- a/csrc/util_class.cpp
+++ b/csrc/util_class.cpp
@@ -254,6 +254,53 @@ JNIEXPORT jbyteArray JNICALL Java_com_amazon_corretto_crypto_utils_MlDsaUtils_co
 #endif // !defined(FIPS_BUILD) || defined(EXPERIMENTAL_FIPS_BUILD)
 
 /*
+ * Class:     com_amazon_corretto_crypto_utils_DigestUtils
+ * Method:    digestInfoWrapInternal
+ * Signature: (Ljava/lang/String;[B)[B
+ */
+JNIEXPORT jbyteArray JNICALL Java_com_amazon_corretto_crypto_utils_DigestUtils_digestInfoWrapInternal(
+    JNIEnv* pEnv, jclass, jstring digestName, jbyteArray digestBytes)
+{
+    jbyteArray result = nullptr;
+    try {
+        raii_env env(pEnv);
+        if (!digestName) {
+            throw_java_ex(EX_ILLEGAL_ARGUMENT, "digestName must not be null");
+        }
+        jni_string md_name(env, digestName);
+        const EVP_MD* md = EVP_get_digestbyname(md_name.native_str);
+        if (!md) {
+            throw_java_ex(EX_ILLEGAL_ARGUMENT, "Unsupported digest algorithm");
+        }
+        const int hash_nid = EVP_MD_type(md);
+
+        jsize digest_len = env->GetArrayLength(digestBytes);
+        jbyte* digest = env->GetByteArrayElements(digestBytes, nullptr);
+        CHECK_OPENSSL(digest);
+
+        uint8_t* out_msg = nullptr;
+        size_t out_msg_len = 0;
+        int is_alloced = 0;
+        if (1 != RSA_add_pkcs1_prefix(
+                &out_msg, &out_msg_len, &is_alloced, hash_nid, (const uint8_t*)digest, (size_t)digest_len)) {
+            throw_java_ex(EX_ILLEGAL_ARGUMENT, "RSA_add_pkcs1_prefix failed");
+        }
+        if (!(result = env->NewByteArray((jsize)out_msg_len))) {
+            throw_java_ex(EX_OOM, "Unable to allocate DigestInfo array");
+        }
+        env->SetByteArrayRegion(result, 0, (jsize)out_msg_len, (const jbyte*)out_msg);
+        if (is_alloced && out_msg) {
+            OPENSSL_free(out_msg);
+        }
+        env->ReleaseByteArrayElements(digestBytes, digest, JNI_ABORT);
+    } catch (java_ex& ex) {
+        ex.throw_to_java(pEnv);
+        return nullptr;
+    }
+    return result;
+}
+
+/*
  * Class:     com_amazon_corretto_crypto_utils_EcUtils
  * Method:    encodeRfc5915EcPrivateKeyInternal
  * Signature: ([B)[B

--- a/csrc/util_class.cpp
+++ b/csrc/util_class.cpp
@@ -273,7 +273,8 @@ JNIEXPORT jbyteArray JNICALL Java_com_amazon_corretto_crypto_utils_DigestUtils_d
         jni_string md_name(env, digestName);
         const EVP_MD* md = EVP_get_digestbyname(md_name.native_str);
         if (md == nullptr) {
-            throw_java_ex(EX_ILLEGAL_ARGUMENT, "Unsupported digest algorithm");
+            throw_java_ex(
+                EX_ILLEGAL_ARGUMENT, std::string("Unsupported digest algorithm: ") + md_name.native_str);
         }
         const int hash_nid = EVP_MD_type(md);
 

--- a/csrc/util_class.cpp
+++ b/csrc/util_class.cpp
@@ -298,13 +298,13 @@ JNIEXPORT jbyteArray JNICALL Java_com_amazon_corretto_crypto_utils_DigestUtils_d
             }
             env->SetByteArrayRegion(result, 0, (jsize)out_msg_len, (const jbyte*)out_msg);
         } catch (...) {
-            if (is_alloced && out_msg) {
+            if (is_alloced) {
                 OPENSSL_free(out_msg);
             }
             env->ReleaseByteArrayElements(digestBytes, digest, JNI_ABORT);
             throw;
         }
-        if (is_alloced && out_msg) {
+        if (is_alloced) {
             OPENSSL_free(out_msg);
         }
         env->ReleaseByteArrayElements(digestBytes, digest, JNI_ABORT);

--- a/csrc/util_class.cpp
+++ b/csrc/util_class.cpp
@@ -17,8 +17,10 @@ extern "C" {
  * Signature: (Ljava/nio/ByteBuffer;Ljava/nio/ByteBuffer;)J
  */
 
-JNIEXPORT jlong JNICALL Java_com_amazon_corretto_crypto_provider_Utils_getNativeBufferOffset(
-    JNIEnv* env, jclass, jobject bufA, jobject bufB)
+JNIEXPORT jlong JNICALL Java_com_amazon_corretto_crypto_provider_Utils_getNativeBufferOffset(JNIEnv* env,
+                                                                                             jclass,
+                                                                                             jobject bufA,
+                                                                                             jobject bufB)
 {
     const jlong JINT_MAX = (1L << 31) - 1L;
     const jlong JINT_MIN = -(1L << 31);
@@ -62,8 +64,9 @@ JNIEXPORT jlong JNICALL Java_com_amazon_corretto_crypto_provider_Utils_getNative
  * Method:    getEvpMdFromName
  * Signature: (Ljava/lang/String;)J
  */
-JNIEXPORT jlong JNICALL Java_com_amazon_corretto_crypto_provider_Utils_getEvpMdFromName(
-    JNIEnv* pEnv, jclass, jstring mdName)
+JNIEXPORT jlong JNICALL Java_com_amazon_corretto_crypto_provider_Utils_getEvpMdFromName(JNIEnv* pEnv,
+                                                                                        jclass,
+                                                                                        jstring mdName)
 {
     try {
         raii_env env(pEnv);
@@ -90,8 +93,8 @@ JNIEXPORT jint JNICALL Java_com_amazon_corretto_crypto_provider_Utils_getDigestL
  * Method:    expandPrivateKeyInternal
  * Signature: ([B)[B
  */
-JNIEXPORT jbyteArray JNICALL Java_com_amazon_corretto_crypto_utils_MlDsaUtils_expandPrivateKeyInternal(
-    JNIEnv* pEnv, jclass, jbyteArray keyBytes)
+JNIEXPORT jbyteArray JNICALL
+Java_com_amazon_corretto_crypto_utils_MlDsaUtils_expandPrivateKeyInternal(JNIEnv* pEnv, jclass, jbyteArray keyBytes)
 {
     jbyteArray result = NULL;
     try {
@@ -143,8 +146,8 @@ JNIEXPORT jbyteArray JNICALL Java_com_amazon_corretto_crypto_utils_MlDsaUtils_ex
  * via KEM_KEY_set_raw_keypair_from_seed. We then use encodeExpandedMLKEMPrivateKey
  * to manually build expanded-format PKCS8.
  */
-JNIEXPORT jbyteArray JNICALL Java_com_amazon_corretto_crypto_utils_MlKemUtils_expandPrivateKeyInternal(
-    JNIEnv* pEnv, jclass, jbyteArray keyBytes)
+JNIEXPORT jbyteArray JNICALL
+Java_com_amazon_corretto_crypto_utils_MlKemUtils_expandPrivateKeyInternal(JNIEnv* pEnv, jclass, jbyteArray keyBytes)
 {
     jbyteArray result = NULL;
     try {
@@ -264,32 +267,43 @@ JNIEXPORT jbyteArray JNICALL Java_com_amazon_corretto_crypto_utils_DigestUtils_d
     jbyteArray result = nullptr;
     try {
         raii_env env(pEnv);
-        if (!digestName) {
+        if (digestName == nullptr) {
             throw_java_ex(EX_ILLEGAL_ARGUMENT, "digestName must not be null");
         }
         jni_string md_name(env, digestName);
         const EVP_MD* md = EVP_get_digestbyname(md_name.native_str);
-        if (!md) {
+        if (md == nullptr) {
             throw_java_ex(EX_ILLEGAL_ARGUMENT, "Unsupported digest algorithm");
         }
         const int hash_nid = EVP_MD_type(md);
 
         jsize digest_len = env->GetArrayLength(digestBytes);
         jbyte* digest = env->GetByteArrayElements(digestBytes, nullptr);
-        CHECK_OPENSSL(digest);
+        if (digest == nullptr) {
+            throw_java_ex(EX_OOM, "Unable to pin or copy digestBytes array");
+        }
 
         uint8_t* out_msg = nullptr;
         size_t out_msg_len = 0;
         int is_alloced = 0;
-        if (1 != RSA_add_pkcs1_prefix(
-                &out_msg, &out_msg_len, &is_alloced, hash_nid, (const uint8_t*)digest, (size_t)digest_len)) {
-            ERR_clear_error();
-            throw_java_ex(EX_ILLEGAL_ARGUMENT, "RSA_add_pkcs1_prefix failed");
+        try {
+            if (1
+                != RSA_add_pkcs1_prefix(&out_msg, &out_msg_len, &is_alloced, hash_nid, (const uint8_t*)digest,
+                                        (size_t)digest_len)) {
+                ERR_clear_error();
+                throw_java_ex(EX_ILLEGAL_ARGUMENT, "RSA_add_pkcs1_prefix failed");
+            }
+            if (!(result = env->NewByteArray((jsize)out_msg_len))) {
+                throw_java_ex(EX_OOM, "Unable to allocate DigestInfo array");
+            }
+            env->SetByteArrayRegion(result, 0, (jsize)out_msg_len, (const jbyte*)out_msg);
+        } catch (...) {
+            if (is_alloced && out_msg) {
+                OPENSSL_free(out_msg);
+            }
+            env->ReleaseByteArrayElements(digestBytes, digest, JNI_ABORT);
+            throw;
         }
-        if (!(result = env->NewByteArray((jsize)out_msg_len))) {
-            throw_java_ex(EX_OOM, "Unable to allocate DigestInfo array");
-        }
-        env->SetByteArrayRegion(result, 0, (jsize)out_msg_len, (const jbyte*)out_msg);
         if (is_alloced && out_msg) {
             OPENSSL_free(out_msg);
         }

--- a/csrc/util_class.cpp
+++ b/csrc/util_class.cpp
@@ -283,6 +283,7 @@ JNIEXPORT jbyteArray JNICALL Java_com_amazon_corretto_crypto_utils_DigestUtils_d
         int is_alloced = 0;
         if (1 != RSA_add_pkcs1_prefix(
                 &out_msg, &out_msg_len, &is_alloced, hash_nid, (const uint8_t*)digest, (size_t)digest_len)) {
+            ERR_clear_error();
             throw_java_ex(EX_ILLEGAL_ARGUMENT, "RSA_add_pkcs1_prefix failed");
         }
         if (!(result = env->NewByteArray((jsize)out_msg_len))) {

--- a/src/com/amazon/corretto/crypto/provider/Utils.java
+++ b/src/com/amazon/corretto/crypto/provider/Utils.java
@@ -25,7 +25,7 @@ import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 
 /** Miscellaneous utility methods. */
-public final class Utils {
+final class Utils {
   static final int SHA1_CODE = 1;
   static final int SHA256_CODE = 2;
   static final int SHA384_CODE = 3;
@@ -69,17 +69,12 @@ public final class Utils {
     return getDigestLength(getEvpMdFromName(digestName));
   }
 
-  public static String jceDigestNameToAwsLcName(final String jceName) {
+  static String jceDigestNameToAwsLcName(final String jceName) {
     if (jceName == null) {
       return null;
     }
-    final String upper = jceName.toUpperCase();
-    // SHA3 short names in AWS-LC retain their hyphen (e.g. "SHA3-256"), so don't strip it.
-    if (upper.startsWith("SHA3-")) {
-      return upper;
-    }
     // e.g. "SHA-512/256" => "SHA512-256"
-    return upper.replace("-", "").replace("/", "-");
+    return jceName.replace("-", "").replace("/", "-").toUpperCase();
   }
 
   /**
@@ -379,7 +374,7 @@ public final class Utils {
     }
   }
 
-  public static void testDigest(MessageDigest md, byte[] message, byte[] expected) {
+  static void testDigest(MessageDigest md, byte[] message, byte[] expected) {
     final int[] lengths = new int[] {1, 3, 4, 7, 8, 16, 32, 48, 64, 128, 256};
     final String alg = md.getAlgorithm();
     assertArrayEquals(alg, expected, md.digest(message));
@@ -652,7 +647,7 @@ public final class Utils {
 
   static native void releaseEvpCipherCtx(long ctxPtr);
 
-  public static byte[] checkAesKey(final Key key) throws InvalidKeyException {
+  static byte[] checkAesKey(final Key key) throws InvalidKeyException {
     if (key == null) {
       throw new InvalidKeyException("Key can't be null");
     }

--- a/src/com/amazon/corretto/crypto/provider/Utils.java
+++ b/src/com/amazon/corretto/crypto/provider/Utils.java
@@ -25,7 +25,7 @@ import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 
 /** Miscellaneous utility methods. */
-final class Utils {
+public final class Utils {
   static final int SHA1_CODE = 1;
   static final int SHA256_CODE = 2;
   static final int SHA384_CODE = 3;
@@ -69,12 +69,17 @@ final class Utils {
     return getDigestLength(getEvpMdFromName(digestName));
   }
 
-  static String jceDigestNameToAwsLcName(final String jceName) {
+  public static String jceDigestNameToAwsLcName(final String jceName) {
     if (jceName == null) {
       return null;
     }
+    final String upper = jceName.toUpperCase();
+    // SHA3 short names in AWS-LC retain their hyphen (e.g. "SHA3-256"), so don't strip it.
+    if (upper.startsWith("SHA3-")) {
+      return upper;
+    }
     // e.g. "SHA-512/256" => "SHA512-256"
-    return jceName.replace("-", "").replace("/", "-").toUpperCase();
+    return upper.replace("-", "").replace("/", "-");
   }
 
   /**

--- a/src/com/amazon/corretto/crypto/utils/DigestUtils.java
+++ b/src/com/amazon/corretto/crypto/utils/DigestUtils.java
@@ -41,7 +41,6 @@ public final class DigestUtils {
     return digestInfoWrapInternal(normalizeDigestName(digestName), digestBytes);
   }
 
-
   private static String normalizeDigestName(final String jceName) {
     if (jceName == null) {
       return null;
@@ -54,6 +53,4 @@ public final class DigestUtils {
     // e.g. "SHA-512/256" => "SHA512-256"
     return upper.replace("-", "").replace("/", "-");
   }
-
-
 }

--- a/src/com/amazon/corretto/crypto/utils/DigestUtils.java
+++ b/src/com/amazon/corretto/crypto/utils/DigestUtils.java
@@ -42,9 +42,6 @@ public final class DigestUtils {
   }
 
   private static String normalizeDigestName(final String jceName) {
-    if (jceName == null) {
-      return null;
-    }
     final String upper = jceName.toUpperCase();
     // SHA3 short names in AWS-LC retain their hyphen (e.g. "SHA3-256"), so don't strip it.
     if (upper.startsWith("SHA3-")) {

--- a/src/com/amazon/corretto/crypto/utils/DigestUtils.java
+++ b/src/com/amazon/corretto/crypto/utils/DigestUtils.java
@@ -1,0 +1,46 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package com.amazon.corretto.crypto.utils;
+
+/** Public utility methods for message digest operations. */
+public final class DigestUtils {
+  private DigestUtils() {} // private constructor to prevent instantiation
+
+  private static native byte[] digestInfoWrapInternal(String digestName, byte[] digestBytes);
+
+  /**
+   * Returns the PKCS#1 v1.5 DigestInfo DER encoding of {@code digestBytes} under the hash algorithm
+   * named by {@code digestName}. That is, the output is the DER encoding of
+   *
+   * <pre>
+   *   DigestInfo ::= SEQUENCE {
+   *     digestAlgorithm AlgorithmIdentifier,
+   *     digest          OCTET STRING
+   *   }
+   * </pre>
+   *
+   * as defined in RFC 8017 Sec. 9.2. The DER encoding is produced by AWS-LC's {@code
+   * RSA_add_pkcs1_prefix}.
+   *
+   * @param digestName the JCE name of the hash algorithm (e.g. {@code "SHA-256"}, {@code
+   *     "SHA-512/256"}, {@code "SHA3-256"})
+   * @param digestBytes the raw digest bytes; length must match the output length of the algorithm
+   *     named by {@code digestName}
+   * @return the DER-encoded DigestInfo
+   * @throws IllegalArgumentException if {@code digestName} or {@code digestBytes} is null, if
+   *     {@code digestName} is not a supported hash, or if {@code digestBytes} does not match the
+   *     expected digest length
+   */
+  public static byte[] digestInfoWrap(String digestName, byte[] digestBytes) {
+    if (digestName == null) {
+      throw new IllegalArgumentException("digestName must not be null");
+    }
+    if (digestBytes == null) {
+      throw new IllegalArgumentException("digestBytes must not be null");
+    }
+    // Normalize JCE digest names (e.g., "SHA-256" -> "SHA256", "SHA-512/256" -> "SHA512-256")
+    // to the form accepted by AWS-LC's EVP_get_digestbyname.
+    final String awsLcName = digestName.replace("-", "").replace("/", "-").toUpperCase();
+    return digestInfoWrapInternal(awsLcName, digestBytes);
+  }
+}

--- a/src/com/amazon/corretto/crypto/utils/DigestUtils.java
+++ b/src/com/amazon/corretto/crypto/utils/DigestUtils.java
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.amazon.corretto.crypto.utils;
 
-import com.amazon.corretto.crypto.provider.Utils;
-
 /** Public utility methods for message digest operations. */
 public final class DigestUtils {
   private DigestUtils() {} // private constructor to prevent instantiation
@@ -40,6 +38,22 @@ public final class DigestUtils {
     if (digestBytes == null) {
       throw new IllegalArgumentException("digestBytes must not be null");
     }
-    return digestInfoWrapInternal(Utils.jceDigestNameToAwsLcName(digestName), digestBytes);
+    return digestInfoWrapInternal(normalizeDigestName(digestName), digestBytes);
   }
+
+
+  private static String normalizeDigestName(final String jceName) {
+    if (jceName == null) {
+      return null;
+    }
+    final String upper = jceName.toUpperCase();
+    // SHA3 short names in AWS-LC retain their hyphen (e.g. "SHA3-256"), so don't strip it.
+    if (upper.startsWith("SHA3-")) {
+      return upper;
+    }
+    // e.g. "SHA-512/256" => "SHA512-256"
+    return upper.replace("-", "").replace("/", "-");
+  }
+
+
 }

--- a/src/com/amazon/corretto/crypto/utils/DigestUtils.java
+++ b/src/com/amazon/corretto/crypto/utils/DigestUtils.java
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.amazon.corretto.crypto.utils;
 
+import com.amazon.corretto.crypto.provider.Utils;
+
 /** Public utility methods for message digest operations. */
 public final class DigestUtils {
   private DigestUtils() {} // private constructor to prevent instantiation
@@ -38,9 +40,6 @@ public final class DigestUtils {
     if (digestBytes == null) {
       throw new IllegalArgumentException("digestBytes must not be null");
     }
-    // Normalize JCE digest names (e.g., "SHA-256" -> "SHA256", "SHA-512/256" -> "SHA512-256")
-    // to the form accepted by AWS-LC's EVP_get_digestbyname.
-    final String awsLcName = digestName.replace("-", "").replace("/", "-").toUpperCase();
-    return digestInfoWrapInternal(awsLcName, digestBytes);
+    return digestInfoWrapInternal(Utils.jceDigestNameToAwsLcName(digestName), digestBytes);
   }
 }

--- a/tst/com/amazon/corretto/crypto/provider/test/DigestUtilsTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/DigestUtilsTest.java
@@ -3,7 +3,6 @@
 package com.amazon.corretto.crypto.provider.test;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.amazon.corretto.crypto.provider.AmazonCorrettoCryptoProvider;

--- a/tst/com/amazon/corretto/crypto/provider/test/DigestUtilsTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/DigestUtilsTest.java
@@ -113,6 +113,90 @@ public class DigestUtilsTest {
     0x04,
     0x20
   };
+  private static final byte[] SHA3_224_PREFIX = {
+    0x30,
+    0x2d,
+    0x30,
+    0x0d,
+    0x06,
+    0x09,
+    0x60,
+    (byte) 0x86,
+    0x48,
+    0x01,
+    0x65,
+    0x03,
+    0x04,
+    0x02,
+    0x07,
+    0x05,
+    0x00,
+    0x04,
+    0x1c
+  };
+  private static final byte[] SHA3_256_PREFIX = {
+    0x30,
+    0x31,
+    0x30,
+    0x0d,
+    0x06,
+    0x09,
+    0x60,
+    (byte) 0x86,
+    0x48,
+    0x01,
+    0x65,
+    0x03,
+    0x04,
+    0x02,
+    0x08,
+    0x05,
+    0x00,
+    0x04,
+    0x20
+  };
+  private static final byte[] SHA3_384_PREFIX = {
+    0x30,
+    0x41,
+    0x30,
+    0x0d,
+    0x06,
+    0x09,
+    0x60,
+    (byte) 0x86,
+    0x48,
+    0x01,
+    0x65,
+    0x03,
+    0x04,
+    0x02,
+    0x09,
+    0x05,
+    0x00,
+    0x04,
+    0x30
+  };
+  private static final byte[] SHA3_512_PREFIX = {
+    0x30,
+    0x51,
+    0x30,
+    0x0d,
+    0x06,
+    0x09,
+    0x60,
+    (byte) 0x86,
+    0x48,
+    0x01,
+    0x65,
+    0x03,
+    0x04,
+    0x02,
+    0x0a,
+    0x05,
+    0x00,
+    0x04,
+    0x40
+  };
 
   private static byte[] concat(byte[] a, byte[] b) {
     byte[] out = new byte[a.length + b.length];
@@ -155,10 +239,45 @@ public class DigestUtilsTest {
   }
 
   @Test
-  public void testSha512Trunc256() throws Exception {
+  public void testSha512_256() throws Exception {
     byte[] digest = MessageDigest.getInstance("SHA-512/256").digest("hello".getBytes());
     byte[] wrapped = DigestUtils.digestInfoWrap("SHA-512/256", digest);
     assertArrayEquals(concat(SHA512_256_PREFIX, digest), wrapped);
+  }
+
+  // ACCP doesn't support SHA3 yet (see PR 485). Until then, simulate SHA3 hashes with
+  // filled arrays to test below.
+
+  @Test
+  public void testSha3_224() {
+    byte[] digest = new byte[28];
+    Arrays.fill(digest, (byte) 0x11);
+    byte[] wrapped = DigestUtils.digestInfoWrap("SHA3-224", digest);
+    assertArrayEquals(concat(SHA3_224_PREFIX, digest), wrapped);
+  }
+
+  @Test
+  public void testSha3_256() {
+    byte[] digest = new byte[32];
+    Arrays.fill(digest, (byte) 0x22);
+    byte[] wrapped = DigestUtils.digestInfoWrap("SHA3-256", digest);
+    assertArrayEquals(concat(SHA3_256_PREFIX, digest), wrapped);
+  }
+
+  @Test
+  public void testSha3_384() {
+    byte[] digest = new byte[48];
+    Arrays.fill(digest, (byte) 0x33);
+    byte[] wrapped = DigestUtils.digestInfoWrap("SHA3-384", digest);
+    assertArrayEquals(concat(SHA3_384_PREFIX, digest), wrapped);
+  }
+
+  @Test
+  public void testSha3_512() {
+    byte[] digest = new byte[64];
+    Arrays.fill(digest, (byte) 0x44);
+    byte[] wrapped = DigestUtils.digestInfoWrap("SHA3-512", digest);
+    assertArrayEquals(concat(SHA3_512_PREFIX, digest), wrapped);
   }
 
   @Test

--- a/tst/com/amazon/corretto/crypto/provider/test/DigestUtilsTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/DigestUtilsTest.java
@@ -1,0 +1,194 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package com.amazon.corretto.crypto.provider.test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.amazon.corretto.crypto.provider.AmazonCorrettoCryptoProvider;
+import com.amazon.corretto.crypto.utils.DigestUtils;
+import java.security.MessageDigest;
+import java.security.Provider;
+import java.util.Arrays;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
+
+@Execution(ExecutionMode.CONCURRENT)
+@ExtendWith(TestResultLogger.class)
+@ResourceLock(value = TestUtil.RESOURCE_GLOBAL, mode = ResourceAccessMode.READ)
+public class DigestUtilsTest {
+  private static final Provider NATIVE_PROVIDER = AmazonCorrettoCryptoProvider.INSTANCE;
+
+  // Expected DigestInfo DER prefixes per RFC 8017 Sec. 9.2 Note 1. Output of digestInfoWrap
+  // must be prefix || digest bytes.
+  private static final byte[] SHA1_PREFIX = {
+    0x30, 0x21, 0x30, 0x09, 0x06, 0x05, 0x2b, 0x0e, 0x03, 0x02, 0x1a, 0x05, 0x00, 0x04, 0x14
+  };
+  private static final byte[] SHA256_PREFIX = {
+    0x30,
+    0x31,
+    0x30,
+    0x0d,
+    0x06,
+    0x09,
+    0x60,
+    (byte) 0x86,
+    0x48,
+    0x01,
+    0x65,
+    0x03,
+    0x04,
+    0x02,
+    0x01,
+    0x05,
+    0x00,
+    0x04,
+    0x20
+  };
+  private static final byte[] SHA384_PREFIX = {
+    0x30,
+    0x41,
+    0x30,
+    0x0d,
+    0x06,
+    0x09,
+    0x60,
+    (byte) 0x86,
+    0x48,
+    0x01,
+    0x65,
+    0x03,
+    0x04,
+    0x02,
+    0x02,
+    0x05,
+    0x00,
+    0x04,
+    0x30
+  };
+  private static final byte[] SHA512_PREFIX = {
+    0x30,
+    0x51,
+    0x30,
+    0x0d,
+    0x06,
+    0x09,
+    0x60,
+    (byte) 0x86,
+    0x48,
+    0x01,
+    0x65,
+    0x03,
+    0x04,
+    0x02,
+    0x03,
+    0x05,
+    0x00,
+    0x04,
+    0x40
+  };
+  private static final byte[] SHA512_256_PREFIX = {
+    0x30,
+    0x31,
+    0x30,
+    0x0d,
+    0x06,
+    0x09,
+    0x60,
+    (byte) 0x86,
+    0x48,
+    0x01,
+    0x65,
+    0x03,
+    0x04,
+    0x02,
+    0x06,
+    0x05,
+    0x00,
+    0x04,
+    0x20
+  };
+
+  private static byte[] concat(byte[] a, byte[] b) {
+    byte[] out = new byte[a.length + b.length];
+    System.arraycopy(a, 0, out, 0, a.length);
+    System.arraycopy(b, 0, out, a.length, b.length);
+    return out;
+  }
+
+  @Test
+  public void testSha256() throws Exception {
+    byte[] digest =
+        MessageDigest.getInstance("SHA-256", NATIVE_PROVIDER).digest("hello".getBytes());
+    byte[] wrapped = DigestUtils.digestInfoWrap("SHA-256", digest);
+    assertArrayEquals(concat(SHA256_PREFIX, digest), wrapped);
+    assertEquals(digest.length + 19, wrapped.length);
+  }
+
+  @Test
+  public void testSha1() throws Exception {
+    byte[] digest = MessageDigest.getInstance("SHA-1", NATIVE_PROVIDER).digest("hello".getBytes());
+    byte[] wrapped = DigestUtils.digestInfoWrap("SHA-1", digest);
+    assertArrayEquals(concat(SHA1_PREFIX, digest), wrapped);
+    assertEquals(digest.length + 15, wrapped.length);
+  }
+
+  @Test
+  public void testSha384() throws Exception {
+    byte[] digest =
+        MessageDigest.getInstance("SHA-384", NATIVE_PROVIDER).digest("hello".getBytes());
+    byte[] wrapped = DigestUtils.digestInfoWrap("SHA-384", digest);
+    assertArrayEquals(concat(SHA384_PREFIX, digest), wrapped);
+  }
+
+  @Test
+  public void testSha512() throws Exception {
+    byte[] digest =
+        MessageDigest.getInstance("SHA-512", NATIVE_PROVIDER).digest("hello".getBytes());
+    byte[] wrapped = DigestUtils.digestInfoWrap("SHA-512", digest);
+    assertArrayEquals(concat(SHA512_PREFIX, digest), wrapped);
+  }
+
+  @Test
+  public void testSha512Trunc256() throws Exception {
+    byte[] digest = MessageDigest.getInstance("SHA-512/256").digest("hello".getBytes());
+    byte[] wrapped = DigestUtils.digestInfoWrap("SHA-512/256", digest);
+    assertArrayEquals(concat(SHA512_256_PREFIX, digest), wrapped);
+  }
+
+  @Test
+  public void testNullDigestName() {
+    assertThrows(
+        IllegalArgumentException.class, () -> DigestUtils.digestInfoWrap(null, new byte[32]));
+  }
+
+  @Test
+  public void testNullDigestBytes() {
+    assertThrows(IllegalArgumentException.class, () -> DigestUtils.digestInfoWrap("SHA-256", null));
+  }
+
+  @Test
+  public void testUnsupportedDigestName() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> DigestUtils.digestInfoWrap("NO-SUCH-DIGEST", new byte[32]));
+  }
+
+  @Test
+  public void testWrongDigestLength() {
+    byte[] tooShort = new byte[16];
+    Arrays.fill(tooShort, (byte) 0xaa);
+    assertThrows(
+        IllegalArgumentException.class, () -> DigestUtils.digestInfoWrap("SHA-256", tooShort));
+
+    byte[] tooLong = new byte[64];
+    Arrays.fill(tooLong, (byte) 0xbb);
+    assertThrows(
+        IllegalArgumentException.class, () -> DigestUtils.digestInfoWrap("SHA-256", tooLong));
+  }
+}

--- a/tst/com/amazon/corretto/crypto/provider/test/DigestUtilsTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/DigestUtilsTest.java
@@ -29,6 +29,48 @@ public class DigestUtilsTest {
   private static final byte[] SHA1_PREFIX = {
     0x30, 0x21, 0x30, 0x09, 0x06, 0x05, 0x2b, 0x0e, 0x03, 0x02, 0x1a, 0x05, 0x00, 0x04, 0x14
   };
+  private static final byte[] SHA224_PREFIX = {
+    0x30,
+    0x2d,
+    0x30,
+    0x0d,
+    0x06,
+    0x09,
+    0x60,
+    (byte) 0x86,
+    0x48,
+    0x01,
+    0x65,
+    0x03,
+    0x04,
+    0x02,
+    0x04,
+    0x05,
+    0x00,
+    0x04,
+    0x1c
+  };
+  private static final byte[] SHA512_224_PREFIX = {
+    0x30,
+    0x2d,
+    0x30,
+    0x0d,
+    0x06,
+    0x09,
+    0x60,
+    (byte) 0x86,
+    0x48,
+    0x01,
+    0x65,
+    0x03,
+    0x04,
+    0x02,
+    0x05,
+    0x05,
+    0x00,
+    0x04,
+    0x1c
+  };
   private static final byte[] SHA256_PREFIX = {
     0x30,
     0x31,
@@ -211,7 +253,6 @@ public class DigestUtilsTest {
         MessageDigest.getInstance("SHA-256", NATIVE_PROVIDER).digest("hello".getBytes());
     byte[] wrapped = DigestUtils.digestInfoWrap("SHA-256", digest);
     assertArrayEquals(concat(SHA256_PREFIX, digest), wrapped);
-    assertEquals(digest.length + 19, wrapped.length);
   }
 
   @Test
@@ -219,7 +260,6 @@ public class DigestUtilsTest {
     byte[] digest = MessageDigest.getInstance("SHA-1", NATIVE_PROVIDER).digest("hello".getBytes());
     byte[] wrapped = DigestUtils.digestInfoWrap("SHA-1", digest);
     assertArrayEquals(concat(SHA1_PREFIX, digest), wrapped);
-    assertEquals(digest.length + 15, wrapped.length);
   }
 
   @Test
@@ -239,7 +279,24 @@ public class DigestUtilsTest {
   }
 
   @Test
+  public void testSha224() throws Exception {
+    // ACCP doesn't register SHA-224, so use the JDK default provider.
+    byte[] digest = MessageDigest.getInstance("SHA-224").digest("hello".getBytes());
+    byte[] wrapped = DigestUtils.digestInfoWrap("SHA-224", digest);
+    assertArrayEquals(concat(SHA224_PREFIX, digest), wrapped);
+  }
+
+  @Test
+  public void testSha512_224() throws Exception {
+    // Below uses JDK default provider as ACCP doesn't support truncated SHA-512 digests
+    byte[] digest = MessageDigest.getInstance("SHA-512/224").digest("hello".getBytes());
+    byte[] wrapped = DigestUtils.digestInfoWrap("SHA-512/224", digest);
+    assertArrayEquals(concat(SHA512_224_PREFIX, digest), wrapped);
+  }
+
+  @Test
   public void testSha512_256() throws Exception {
+    // Below uses JDK default provider as ACCP doesn't support truncated SHA-512 digests
     byte[] digest = MessageDigest.getInstance("SHA-512/256").digest("hello".getBytes());
     byte[] wrapped = DigestUtils.digestInfoWrap("SHA-512/256", digest);
     assertArrayEquals(concat(SHA512_256_PREFIX, digest), wrapped);
@@ -278,6 +335,13 @@ public class DigestUtilsTest {
     Arrays.fill(digest, (byte) 0x44);
     byte[] wrapped = DigestUtils.digestInfoWrap("SHA3-512", digest);
     assertArrayEquals(concat(SHA3_512_PREFIX, digest), wrapped);
+  }
+
+  @Test
+  public void testLowerCaseShaValid() throws Exception {
+    byte[] digest = new byte[32];
+    byte[] wrapped = DigestUtils.digestInfoWrap("sha-256", digest);
+    assertArrayEquals(concat(SHA256_PREFIX, digest), wrapped);
   }
 
   @Test


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR provides a static utility function `DigestUtils.digestInfoWrap` to wrap a digest in a `DigestInfo` DER encoding wrapper per RFC 8017 Sec. 9.2. We provide a few basic KAT tests for common digest algorithms.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
