### PR TITLE
Restrict X25519 >JDK11, no-op KeyPairGenerator init

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,14 +89,14 @@ KeyPairGenerator:
 * EC
 * RSA
 * ED25519
-* X25519 (JDK >11)
+* X25519 (JDK 12+)
 
 KeyGenerator:
 * AES
 
 KeyAgreement:
 * ECDH
-* X25519 (JDK >11)
+* X25519 (JDK 12+)
 
 KEM algorithms:
 * ML-KEM (JDK 17+ LTS, also see [ML-KEM Considerations](#ml-kem-considerations))
@@ -122,7 +122,7 @@ KeyFactory:
 * EC
 * RSA
 * ED25519 (JDK 15+). Please refer to [system properties](https://github.com/corretto/amazon-corretto-crypto-provider#other-system-properties) for more information.
-* X25519 (JDK >11)
+* X25519 (JDK 12+)
 
 AlgorithmParameters:
 * EC. Please refer to [system properties](https://github.com/corretto/amazon-corretto-crypto-provider#other-system-properties) for more information.

--- a/README.md
+++ b/README.md
@@ -89,14 +89,14 @@ KeyPairGenerator:
 * EC
 * RSA
 * ED25519
-* X25519 (JDK ≥11)
+* X25519 (JDK >11)
 
 KeyGenerator:
 * AES
 
 KeyAgreement:
 * ECDH
-* X25519 (JDK ≥11)
+* X25519 (JDK >11)
 
 KEM algorithms:
 * ML-KEM (JDK 17+ LTS, also see [ML-KEM Considerations](#ml-kem-considerations))
@@ -122,7 +122,7 @@ KeyFactory:
 * EC
 * RSA
 * ED25519 (JDK 15+). Please refer to [system properties](https://github.com/corretto/amazon-corretto-crypto-provider#other-system-properties) for more information.
-* X25519 (JDK ≥11)
+* X25519 (JDK >11)
 
 AlgorithmParameters:
 * EC. Please refer to [system properties](https://github.com/corretto/amazon-corretto-crypto-provider#other-system-properties) for more information.

--- a/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
+++ b/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
@@ -602,7 +602,9 @@ public final class AmazonCorrettoCryptoProvider extends java.security.Provider {
 
     this.shouldRegisterMLKEM = Utils.isMlKemSupported();
 
-    this.shouldRegisterX25519 = Utils.getJavaVersion() >= 11;
+    // XECKeys were introduced in JDK11, but ACCP's keys aren't compatible until JDK12+.
+    // See comment in XDHGen.java for more details.
+    this.shouldRegisterX25519 = Utils.getJavaVersion() > 11;
 
     this.nativeContextReleaseStrategy = Utils.getNativeContextReleaseStrategyProperty();
 

--- a/src/com/amazon/corretto/crypto/provider/EvpKeyPairGenerator.java
+++ b/src/com/amazon/corretto/crypto/provider/EvpKeyPairGenerator.java
@@ -27,7 +27,7 @@ abstract class EvpKeyPairGenerator extends KeyPairGeneratorSpi {
 
   @Override
   public void initialize(final int keysize, final SecureRandom random) {
-    throw new UnsupportedOperationException();
+    // No-op for compatibility
   }
 
   // Provides an appropriate KeyFactory for this key type

--- a/src/com/amazon/corretto/crypto/provider/EvpKeyPairGenerator.java
+++ b/src/com/amazon/corretto/crypto/provider/EvpKeyPairGenerator.java
@@ -27,7 +27,12 @@ abstract class EvpKeyPairGenerator extends KeyPairGeneratorSpi {
 
   @Override
   public void initialize(final int keysize, final SecureRandom random) {
-    // No-op for compatibility
+    // No-op for compatibility with callers (e.g. BouncyCastle TLS) that invoke
+    // initialize(int, SecureRandom) before generateKeyPair(). The keysize is
+    // fixed by the underlying algorithm, so there is nothing to configure, and
+    // ACCP's generator always uses libcrypto's DRBG regardless of |random|.
+    // Note: initialize(AlgorithmParameterSpec, SecureRandom) is intentionally
+    // left to throw UnsupportedOperationException via the default SPI impl.
   }
 
   // Provides an appropriate KeyFactory for this key type

--- a/tst/com/amazon/corretto/crypto/provider/test/EvpKeyAgreementSpecificTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/EvpKeyAgreementSpecificTest.java
@@ -73,19 +73,20 @@ public class EvpKeyAgreementSpecificTest {
 
   @Test
   public void testXECKeyAgreementWithBouncyCastle() throws Exception {
+    TestUtil.assumeMinimumJavaVersion(17);
     assertAccpXECKeysInteropWith("X25519", TestUtil.BC_PROVIDER);
     assertAccpXECKeysInteropWith("XDH", TestUtil.BC_PROVIDER);
   }
 
   @Test
   public void testXECKeyAgreementWithSunEC() throws Exception {
+    TestUtil.assumeMinimumJavaVersion(17);
     assertAccpXECKeysInteropWith("X25519", Security.getProvider("SunEC"));
     assertAccpXECKeysInteropWith("XDH", Security.getProvider("SunEC"));
   }
 
   private static void assertAccpXECKeysInteropWith(final String algorithm, final Provider provider)
       throws Exception {
-    TestUtil.assumeMinimumJavaVersion(11);
     final KeyPairGenerator keyPairGenerator =
         KeyPairGenerator.getInstance(algorithm, NATIVE_PROVIDER);
     final KeyPair aliceKeyPair = keyPairGenerator.generateKeyPair();

--- a/tst/com/amazon/corretto/crypto/provider/test/EvpKeyAgreementSpecificTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/EvpKeyAgreementSpecificTest.java
@@ -14,6 +14,8 @@ import java.security.Key;
 import java.security.KeyFactory;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
+import java.security.Provider;
+import java.security.Security;
 import java.security.interfaces.ECPublicKey;
 import java.security.spec.ECGenParameterSpec;
 import javax.crypto.KeyAgreement;
@@ -67,6 +69,39 @@ public class EvpKeyAgreementSpecificTest {
             agree(
                 EC_KEYPAIR.getPrivate(),
                 EvpKeyAgreementTest.buildKeyOnWrongCurve((ECPublicKey) EC_KEYPAIR.getPublic())));
+  }
+
+  @Test
+  public void testXECKeyAgreementWithBouncyCastle() throws Exception {
+    assertAccpXECKeysInteropWith("X25519", TestUtil.BC_PROVIDER);
+    assertAccpXECKeysInteropWith("XDH", TestUtil.BC_PROVIDER);
+  }
+
+  @Test
+  public void testXECKeyAgreementWithSunEC() throws Exception {
+    assertAccpXECKeysInteropWith("X25519", Security.getProvider("SunEC"));
+    assertAccpXECKeysInteropWith("XDH", Security.getProvider("SunEC"));
+  }
+
+  private static void assertAccpXECKeysInteropWith(final String algorithm, final Provider provider)
+      throws Exception {
+    TestUtil.assumeMinimumJavaVersion(11);
+    final KeyPairGenerator keyPairGenerator =
+        KeyPairGenerator.getInstance(algorithm, NATIVE_PROVIDER);
+    final KeyPair aliceKeyPair = keyPairGenerator.generateKeyPair();
+    final KeyPair bobKeyPair = keyPairGenerator.generateKeyPair();
+
+    final KeyAgreement aliceAgreement = KeyAgreement.getInstance(algorithm, provider);
+    aliceAgreement.init(aliceKeyPair.getPrivate());
+    aliceAgreement.doPhase(bobKeyPair.getPublic(), true);
+    final byte[] aliceSecret = aliceAgreement.generateSecret();
+
+    final KeyAgreement bobAgreement = KeyAgreement.getInstance(algorithm, provider);
+    bobAgreement.init(bobKeyPair.getPrivate());
+    bobAgreement.doPhase(aliceKeyPair.getPublic(), true);
+    final byte[] bobSecret = bobAgreement.generateSecret();
+
+    assertArrayEquals(aliceSecret, bobSecret);
   }
 
   @Test

--- a/tst/com/amazon/corretto/crypto/provider/test/EvpKeyAgreementSpecificTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/EvpKeyAgreementSpecificTest.java
@@ -15,6 +15,7 @@ import java.security.KeyFactory;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.Provider;
+import java.security.SecureRandom;
 import java.security.Security;
 import java.security.interfaces.ECPublicKey;
 import java.security.spec.ECGenParameterSpec;
@@ -89,6 +90,9 @@ public class EvpKeyAgreementSpecificTest {
       throws Exception {
     final KeyPairGenerator keyPairGenerator =
         KeyPairGenerator.getInstance(algorithm, NATIVE_PROVIDER);
+    // Exercise the BC TLS compatibility path: callers may invoke initialize(int, SecureRandom)
+    // before generateKeyPair(). 255 is the X25519 key size in bits.
+    keyPairGenerator.initialize(255, new SecureRandom());
     final KeyPair aliceKeyPair = keyPairGenerator.generateKeyPair();
     final KeyPair bobKeyPair = keyPairGenerator.generateKeyPair();
 

--- a/tst/com/amazon/corretto/crypto/provider/test/EvpKeyAgreementTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/EvpKeyAgreementTest.java
@@ -68,7 +68,7 @@ public class EvpKeyAgreementTest {
     MASTER_PARAMS_LIST.add(buildEcdhParameters(new ECGenParameterSpec("NIST P-384"), "NIST P-384"));
     MASTER_PARAMS_LIST.add(buildEcdhParameters(new ECGenParameterSpec("NIST P-521"), "NIST P-521"));
     MASTER_PARAMS_LIST.add(buildEcdhParameters(EcGenTest.EXPLICIT_CURVE, "Explicit Curve"));
-    if (TestUtil.JAVA_VERSION >= 11) {
+    if (TestUtil.JAVA_VERSION > 11) {
       MASTER_PARAMS_LIST.add(buildX25519Parameters());
     }
   }

--- a/tst/com/amazon/corretto/crypto/provider/test/KeyPairGeneratorTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/KeyPairGeneratorTest.java
@@ -10,6 +10,7 @@ import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
 import java.security.PublicKey;
+import java.security.SecureRandom;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.parallel.Execution;
@@ -31,7 +32,7 @@ public class KeyPairGeneratorTest {
   }
 
   @Test
-  public void generateXECKeys() {
+  public void testGenerateXECKeys() {
     TestUtil.assumeMinimumJavaVersion(11);
     final KeyPairGenerator keyPairGenerator = getXECKeyPairGenerator();
     assertEquals("X25519", keyPairGenerator.getAlgorithm());
@@ -50,5 +51,13 @@ public class KeyPairGeneratorTest {
     assertEquals("X.509", publicKey.getFormat());
     assertEquals("XDH", publicKey.getAlgorithm());
     assertEquals(44, publicKey.getEncoded().length);
+  }
+
+  @Test
+  public void testInitKeyPairNoOp() {
+    TestUtil.assumeMinimumJavaVersion(11);
+    final KeyPairGenerator keyPairGenerator = getXECKeyPairGenerator();
+    keyPairGenerator.initialize(123, new SecureRandom());
+    keyPairGenerator.generateKeyPair();
   }
 }

--- a/tst/com/amazon/corretto/crypto/provider/test/KeyPairGeneratorTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/KeyPairGeneratorTest.java
@@ -23,9 +23,9 @@ import org.junit.jupiter.api.parallel.ResourceLock;
 @ResourceLock(value = TestUtil.RESOURCE_GLOBAL, mode = ResourceAccessMode.READ)
 public class KeyPairGeneratorTest {
 
-  KeyPairGenerator getXECKeyPairGenerator() {
+  KeyPairGenerator getKeyPairGenerator(String alg) {
     try {
-      return KeyPairGenerator.getInstance("X25519", TestUtil.NATIVE_PROVIDER);
+      return KeyPairGenerator.getInstance(alg, TestUtil.NATIVE_PROVIDER);
     } catch (final NoSuchAlgorithmException e) {
       throw new RuntimeException(e);
     }
@@ -34,7 +34,7 @@ public class KeyPairGeneratorTest {
   @Test
   public void testGenerateXECKeys() {
     TestUtil.assumeMinimumJavaVersion(17);
-    final KeyPairGenerator keyPairGenerator = getXECKeyPairGenerator();
+    final KeyPairGenerator keyPairGenerator = getKeyPairGenerator("X25519");
     assertEquals("X25519", keyPairGenerator.getAlgorithm());
 
     final KeyPair keyPair = keyPairGenerator.generateKeyPair();
@@ -56,10 +56,12 @@ public class KeyPairGeneratorTest {
   @Test
   public void testInitKeyPairNoOp() {
     TestUtil.assumeMinimumJavaVersion(17);
-    final KeyPairGenerator keyPairGenerator = getXECKeyPairGenerator();
-    // 255 is X25519's key size in bits; ACCP ignores it (and the SecureRandom),
-    // but the call must not throw. This mirrors BouncyCastle TLS's invocation.
-    keyPairGenerator.initialize(255, new SecureRandom());
-    keyPairGenerator.generateKeyPair();
+    for (String alg : new String[] {"Ed25519", "X25519"}) {
+      final KeyPairGenerator keyPairGenerator = getKeyPairGenerator(alg);
+      // 255 is Curve25519's key size in bits; ACCP ignores it (and the SecureRandom),
+      // but the call must not throw. This mirrors BouncyCastle TLS's invocation.
+      keyPairGenerator.initialize(255, new SecureRandom());
+      keyPairGenerator.generateKeyPair();
+    }
   }
 }

--- a/tst/com/amazon/corretto/crypto/provider/test/KeyPairGeneratorTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/KeyPairGeneratorTest.java
@@ -57,7 +57,9 @@ public class KeyPairGeneratorTest {
   public void testInitKeyPairNoOp() {
     TestUtil.assumeMinimumJavaVersion(17);
     final KeyPairGenerator keyPairGenerator = getXECKeyPairGenerator();
-    keyPairGenerator.initialize(123, new SecureRandom());
+    // 255 is X25519's key size in bits; ACCP ignores it (and the SecureRandom),
+    // but the call must not throw. This mirrors BouncyCastle TLS's invocation.
+    keyPairGenerator.initialize(255, new SecureRandom());
     keyPairGenerator.generateKeyPair();
   }
 }

--- a/tst/com/amazon/corretto/crypto/provider/test/KeyPairGeneratorTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/KeyPairGeneratorTest.java
@@ -33,7 +33,7 @@ public class KeyPairGeneratorTest {
 
   @Test
   public void testGenerateXECKeys() {
-    TestUtil.assumeMinimumJavaVersion(11);
+    TestUtil.assumeMinimumJavaVersion(17);
     final KeyPairGenerator keyPairGenerator = getXECKeyPairGenerator();
     assertEquals("X25519", keyPairGenerator.getAlgorithm());
 
@@ -55,7 +55,7 @@ public class KeyPairGeneratorTest {
 
   @Test
   public void testInitKeyPairNoOp() {
-    TestUtil.assumeMinimumJavaVersion(11);
+    TestUtil.assumeMinimumJavaVersion(17);
     final KeyPairGenerator keyPairGenerator = getXECKeyPairGenerator();
     keyPairGenerator.initialize(123, new SecureRandom());
     keyPairGenerator.generateKeyPair();


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

BouncyCastle's TLS implementation [calls](https://github.com/bcgit/bc-java/blob/848055162f8591b8060950040d32e6b5ced32c72/tls/src/main/java/org/bouncycastle/tls/crypto/impl/jcajce/JceX25519Domain.java#L71) `KeyPairGenerator.initialize`, in which case we currently `throw UnsupportedOperationException`. This behavior appears to be elective -- `KeyPairGeneratorSpi` [doesn't require this](https://docs.oracle.com/javase/8/docs/api/java/security/KeyPairGeneratorSpi.html#initialize-java.security.spec.AlgorithmParameterSpec-java.security.SecureRandom-) by contract. Silently ignoring specified key size and DRBG isn't ideal, but with this change we trade strictness/clarity for compatibility.

We also restrict registration of X25519 KeyPairGenerator, KeyFactory, and KeyAgreement to JDK versions strictly >11 due to JDK-internal compatibility issues found while testing the above change.

---


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.