### PR TITLE
Deep-copy encoded_key in HmacState.clone()

### DIFF
--- a/src/com/amazon/corretto/crypto/provider/EvpHmac.java
+++ b/src/com/amazon/corretto/crypto/provider/EvpHmac.java
@@ -361,6 +361,7 @@ class EvpHmac extends MacSpi implements Cloneable {
       try {
         HmacState cloned = (HmacState) super.clone();
         cloned.context = cloned.context.clone();
+        cloned.encoded_key = (encoded_key != null) ? encoded_key.clone() : null;
         return cloned;
       } catch (final CloneNotSupportedException ex) {
         throw new AssertionError(ex);

--- a/tst/com/amazon/corretto/crypto/provider/test/HmacTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/HmacTest.java
@@ -716,6 +716,41 @@ public class HmacTest {
     assertArrayEquals(expected, nativeMac.doFinal());
   }
 
+  @Test
+  public void cloneThenRekeyOriginalDoesNotCorruptClone() throws Exception {
+    byte[] keyBytesA = new byte[32];
+    for (int i = 0; i < 32; i++) keyBytesA[i] = (byte) (i + 1);
+    byte[] keyBytesB = new byte[32];
+    Arrays.fill(keyBytesB, (byte) 0x55);
+    byte[] msg = "test message".getBytes(StandardCharsets.UTF_8);
+
+    Mac mac = Mac.getInstance("HmacSHA256", NATIVE_PROVIDER);
+    mac.init(new SecretKeySpec(keyBytesA, "HmacSHA256"));
+
+    Mac cloned = (Mac) mac.clone();
+
+    // Re-key the original — must not affect the clone
+    mac.init(new SecretKeySpec(keyBytesB, "HmacSHA256"));
+
+    byte[] cloneResult = cloned.doFinal(msg);
+
+    // Compute expected result: HMAC(keyA, msg) using a fresh instance
+    Mac reference = Mac.getInstance("HmacSHA256", NATIVE_PROVIDER);
+    reference.init(new SecretKeySpec(keyBytesA, "HmacSHA256"));
+    byte[] expected = reference.doFinal(msg);
+
+    assertArrayEquals(expected, cloneResult, "Clone must use original key, not zeroed key");
+
+    // Also verify clone does NOT produce HMAC(zeros, msg)
+    Mac zeroMac = Mac.getInstance("HmacSHA256", NATIVE_PROVIDER);
+    zeroMac.init(new SecretKeySpec(new byte[32], "HmacSHA256"));
+    byte[] zeroResult = zeroMac.doFinal(msg);
+
+    if (Arrays.equals(cloneResult, zeroResult)) {
+      throw new AssertionError("Clone produced HMAC with zeroed key — encoded_key was corrupted");
+    }
+  }
+
   @ParameterizedTest
   @MethodSource("supportedHmacs")
   public void selfTest(final String algorithm) throws Throwable {

--- a/tst/com/amazon/corretto/crypto/provider/test/HmacTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/HmacTest.java
@@ -729,7 +729,7 @@ public class HmacTest {
 
     Mac cloned = (Mac) mac.clone();
 
-    // Re-key the original — must not affect the clone
+    // Re-key the original -- must not affect the clone
     mac.init(new SecretKeySpec(keyBytesB, "HmacSHA256"));
 
     byte[] cloneResult = cloned.doFinal(msg);
@@ -747,7 +747,7 @@ public class HmacTest {
     byte[] zeroResult = zeroMac.doFinal(msg);
 
     if (Arrays.equals(cloneResult, zeroResult)) {
-      throw new AssertionError("Clone produced HMAC with zeroed key — encoded_key was corrupted");
+      throw new AssertionError("Clone produced HMAC with zeroed key -- encoded_key was corrupted");
     }
   }
 


### PR DESCRIPTION
## Resolves

V2220038473

## Summary

- `HmacState.clone()` shallow-copies the `encoded_key` byte array. When the original `Mac` is re-keyed, `setKey()` zeros the shared array via `Arrays.fill()`, corrupting the clone's key material — the clone then computes HMAC with an all-zeros key.
- Deep-copy `encoded_key` in `clone()` to ensure independence, consistent with the JCA `clone()` contract and OpenJDK's `HmacCore` reference implementation.
- Adds a regression test verifying that re-keying the original `Mac` does not affect a previously cloned instance.

## Test plan

- [x] `./gradlew singleTest -DSINGLE_TEST=com.amazon.corretto.crypto.provider.test.HmacTest` — 101/101 pass (including new `cloneThenRekeyOriginalDoesNotCorruptClone` regression test)