### PR TITLE
Reset RsaCipher buffer unconditionally on init and on doFinal failure

### DIFF
--- a/src/com/amazon/corretto/crypto/provider/RsaCipher.java
+++ b/src/com/amazon/corretto/crypto/provider/RsaCipher.java
@@ -212,7 +212,7 @@ class RsaCipher extends CipherSpi {
 
         return result;
       } finally {
-        buffer_ = new AccessibleByteArrayOutputStream(keySizeBytes_, keySizeBytes_);
+        buffer_.reset();
       }
     }
   }

--- a/src/com/amazon/corretto/crypto/provider/RsaCipher.java
+++ b/src/com/amazon/corretto/crypto/provider/RsaCipher.java
@@ -129,89 +129,91 @@ class RsaCipher extends CipherSpi {
     synchronized (lock_) {
       assertInitialized();
 
-      if (buffer_.size() != 0) { // Not one-shot
-        if (input != null) {
-          buffer_.write(input, inputOffset, inputLen);
-        }
-        input = buffer_.getDataBuffer();
-        inputOffset = 0;
-        inputLen = buffer_.size();
-      }
-      // One-shot, no input. Cipher only calls engineDoFinal with null input in doFinal overloads
-      // that don't take an input buffer, and in those cases, inputOffset and inputLen are 0.
-      // We set them here anyways to be safe, because the API makes no such guarantee.
-      else if (input == null) {
-        input = Utils.EMPTY_ARRAY;
-        inputOffset = 0;
-        inputLen = 0;
-      }
-
-      if (output.length - outputOffset < engineGetOutputSize(inputLen)) {
-        throw new ShortBufferException();
-      }
-      if (mode_ == Cipher.ENCRYPT_MODE || mode_ == Cipher.WRAP_MODE) {
-        if (inputLen > keySizeBytes_ - paddingSize_) {
-          throw new IllegalBlockSizeException(
-              "Data must not be longer than " + (keySizeBytes_ - paddingSize_) + " bytes");
-        }
-        // We're allowed to pad NO_PADDING with zero bytes on the left.
-        // This is because RSA fundamentally works on positive integers so
-        // adding new high-order zero bytes does not change the numeric value
-        // of the input and thus does not change the output.
-        if (padding_.equals(Padding.NO_PADDING) && inputLen < keySizeBytes_) {
-          byte[] tmp = new byte[keySizeBytes_];
-          System.arraycopy(input, inputOffset, tmp, keySizeBytes_ - inputLen, inputLen);
-          input = tmp;
+      try {
+        if (buffer_.size() != 0) { // Not one-shot
+          if (input != null) {
+            buffer_.write(input, inputOffset, inputLen);
+          }
+          input = buffer_.getDataBuffer();
           inputOffset = 0;
-          inputLen = keySizeBytes_;
+          inputLen = buffer_.size();
         }
-      } else {
-        if (inputLen > keySizeBytes_) {
-          throw new IllegalBlockSizeException(
-              "Data must not be longer than " + keySizeBytes_ + " bytes");
+        // One-shot, no input. Cipher only calls engineDoFinal with null input in doFinal overloads
+        // that don't take an input buffer, and in those cases, inputOffset and inputLen are 0.
+        // We set them here anyways to be safe, because the API makes no such guarantee.
+        else if (input == null) {
+          input = Utils.EMPTY_ARRAY;
+          inputOffset = 0;
+          inputLen = 0;
         }
+
+        if (output.length - outputOffset < engineGetOutputSize(inputLen)) {
+          throw new ShortBufferException();
+        }
+        if (mode_ == Cipher.ENCRYPT_MODE || mode_ == Cipher.WRAP_MODE) {
+          if (inputLen > keySizeBytes_ - paddingSize_) {
+            throw new IllegalBlockSizeException(
+                "Data must not be longer than " + (keySizeBytes_ - paddingSize_) + " bytes");
+          }
+          // We're allowed to pad NO_PADDING with zero bytes on the left.
+          // This is because RSA fundamentally works on positive integers so
+          // adding new high-order zero bytes does not change the numeric value
+          // of the input and thus does not change the output.
+          if (padding_.equals(Padding.NO_PADDING) && inputLen < keySizeBytes_) {
+            byte[] tmp = new byte[keySizeBytes_];
+            System.arraycopy(input, inputOffset, tmp, keySizeBytes_ - inputLen, inputLen);
+            input = tmp;
+            inputOffset = 0;
+            inputLen = keySizeBytes_;
+          }
+        } else {
+          if (inputLen > keySizeBytes_) {
+            throw new IllegalBlockSizeException(
+                "Data must not be longer than " + keySizeBytes_ + " bytes");
+          }
+        }
+
+        final long oaepMdPtr;
+        final long mgfMdPtr;
+        final byte[] oaepLabel;
+        if (padding_ == Padding.OAEP) {
+          oaepMdPtr = Utils.getMdPtr(oaepParams_.getDigestAlgorithm());
+          mgfMdPtr =
+              Utils.getMdPtr(
+                  ((MGF1ParameterSpec) oaepParams_.getMGFParameters()).getDigestAlgorithm());
+          oaepLabel =
+              oaepParams_.getPSource() == null
+                  ? null
+                  : ((PSource.PSpecified) oaepParams_.getPSource()).getValue();
+        } else {
+          oaepMdPtr = 0;
+          mgfMdPtr = 0;
+          oaepLabel = null;
+        }
+
+        final byte[] finalInput = input;
+        final int finalInputOffset = inputOffset;
+        final int finalInputLen = inputLen;
+        final int result =
+            nativeKey_.use(
+                ptr ->
+                    cipher(
+                        ptr,
+                        mode_,
+                        padding_.nativeVal,
+                        oaepMdPtr,
+                        mgfMdPtr,
+                        oaepLabel,
+                        finalInput,
+                        finalInputOffset,
+                        finalInputLen,
+                        output,
+                        outputOffset));
+
+        return result;
+      } finally {
+        buffer_ = new AccessibleByteArrayOutputStream(keySizeBytes_, keySizeBytes_);
       }
-
-      final long oaepMdPtr;
-      final long mgfMdPtr;
-      final byte[] oaepLabel;
-      if (padding_ == Padding.OAEP) {
-        oaepMdPtr = Utils.getMdPtr(oaepParams_.getDigestAlgorithm());
-        mgfMdPtr =
-            Utils.getMdPtr(
-                ((MGF1ParameterSpec) oaepParams_.getMGFParameters()).getDigestAlgorithm());
-        oaepLabel =
-            oaepParams_.getPSource() == null
-                ? null
-                : ((PSource.PSpecified) oaepParams_.getPSource()).getValue();
-      } else {
-        oaepMdPtr = 0;
-        mgfMdPtr = 0;
-        oaepLabel = null;
-      }
-
-      final byte[] finalInput = input;
-      final int finalInputOffset = inputOffset;
-      final int finalInputLen = inputLen;
-      final int result =
-          nativeKey_.use(
-              ptr ->
-                  cipher(
-                      ptr,
-                      mode_,
-                      padding_.nativeVal,
-                      oaepMdPtr,
-                      mgfMdPtr,
-                      oaepLabel,
-                      finalInput,
-                      finalInputOffset,
-                      finalInputLen,
-                      output,
-                      outputOffset));
-
-      buffer_ = new AccessibleByteArrayOutputStream();
-
-      return result;
     }
   }
 
@@ -309,9 +311,9 @@ class RsaCipher extends CipherSpi {
 
         key_ = (RSAKey) key;
         keySizeBytes_ = (key_.getModulus().bitLength() + 7) / 8;
-        buffer_ = new AccessibleByteArrayOutputStream(keySizeBytes_, keySizeBytes_);
         nativeKey_ = provider_.translateKey(key, EvpKeyType.RSA);
       }
+      buffer_ = new AccessibleByteArrayOutputStream(keySizeBytes_, keySizeBytes_);
 
       if (params instanceof OAEPParameterSpec) {
         // Cache MD struct ptrs, validate digest names, update params + padding len

--- a/tst/com/amazon/corretto/crypto/provider/test/RsaCipherTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/RsaCipherTest.java
@@ -1239,11 +1239,7 @@ public class RsaCipherTest {
     byte[] tooLarge = new byte[215];
     Arrays.fill(tooLarge, (byte) 0xCC);
     c.update(tooLarge);
-    try {
-      c.doFinal();
-      fail("Expected IllegalBlockSizeException");
-    } catch (IllegalBlockSizeException expected) {
-    }
+    assertThrows(IllegalBlockSizeException.class, () -> c.doFinal());
 
     // Next operation on same cipher should work cleanly
     byte[] plaintext = new byte[16];

--- a/tst/com/amazon/corretto/crypto/provider/test/RsaCipherTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/RsaCipherTest.java
@@ -1197,6 +1197,66 @@ public class RsaCipherTest {
     assertArrayEquals(PAIR_512.getPrivate().getEncoded(), priv.getEncoded());
   }
 
+  @Test
+  public void reinitWithSameKeyClearsBuffer() throws Exception {
+    PublicKey pk = PAIR_2048.getPublic();
+
+    byte[] secretA = new byte[16];
+    Arrays.fill(secretA, (byte) 0xAA);
+    byte[] aesKeyBytes = new byte[16];
+    Arrays.fill(aesKeyBytes, (byte) 0xBB);
+
+    Cipher c = Cipher.getInstance("RSA/ECB/OAEPPadding", NATIVE_PROVIDER);
+
+    // Operation A -- aborted before doFinal
+    c.init(Cipher.ENCRYPT_MODE, pk);
+    c.update(secretA);
+
+    // Operation B -- re-init with same key, then wrap
+    c.init(Cipher.WRAP_MODE, pk);
+    byte[] wrapped = c.wrap(new SecretKeySpec(aesKeyBytes, "AES"));
+
+    // Unwrap and verify only operation B's data is present
+    Cipher unwrap = Cipher.getInstance("RSA/ECB/OAEPPadding", NATIVE_PROVIDER);
+    unwrap.init(Cipher.UNWRAP_MODE, PAIR_2048.getPrivate());
+    byte[] recovered = unwrap.unwrap(wrapped, "AES", Cipher.SECRET_KEY).getEncoded();
+
+    assertArrayEquals(
+        aesKeyBytes,
+        recovered,
+        "Re-init must clear buffer; stale data must not bleed into next operation");
+  }
+
+  @Test
+  public void failedDoFinalClearsBuffer() throws Exception {
+    PublicKey pk = PAIR_2048.getPublic();
+
+    Cipher c = Cipher.getInstance("RSA/ECB/OAEPPadding", NATIVE_PROVIDER);
+    c.init(Cipher.ENCRYPT_MODE, pk);
+
+    // Feed data that exceeds OAEP plaintext capacity (214 bytes for 2048-bit RSA)
+    // but fits in the buffer (256 bytes)
+    byte[] tooLarge = new byte[215];
+    Arrays.fill(tooLarge, (byte) 0xCC);
+    c.update(tooLarge);
+    try {
+      c.doFinal();
+      fail("Expected IllegalBlockSizeException");
+    } catch (IllegalBlockSizeException expected) {
+    }
+
+    // Next operation on same cipher should work cleanly
+    byte[] plaintext = new byte[16];
+    Arrays.fill(plaintext, (byte) 0xDD);
+    byte[] ciphertext = c.doFinal(plaintext);
+
+    Cipher dec = Cipher.getInstance("RSA/ECB/OAEPPadding", NATIVE_PROVIDER);
+    dec.init(Cipher.DECRYPT_MODE, PAIR_2048.getPrivate());
+    byte[] recovered = dec.doFinal(ciphertext);
+
+    assertArrayEquals(plaintext, recovered, "Buffer must be cleared after failed doFinal");
+  }
+
   private class TestThread extends Thread {
     private final SecureRandom rnd_;
     private final List<KeyPair> keys_;


### PR DESCRIPTION
## Resolves

V2220039808

## Summary

- `RsaCipher.engineInit()` only resets `buffer_` when the `Key` reference changes. With the same `Key` object, stale data from an aborted operation survives re-init and is prepended to the next operation's input -- causing cross-operation data bleed, including into `Cipher.wrap()`. This violates the JCA `Cipher.init()` contract (\"any previously-acquired state is lost\").
- `engineDoFinal()` only resets `buffer_` on the success path. A failed `doFinal` (e.g., `IllegalBlockSizeException`) leaves accumulated data in the buffer, corrupting subsequent operations on the same `Cipher` instance.
- Fix: (1) move `buffer_` allocation outside the `if (key_ != key)` block so it always resets on `init`, (2) wrap the entire `doFinal` body in `try/finally` so the buffer resets on any exit path. Use the capped two-arg `AccessibleByteArrayOutputStream` constructor at the reset site.
- Adds regression tests for both scenarios.

## Test plan

- [x] `./gradlew singleTest -DSINGLE_TEST=com.amazon.corretto.crypto.provider.test.RsaCipherTest` -- 3504 tests, 0 failed (33 aborted are pre-existing NoPadding skips)
- [x] `./gradlew spotlessJavaCheck` clean