### PR TITLE
Re-init AES-GCM native context when IV length changes

### DIFF
--- a/src/com/amazon/corretto/crypto/provider/AesGcmSpi.java
+++ b/src/com/amazon/corretto/crypto/provider/AesGcmSpi.java
@@ -398,7 +398,14 @@ final class AesGcmSpi extends CipherSpi {
       final byte[] newIv)
       throws InvalidAlgorithmParameterException {
 
-    final boolean sameKey = ConstantTime.equals(lastKey, newKey);
+    // The cached EVP_CIPHER_CTX retains its ivlen from the prior init.
+    // Reusing it with a new IV of a different length would either read past
+    // the new IV buffer or silently truncate the nonce, so treat differing
+    // IV lengths as a key change to force a full native re-init.
+    final boolean secretKeyIsTheSame = ConstantTime.equals(lastKey, newKey);
+    final boolean ivLengthIsTheSame =
+        lastIv != null && newIv != null && lastIv.length == newIv.length;
+    final boolean sameKey = secretKeyIsTheSame && ivLengthIsTheSame;
 
     if (sameKey
         && (jceOpMode == Cipher.ENCRYPT_MODE || jceOpMode == Cipher.WRAP_MODE)

--- a/tst/com/amazon/corretto/crypto/provider/test/AesTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/AesTest.java
@@ -397,6 +397,34 @@ public class AesTest {
     }
   }
 
+  /**
+   * V2200543407: re-initializing a Cipher with the same key but a different-length IV must produce
+   * the same output as a fresh Cipher. The native EVP_CIPHER_CTX caches its ivlen from the prior
+   * init; if reused, a different-length IV would be truncated or read past the buffer. The two
+   * primer cycles get the native context cached so the regression step exercises that reuse path;
+   * primer IVs must differ to avoid the "Cannot reuse same iv and key" guard.
+   */
+  @Test
+  public void gcm_reinit_differentIvLengthMustNotReuseCachedIvlen()
+      throws GeneralSecurityException {
+    final byte[] ivPrimerA = TestUtil.getRandomBytes(12);
+    final byte[] ivPrimerB = TestUtil.getRandomBytes(12);
+    amznC.init(Cipher.ENCRYPT_MODE, key, new GCMParameterSpec(128, ivPrimerA));
+    amznC.doFinal(PLAINTEXT);
+    amznC.init(Cipher.ENCRYPT_MODE, key, new GCMParameterSpec(128, ivPrimerB));
+    amznC.doFinal(PLAINTEXT);
+
+    final byte[] ivDifferentLength = TestUtil.getRandomBytes(16);
+    amznC.init(Cipher.ENCRYPT_MODE, key, new GCMParameterSpec(128, ivDifferentLength));
+    final byte[] ctReused = amznC.doFinal(PLAINTEXT);
+
+    final Cipher fresh = Cipher.getInstance(ALGO_NAME, NATIVE_PROVIDER);
+    fresh.init(Cipher.ENCRYPT_MODE, key, new GCMParameterSpec(128, ivDifferentLength));
+    final byte[] ctFresh = fresh.doFinal(PLAINTEXT);
+
+    assertArrayEquals(ctFresh, ctReused);
+  }
+
   @Test
   public void edge_badSetMode() throws Throwable {
     assertThrows(


### PR DESCRIPTION
*Issue #, if available:*
  
  `V2200543407`

*Description of changes:*
  
`AesGcmSpi.checkKeyIvPair` decided `sameKey` from the key bytes alone, so re-initializing a `Cipher` with the same key but an IV with a different length took the cached-context fast path in the native layer and kept the prior `ivlen`.
This would either read past the new IV buffer (shorter new IV) or silently truncates the nonce (longer new IV, causing nonce reuse when IVs share a prefix).
  
Treat a differing IV length as a non-match so the fast path is skipped and the native layer runs a full re-init. Two regression tests added to `AesTest` covering both directions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
