### PR TITLE
Add support for PBKDF2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -330,6 +330,7 @@ set(C_SRC
     csrc/libcrypto_rng.cpp
     csrc/loader.cpp
     csrc/md5.cpp
+    csrc/pbkdf2.cpp
     csrc/rsa_cipher.cpp
     csrc/rsa_gen.cpp
     csrc/sha1.cpp

--- a/csrc/pbkdf2.cpp
+++ b/csrc/pbkdf2.cpp
@@ -1,0 +1,37 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+#include "buffer.h"
+#include "env.h"
+#include "generated-headers.h"
+#include <openssl/evp.h>
+
+using namespace AmazonCorrettoCryptoProvider;
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_amazon_corretto_crypto_provider_Pbkdf2SecretKeyFactorySpi_pbkdf2(JNIEnv* env,
+                                                                          jclass,
+                                                                          jbyteArray jPassword,
+                                                                          jint passwordLen,
+                                                                          jbyteArray jSalt,
+                                                                          jint saltLen,
+                                                                          jint iterations,
+                                                                          jint digestCode,
+                                                                          jbyteArray jOutput,
+                                                                          jint outputLen)
+{
+    try {
+        JByteArrayCritical password(env, jPassword);
+        JByteArrayCritical salt(env, jSalt);
+        JByteArrayCritical output(env, jOutput);
+        EVP_MD const* digest = digest_code_to_EVP_MD(digestCode);
+
+        if (PKCS5_PBKDF2_HMAC(reinterpret_cast<const char*>(password.get()), passwordLen, salt.get(), saltLen,
+                              iterations, digest, outputLen, output.get())
+            != 1) {
+            throw_openssl(EX_RUNTIME_CRYPTO, "PBKDF2 failed.");
+        }
+
+    } catch (java_ex& ex) {
+        ex.throw_to_java(env);
+    }
+}

--- a/csrc/pbkdf2.cpp
+++ b/csrc/pbkdf2.cpp
@@ -28,7 +28,7 @@ Java_com_amazon_corretto_crypto_provider_Pbkdf2SecretKeyFactorySpi_pbkdf2(JNIEnv
         if (PKCS5_PBKDF2_HMAC(reinterpret_cast<const char*>(password.get()), passwordLen, salt.get(), saltLen,
                               iterations, digest, outputLen, output.get())
             != 1) {
-            throw_openssl(EX_RUNTIME_CRYPTO, "PBKDF2 failed.");
+            throw_openssl(EX_RUNTIME_CRYPTO, "Heap allocation in PBKDF2 failed.");
         }
 
     } catch (java_ex& ex) {

--- a/csrc/util.cpp
+++ b/csrc/util.cpp
@@ -59,6 +59,8 @@ EVP_MD const* digest_code_to_EVP_MD(int digestCode)
         return EVP_sha384();
     case com_amazon_corretto_crypto_provider_Utils_SHA512_CODE:
         return EVP_sha512();
+    case com_amazon_corretto_crypto_provider_Utils_SHA224_CODE:
+        return EVP_sha224();
     default:
         throw java_ex(EX_ERROR, "THIS SHOULD NOT BE REACHABLE.");
     }

--- a/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
+++ b/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
@@ -23,6 +23,11 @@ import static com.amazon.corretto.crypto.provider.Loader.EXPERIMENTAL_FIPS_BUILD
 import static com.amazon.corretto.crypto.provider.Loader.FIPS_BUILD;
 import static com.amazon.corretto.crypto.provider.Loader.PROVIDER_VERSION;
 import static com.amazon.corretto.crypto.provider.Loader.PROVIDER_VERSION_STR;
+import static com.amazon.corretto.crypto.provider.Pbkdf2SecretKeyFactorySpi.PBKDF2_WITH_SHA1;
+import static com.amazon.corretto.crypto.provider.Pbkdf2SecretKeyFactorySpi.PBKDF2_WITH_SHA224;
+import static com.amazon.corretto.crypto.provider.Pbkdf2SecretKeyFactorySpi.PBKDF2_WITH_SHA256;
+import static com.amazon.corretto.crypto.provider.Pbkdf2SecretKeyFactorySpi.PBKDF2_WITH_SHA384;
+import static com.amazon.corretto.crypto.provider.Pbkdf2SecretKeyFactorySpi.PBKDF2_WITH_SHA512;
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonMap;
@@ -138,6 +143,13 @@ public final class AmazonCorrettoCryptoProvider extends java.security.Provider {
     addService("SecretKeyFactory", HKDF_WITH_SHA256, hkdfSpi, false);
     addService("SecretKeyFactory", HKDF_WITH_SHA384, hkdfSpi, false);
     addService("SecretKeyFactory", HKDF_WITH_SHA512, hkdfSpi, false);
+
+    final String pbkdf2Spi = "Pbkdf2SecretKeyFactorySpi";
+    addService("SecretKeyFactory", PBKDF2_WITH_SHA1, pbkdf2Spi, false);
+    addService("SecretKeyFactory", PBKDF2_WITH_SHA224, pbkdf2Spi, false);
+    addService("SecretKeyFactory", PBKDF2_WITH_SHA256, pbkdf2Spi, false);
+    addService("SecretKeyFactory", PBKDF2_WITH_SHA384, pbkdf2Spi, false);
+    addService("SecretKeyFactory", PBKDF2_WITH_SHA512, pbkdf2Spi, false);
 
     final String concatenationKdfSpi = "ConcatenationKdfSpi";
     addService("SecretKeyFactory", CKDF_WITH_SHA256, concatenationKdfSpi, false);
@@ -435,6 +447,13 @@ public final class AmazonCorrettoCryptoProvider extends java.security.Provider {
                   HkdfSecretKeyFactorySpi.getSpiFactoryForAlgName(algo));
           if (spi != null) {
             return spi;
+          }
+
+          final Pbkdf2SecretKeyFactorySpi pbkdf2Spi =
+              Pbkdf2SecretKeyFactorySpi.INSTANCES.get(
+                  Pbkdf2SecretKeyFactorySpi.getSpiFactoryForAlgName(algo));
+          if (pbkdf2Spi != null) {
+            return pbkdf2Spi;
           }
 
           final ConcatenationKdfSpi ckdfSpi =

--- a/src/com/amazon/corretto/crypto/provider/Pbkdf2SecretKeyFactorySpi.java
+++ b/src/com/amazon/corretto/crypto/provider/Pbkdf2SecretKeyFactorySpi.java
@@ -47,14 +47,8 @@ class Pbkdf2SecretKeyFactorySpi extends KdfSpi {
     final int iterations = spec.getIterationCount();
     final int keyLengthBits = spec.getKeyLength();
 
-    if (password == null) {
-      throw new InvalidKeySpecException("Password cannot be null");
-    }
     if (salt == null) {
       throw new InvalidKeySpecException("Salt cannot be null");
-    }
-    if (iterations < 1) {
-      throw new InvalidKeySpecException("Positive iteration count required");
     }
     if (keyLengthBits <= 0) {
       throw new InvalidKeySpecException("Positive key length required");
@@ -89,8 +83,7 @@ class Pbkdf2SecretKeyFactorySpi extends KdfSpi {
     final int len = bb.limit();
     final byte[] passwordBytes = new byte[len];
     bb.get(passwordBytes, 0, len);
-    bb.clear();
-    bb.put(new byte[len]);
+    Arrays.fill(bb.array(), bb.arrayOffset(), bb.arrayOffset() + bb.capacity(), (byte) 0);
     return passwordBytes;
   }
 

--- a/src/com/amazon/corretto/crypto/provider/Pbkdf2SecretKeyFactorySpi.java
+++ b/src/com/amazon/corretto/crypto/provider/Pbkdf2SecretKeyFactorySpi.java
@@ -1,0 +1,129 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package com.amazon.corretto.crypto.provider;
+
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.StandardCharsets;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.KeySpec;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.PBEKeySpec;
+import javax.crypto.spec.SecretKeySpec;
+
+class Pbkdf2SecretKeyFactorySpi extends KdfSpi {
+
+  private final int digestCode;
+  private final String algorithmName;
+
+  private Pbkdf2SecretKeyFactorySpi(final int digestCode, final String algorithmName) {
+    this.digestCode = digestCode;
+    this.algorithmName = algorithmName;
+  }
+
+  private static native void pbkdf2(
+      byte[] jPassword,
+      int passwordLen,
+      byte[] jSalt,
+      int saltLen,
+      int iterations,
+      int digestCode,
+      byte[] jOutput,
+      int outputLen);
+
+  @Override
+  protected SecretKey engineGenerateSecret(final KeySpec keySpec) throws InvalidKeySpecException {
+    if (!(keySpec instanceof PBEKeySpec)) {
+      throw new InvalidKeySpecException("KeySpec must be an instance of PBEKeySpec");
+    }
+
+    final PBEKeySpec spec = (PBEKeySpec) keySpec;
+    final char[] password = spec.getPassword();
+    final byte[] salt = spec.getSalt();
+    final int iterations = spec.getIterationCount();
+    final int keyLengthBits = spec.getKeyLength();
+
+    if (password == null) {
+      throw new InvalidKeySpecException("Password cannot be null");
+    }
+    if (salt == null) {
+      throw new InvalidKeySpecException("Salt cannot be null");
+    }
+    if (iterations < 1) {
+      throw new InvalidKeySpecException("Positive iteration count required");
+    }
+    if (keyLengthBits <= 0) {
+      throw new InvalidKeySpecException("Positive key length required");
+    }
+
+    final byte[] passwordBytes = charsToBytes(password);
+    final byte[] derivedKey = new byte[keyLengthBits / 8];
+
+    try {
+      pbkdf2(
+          passwordBytes,
+          passwordBytes.length,
+          salt,
+          salt.length,
+          iterations,
+          digestCode,
+          derivedKey,
+          derivedKey.length);
+      return new SecretKeySpec(derivedKey, algorithmName);
+    } finally {
+      Arrays.fill(passwordBytes, (byte) 0);
+      Arrays.fill(derivedKey, (byte) 0);
+    }
+  }
+
+  // PBKDF2 takes the password as a byte string, but PBEKeySpec holds
+  // it as a char array, so we must convert to bytes before calling into PBKDF2. We use
+  // UTF-8 to match SunJCE so keys are identical across providers for any PBEKeySpec input.
+  // https://github.com/openjdk/jdk/blob/a73eca9e8b1b96925b4b4d4ccfeffe9891fd8ce1/src/java.base/share/classes/com/sun/crypto/provider/PBKDF2KeyImpl.java#L48-L57
+  private static byte[] charsToBytes(final char[] password) {
+    final ByteBuffer bb = StandardCharsets.UTF_8.encode(CharBuffer.wrap(password));
+    final int len = bb.limit();
+    final byte[] passwordBytes = new byte[len];
+    bb.get(passwordBytes, 0, len);
+    bb.clear();
+    bb.put(new byte[len]);
+    return passwordBytes;
+  }
+
+  static final Map<String, Pbkdf2SecretKeyFactorySpi> INSTANCES = getInstances();
+
+  private static final String PBKDF2_PREFIX = "PBKDF2WithHmac";
+  static final String PBKDF2_WITH_SHA1 = PBKDF2_PREFIX + "SHA1";
+  static final String PBKDF2_WITH_SHA224 = PBKDF2_PREFIX + "SHA224";
+  static final String PBKDF2_WITH_SHA256 = PBKDF2_PREFIX + "SHA256";
+  static final String PBKDF2_WITH_SHA384 = PBKDF2_PREFIX + "SHA384";
+  static final String PBKDF2_WITH_SHA512 = PBKDF2_PREFIX + "SHA512";
+
+  private static Map<String, Pbkdf2SecretKeyFactorySpi> getInstances() {
+    final Map<String, Pbkdf2SecretKeyFactorySpi> result = new HashMap<>();
+    result.put(
+        getSpiFactoryForAlgName(PBKDF2_WITH_SHA1),
+        new Pbkdf2SecretKeyFactorySpi(Utils.SHA1_CODE, PBKDF2_WITH_SHA1));
+    result.put(
+        getSpiFactoryForAlgName(PBKDF2_WITH_SHA224),
+        new Pbkdf2SecretKeyFactorySpi(Utils.SHA224_CODE, PBKDF2_WITH_SHA224));
+    result.put(
+        getSpiFactoryForAlgName(PBKDF2_WITH_SHA256),
+        new Pbkdf2SecretKeyFactorySpi(Utils.SHA256_CODE, PBKDF2_WITH_SHA256));
+    result.put(
+        getSpiFactoryForAlgName(PBKDF2_WITH_SHA384),
+        new Pbkdf2SecretKeyFactorySpi(Utils.SHA384_CODE, PBKDF2_WITH_SHA384));
+    result.put(
+        getSpiFactoryForAlgName(PBKDF2_WITH_SHA512),
+        new Pbkdf2SecretKeyFactorySpi(Utils.SHA512_CODE, PBKDF2_WITH_SHA512));
+    return Collections.unmodifiableMap(result);
+  }
+
+  static String getSpiFactoryForAlgName(final String alg) {
+    return alg.toUpperCase();
+  }
+}

--- a/src/com/amazon/corretto/crypto/provider/Pbkdf2SecretKeyFactorySpi.java
+++ b/src/com/amazon/corretto/crypto/provider/Pbkdf2SecretKeyFactorySpi.java
@@ -42,7 +42,6 @@ class Pbkdf2SecretKeyFactorySpi extends KdfSpi {
     }
 
     final PBEKeySpec spec = (PBEKeySpec) keySpec;
-    final char[] password = spec.getPassword();
     final byte[] salt = spec.getSalt();
     final int iterations = spec.getIterationCount();
     final int keyLengthBits = spec.getKeyLength();
@@ -54,6 +53,7 @@ class Pbkdf2SecretKeyFactorySpi extends KdfSpi {
       throw new InvalidKeySpecException("Positive key length required");
     }
 
+    final char[] password = spec.getPassword();
     final byte[] passwordBytes = charsToBytes(password);
     final byte[] derivedKey = new byte[keyLengthBits / 8];
 
@@ -69,6 +69,7 @@ class Pbkdf2SecretKeyFactorySpi extends KdfSpi {
           derivedKey.length);
       return new SecretKeySpec(derivedKey, algorithmName);
     } finally {
+      Arrays.fill(password, '\0');
       Arrays.fill(passwordBytes, (byte) 0);
       Arrays.fill(derivedKey, (byte) 0);
     }

--- a/src/com/amazon/corretto/crypto/provider/Utils.java
+++ b/src/com/amazon/corretto/crypto/provider/Utils.java
@@ -30,6 +30,7 @@ final class Utils {
   static final int SHA256_CODE = 2;
   static final int SHA384_CODE = 3;
   static final int SHA512_CODE = 4;
+  static final int SHA224_CODE = 5;
   private static final String PROPERTY_NATIVE_CONTEXT_RELEASE_STRATEGY =
       "nativeContextReleaseStrategy";
 

--- a/tst/com/amazon/corretto/crypto/provider/test/Pbkdf2Test.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/Pbkdf2Test.java
@@ -185,6 +185,21 @@ public class Pbkdf2Test {
     }
   }
 
+  @Test
+  public void testUtf8Encoding() throws Exception {
+    final char[][] passwords = {"fooä".toCharArray(), "bár".toCharArray()};
+    final SecretKeyFactory sun = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA256", "SunJCE");
+    final SecretKeyFactory accp =
+        SecretKeyFactory.getInstance("PBKDF2WithHmacSHA256", TestUtil.NATIVE_PROVIDER);
+    for (char[] password : passwords) {
+      final PBEKeySpec spec = new PBEKeySpec(password, "salt".getBytes(), 1000, 256);
+      assertArrayEquals(
+          sun.generateSecret(spec).getEncoded(),
+          accp.generateSecret(spec).getEncoded(),
+          new String(password));
+    }
+  }
+
   // Verify wrong spec type, null salt, and zero key length each throw InvalidKeySpecException
   @Test
   public void invalidParameterTests() throws Exception {

--- a/tst/com/amazon/corretto/crypto/provider/test/Pbkdf2Test.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/Pbkdf2Test.java
@@ -185,9 +185,12 @@ public class Pbkdf2Test {
     }
   }
 
+  // Verify ACCP matches SunJCE for non-ASCII passwords
+  // Non-ASCII characters are encoded as Unicode escape sequences so the source compiles on the
+  // Ubuntu CI runners.
   @Test
   public void testUtf8Encoding() throws Exception {
-    final char[][] passwords = {"fooä".toCharArray(), "bár".toCharArray()};
+    final char[][] passwords = {"foo\u00e4".toCharArray(), "b\u00e1r".toCharArray()};
     final SecretKeyFactory sun = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA256", "SunJCE");
     final SecretKeyFactory accp =
         SecretKeyFactory.getInstance("PBKDF2WithHmacSHA256", TestUtil.NATIVE_PROVIDER);

--- a/tst/com/amazon/corretto/crypto/provider/test/Pbkdf2Test.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/Pbkdf2Test.java
@@ -1,0 +1,210 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package com.amazon.corretto.crypto.provider.test;
+
+import static com.amazon.corretto.crypto.provider.test.TestUtil.decodeHex;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.security.spec.InvalidKeySpecException;
+import java.util.stream.Stream;
+import javax.crypto.SecretKey;
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.PBEKeySpec;
+import javax.crypto.spec.SecretKeySpec;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@ExtendWith(TestResultLogger.class)
+@Execution(ExecutionMode.CONCURRENT)
+@ResourceLock(value = TestUtil.RESOURCE_GLOBAL, mode = ResourceAccessMode.READ)
+public class Pbkdf2Test {
+
+  private static final String[] DIGESTS = {
+    "HmacSHA1", "HmacSHA224", "HmacSHA256", "HmacSHA384", "HmacSHA512"
+  };
+
+  // Args: id, digest, password, salt, iterations, dkLenBytes, expectedHex
+  // EmptyPassword, RFC6070Vectors kKey1-4, SHA2 kKey1, SHA2 kKey2 vectors are from
+  // https://github.com/aws/aws-lc/blob/main/crypto/fipsmodule/pbkdf/pbkdf_test.cc
+  // SHA-224 and SHA-384 vectors are from
+  // https://github.com/Anti-weakpasswords/PBKDF2-GCC-OpenSSL-library/blob/master/pbkdf2_test.sh
+  private static Stream<Arguments> katVectors() {
+    return Stream.of(
+        Arguments.of(
+            "EmptyPassword",
+            "HmacSHA1",
+            "",
+            "salt",
+            1,
+            20,
+            "a33dddc30478185515311f8752895d36ea4363a2"),
+        Arguments.of(
+            "RFC6070Vectors kKey1",
+            "HmacSHA1",
+            "password",
+            "salt",
+            1,
+            20,
+            "0c60c80f961f0e71f3a9b524af6012062fe037a6"),
+        Arguments.of(
+            "RFC6070Vectors kKey2",
+            "HmacSHA1",
+            "password",
+            "salt",
+            2,
+            20,
+            "ea6c014dc72d6f8ccd1ed92ace1d41f0d8de8957"),
+        Arguments.of(
+            "RFC6070Vectors kKey3",
+            "HmacSHA1",
+            "pass\0word",
+            "sa\0lt",
+            4096,
+            16,
+            "56fa6aa75548099dcc37d7f03425e0c3"),
+        Arguments.of(
+            "RFC6070Vectors kKey4",
+            "HmacSHA1",
+            "passwordPASSWORDpassword",
+            "saltSALTsaltSALTsaltSALTsaltSALTsalt",
+            4096,
+            25,
+            "3d2eec4fe41c849b80c8d83662c0e44a8b291a964cf2f07038"),
+        Arguments.of(
+            "SHA-224 c=1",
+            "HmacSHA224",
+            "passDATAb00AB7YxDTTlRH2dqxD",
+            "saltKEYbcTcXHCBxtjD2PnBh44A",
+            1,
+            28,
+            "86ab2f3d0cb39839b46da2dd8f210915d79ad2e6f2093d155d75c8d9"),
+        Arguments.of(
+            "SHA-224 c=100000",
+            "HmacSHA224",
+            "passDATAb00AB7YxDTTlRH2dqxD",
+            "saltKEYbcTcXHCBxtjD2PnBh44A",
+            100000,
+            28,
+            "0adf2d99e7ff8dbc6b1df4382d32959021bfdacb99b796bf9089d0e3"),
+        Arguments.of(
+            "SHA2 kKey1",
+            "HmacSHA256",
+            "password",
+            "salt",
+            2,
+            32,
+            "ae4d0c95af6b46d32d0adff928f06dd02a303f8ef3c251dfd6e2d85a95474c43"),
+        Arguments.of(
+            "SHA-384 c=1",
+            "HmacSHA384",
+            "passDATAb00AB7YxDTTlRH2dqxDx19GDxDV1zFMz7E6QVqK",
+            "saltKEYbcTcXHCBxtjD2PnBh44AIQ6XUOCESOhXpEp3HrcG",
+            1,
+            48,
+            "0644a3489b088ad85a0e42be3e7f82500ec18936699151a2c90497151bac7bb6"
+                + "9300386a5e798795be3cef0a3c803227"),
+        Arguments.of(
+            "SHA-384 c=100000",
+            "HmacSHA384",
+            "passDATAb00AB7YxDTTlRH2dqxDx19GDxDV1zFMz7E6QVqK",
+            "saltKEYbcTcXHCBxtjD2PnBh44AIQ6XUOCESOhXpEp3HrcG",
+            100000,
+            48,
+            "bf625685b48fe6f187a1780c5cb8e1e4a7b0dbd6f551827f7b2b598735eac158"
+                + "d77afd3602383d9a685d87f8b089af30"),
+        Arguments.of(
+            "SHA2 kKey2",
+            "HmacSHA512",
+            "passwordPASSWORDpassword",
+            "saltSALTsaltSALTsaltSALTsaltSALTsalt",
+            4096,
+            64,
+            "8c0511f4c6e597c6ac6315d8f0362e225f3c501495ba23b868c005174dc4ee71"
+                + "115b59f9e60cd9532fa33e0f75aefe30225c583a186cd82bd4daea9724a3d3b8"));
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("katVectors")
+  public void checkKat(
+      String id,
+      String digest,
+      String password,
+      String salt,
+      int iterations,
+      int dkLenBytes,
+      String expectedHex)
+      throws Exception {
+
+    final SecretKeyFactory skf =
+        SecretKeyFactory.getInstance("PBKDF2With" + digest, TestUtil.NATIVE_PROVIDER);
+    final PBEKeySpec spec =
+        new PBEKeySpec(password.toCharArray(), salt.getBytes(), iterations, dkLenBytes * 8);
+    final byte[] expected = decodeHex(expectedHex);
+    final byte[] actual = skf.generateSecret(spec).getEncoded();
+    assertArrayEquals(expected, actual);
+  }
+
+  @Test
+  public void testInteroperability() throws Exception {
+    final int[] iterations = {1, 2, 100, 4096};
+    final int[] keyLenBytes = {16, 32, 64};
+
+    for (String digest : DIGESTS) {
+      final SecretKeyFactory sun = SecretKeyFactory.getInstance("PBKDF2With" + digest, "SunJCE");
+      final SecretKeyFactory bc =
+          SecretKeyFactory.getInstance("PBKDF2With" + digest, TestUtil.BC_PROVIDER);
+      final SecretKeyFactory accp =
+          SecretKeyFactory.getInstance("PBKDF2With" + digest, TestUtil.NATIVE_PROVIDER);
+
+      for (int iter : iterations) {
+        for (int len : keyLenBytes) {
+          final PBEKeySpec spec =
+              new PBEKeySpec("password".toCharArray(), "salt".getBytes(), iter, len * 8);
+          final SecretKey sunKey = sun.generateSecret(spec);
+          final SecretKey bcKey = bc.generateSecret(spec);
+          final SecretKey accpKey = accp.generateSecret(spec);
+          final String label = digest + " iter=" + iter + " len=" + len;
+
+          assertArrayEquals(sunKey.getEncoded(), accpKey.getEncoded(), "SunJCE keys- " + label);
+          assertArrayEquals(bcKey.getEncoded(), accpKey.getEncoded(), "BC keys - " + label);
+
+          // SunJCE registers the keys in full form, i.e "PBKDF2WithHmacSHA256", while BC registers
+          // all digests under "PBKDF"
+          assertEquals(sunKey.getAlgorithm(), accpKey.getAlgorithm(), label);
+        }
+      }
+    }
+  }
+
+  // Verify wrong spec type, null salt, and zero key length each throw InvalidKeySpecException
+  @Test
+  public void invalidParameterTests() throws Exception {
+    final SecretKeyFactory skf =
+        SecretKeyFactory.getInstance("PBKDF2WithHmacSHA256", TestUtil.NATIVE_PROVIDER);
+    assertThrows(
+        InvalidKeySpecException.class,
+        () -> skf.generateSecret(new SecretKeySpec(new byte[16], "PBKDF2")));
+    assertThrows(
+        InvalidKeySpecException.class,
+        () -> skf.generateSecret(new PBEKeySpec("password".toCharArray())));
+    assertThrows(
+        InvalidKeySpecException.class,
+        () -> skf.generateSecret(new PBEKeySpec("password".toCharArray(), "salt".getBytes(), 1)));
+  }
+
+  @Test
+  public void pbkdf2sAreAvailable() throws Exception {
+    for (String digest : DIGESTS) {
+      SecretKeyFactory.getInstance("PBKDF2With" + digest, TestUtil.NATIVE_PROVIDER);
+    }
+  }
+}


### PR DESCRIPTION
Issue #:  *ACCP-77*

*Description of changes:*

This PR adds support for PBKDF2 in ACCP for the five JCA digests `PBKDF2WithHmacSHA1/224/256/384/512` backed by AWS-LC's `PKCS5_PBKDF2_HMAC`. The new SPI `Pbkdf2SecretKeyFactorySpi.java` follows existing KDF patterns.

*Testing* 

Tests include KATs  from AWS-LC's  [pbkdf_test.cc](https://github.com/aws/aws-lc/blob/main/crypto/fipsmodule/pbkdf/pbkdf_test.cc) covering SHA-1, SHA-256, and SHA-512.

Four SHA-224/SHA-384 vectors come from [Anti-weakpasswords/PBKDF2-GCC-OpenSSL-library](https://github.com/Anti-weakpasswords/PBKDF2-GCC-OpenSSL-library/blob/master/pbkdf2_test.sh).  Each vector in the repo's `pbkdf2_test.sh` script lists  a set of inputs (password, salt, iteration count, output length, digest) and the expected output bytes for that input. Before adding the four vectors from the repo, they were double-checked by building the upstream repo's `pbkdf2` CLI from source. For each of the four entries, the CLI was run with the same password, salt, iteration count, output length, and digest from the upstream `pbkdf2_test.sh` script, to ensure the bytes were identical with the expected values. Python's `hashlib.pbkdf2_hmac` was also used to cross-check. 

Remaining tests check ACCP's interoperability, JCA registration verification, and bad input checks. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
