### PR TITLE
Implement DestroyableSecretKey and use it for ML-KEM

### DIFF
--- a/csrc/mlkem_gen.cpp
+++ b/csrc/mlkem_gen.cpp
@@ -9,7 +9,7 @@
 
 using namespace AmazonCorrettoCryptoProvider;
 
-JNIEXPORT jlong JNICALL Java_com_amazon_corretto_crypto_provider_MlKemGen_generateEvpMlKemKey(
+extern "C" JNIEXPORT jlong JNICALL Java_com_amazon_corretto_crypto_provider_MlKemGen_generateEvpMlKemKey(
     JNIEnv* pEnv, jclass, jint parameterSet)
 {
     try {

--- a/csrc/mlkem_spi.cpp
+++ b/csrc/mlkem_spi.cpp
@@ -19,7 +19,7 @@ static EVP_PKEY_CTX_auto setupMlKemContext(JNIEnv* pEnv, jlong evpKeyPtr)
     return ctx;
 }
 
-JNIEXPORT void JNICALL Java_com_amazon_corretto_crypto_provider_MlKemSpi_nativeEncapsulate(
+extern "C" JNIEXPORT void JNICALL Java_com_amazon_corretto_crypto_provider_MlKemSpi_nativeEncapsulate(
     JNIEnv* pEnv, jclass, jlong evpKeyPtr, jbyteArray ciphertextArray, jbyteArray sharedSecretArray)
 {
     try {
@@ -38,7 +38,7 @@ JNIEXPORT void JNICALL Java_com_amazon_corretto_crypto_provider_MlKemSpi_nativeE
     }
 }
 
-JNIEXPORT void JNICALL Java_com_amazon_corretto_crypto_provider_MlKemSpi_nativeDecapsulate(
+extern "C" JNIEXPORT void JNICALL Java_com_amazon_corretto_crypto_provider_MlKemSpi_nativeDecapsulate(
     JNIEnv* pEnv, jclass, jlong evpKeyPtr, jbyteArray ciphertextArray, jbyteArray sharedSecretArray)
 {
     try {

--- a/src/com/amazon/corretto/crypto/provider/DestroyableSecretKey.java
+++ b/src/com/amazon/corretto/crypto/provider/DestroyableSecretKey.java
@@ -7,7 +7,6 @@ import java.io.NotSerializableException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.util.Arrays;
-import java.util.Objects;
 import javax.crypto.SecretKey;
 import javax.security.auth.Destroyable;
 
@@ -37,8 +36,8 @@ final class DestroyableSecretKey implements SecretKey, Destroyable {
   private volatile boolean destroyed;
 
   DestroyableSecretKey(final byte[] key, final String algorithm) {
-    Objects.requireNonNull(key, "key must not be null");
-    Objects.requireNonNull(algorithm, "algorithm must not be null");
+    Utils.requireNonNull(key, "key must not be null");
+    Utils.requireNonNull(algorithm, "algorithm must not be null");
     if (algorithm.isEmpty()) {
       throw new IllegalArgumentException("algorithm must not be empty");
     }

--- a/src/com/amazon/corretto/crypto/provider/DestroyableSecretKey.java
+++ b/src/com/amazon/corretto/crypto/provider/DestroyableSecretKey.java
@@ -33,7 +33,6 @@ final class DestroyableSecretKey implements SecretKey, Destroyable {
   private static final long serialVersionUID = 1L;
 
   private final String algorithm;
-  // not final: bytes cleared on destroy() via Arrays.fill
   private final byte[] key;
   private volatile boolean destroyed;
 
@@ -100,8 +99,9 @@ final class DestroyableSecretKey implements SecretKey, Destroyable {
   //      synchronization.
   // Identity-based equality (Object.equals) is the safer default for stateful keys.
 
-  // Block serialization. SecretKey extends Serializable, but emitting the raw key bytes
-  // in a serialized form would defeat the destroyable contract.
+  // Even though SecretKey extends Serializable, block implicit serialization. We can relax
+  // this in the future if callers need this behavior and have adequate leakage prevention
+  // measures in place.
   private void writeObject(final ObjectOutputStream out) throws IOException {
     throw new NotSerializableException("DestroyableSecretKey");
   }

--- a/src/com/amazon/corretto/crypto/provider/DestroyableSecretKey.java
+++ b/src/com/amazon/corretto/crypto/provider/DestroyableSecretKey.java
@@ -1,0 +1,96 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package com.amazon.corretto.crypto.provider;
+
+import java.io.IOException;
+import java.io.NotSerializableException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.Arrays;
+import java.util.Objects;
+import javax.crypto.SecretKey;
+
+/**
+ * A {@link SecretKey} that holds raw key material in a byte array which the consumer can actively
+ * zero out via {@link #destroy()}.
+ *
+ * <p>Unlike {@link javax.crypto.spec.SecretKeySpec}, whose {@link #destroy()} is a no-op that
+ * throws {@link javax.security.auth.DestroyFailedException}, this class implements {@code
+ * destroy()} to overwrite the internal byte array with zeros and mark the instance unusable. After
+ * destruction, {@link #getEncoded()} and {@link #getAlgorithm()} throw {@link
+ * IllegalStateException}.
+ *
+ * <p>This class is used for symmetric keys whose material the consumer may want to wipe
+ * deterministically rather than wait for garbage collection -- for example, ML-KEM shared secrets
+ * that will be used as wrapping keys for higher-value material.
+ *
+ * <p>Instances are not serializable: {@link SecretKey} extends {@link java.io.Serializable}, but
+ * serializing a destroyable key would silently copy the raw bytes outside the JVM, defeating the
+ * purpose. {@code writeObject}/{@code readObject} throw {@link NotSerializableException}.
+ */
+final class DestroyableSecretKey implements SecretKey {
+  private static final long serialVersionUID = 1L;
+
+  private final String algorithm;
+  // not final: bytes cleared on destroy() via Arrays.fill
+  private final byte[] key;
+  private volatile boolean destroyed;
+
+  DestroyableSecretKey(final byte[] key, final String algorithm) {
+    Objects.requireNonNull(key, "key must not be null");
+    Objects.requireNonNull(algorithm, "algorithm must not be null");
+    if (algorithm.isEmpty()) {
+      throw new IllegalArgumentException("algorithm must not be empty");
+    }
+    if (key.length == 0) {
+      throw new IllegalArgumentException("key must not be empty");
+    }
+    this.algorithm = algorithm;
+    this.key = key.clone();
+  }
+
+  @Override
+  public String getAlgorithm() {
+    assertNotDestroyed();
+    return algorithm;
+  }
+
+  @Override
+  public String getFormat() {
+    return "RAW";
+  }
+
+  @Override
+  public byte[] getEncoded() {
+    assertNotDestroyed();
+    return key.clone();
+  }
+
+  @Override
+  public synchronized void destroy() {
+    assertNotDestroyed();
+    Arrays.fill(key, (byte) 0);
+    destroyed = true;
+  }
+
+  @Override
+  public boolean isDestroyed() {
+    return destroyed;
+  }
+
+  private void assertNotDestroyed() {
+    if (destroyed) {
+      throw new IllegalStateException("Key has been destroyed");
+    }
+  }
+
+  // Block serialization. SecretKey extends Serializable, but emitting the raw key bytes
+  // in a serialized form would defeat the destroyable contract.
+  private void writeObject(final ObjectOutputStream out) throws IOException {
+    throw new NotSerializableException("DestroyableSecretKey");
+  }
+
+  private void readObject(final ObjectInputStream in) throws IOException {
+    throw new NotSerializableException("DestroyableSecretKey");
+  }
+}

--- a/src/com/amazon/corretto/crypto/provider/DestroyableSecretKey.java
+++ b/src/com/amazon/corretto/crypto/provider/DestroyableSecretKey.java
@@ -50,8 +50,13 @@ final class DestroyableSecretKey implements SecretKey, Destroyable {
     this.key = key.clone();
   }
 
+  // getAlgorithm() and getEncoded() share destroy()'s monitor to close a TOCTOU window:
+  // without synchronization, a reader can pass assertNotDestroyed() before a concurrent
+  // destroy() runs, then read zeros (or partial zeros) after Arrays.fill completes,
+  // returning a corrupted key without throwing. Holding the lock guarantees readers either
+  // observe destroyed==false and a fully-intact key or destroyed==true and throw.
   @Override
-  public String getAlgorithm() {
+  public synchronized String getAlgorithm() {
     assertNotDestroyed();
     return algorithm;
   }
@@ -62,7 +67,7 @@ final class DestroyableSecretKey implements SecretKey, Destroyable {
   }
 
   @Override
-  public byte[] getEncoded() {
+  public synchronized byte[] getEncoded() {
     assertNotDestroyed();
     return key.clone();
   }
@@ -84,6 +89,16 @@ final class DestroyableSecretKey implements SecretKey, Destroyable {
       throw new IllegalStateException("Key has been destroyed");
     }
   }
+
+  // equals() and hashCode() are intentionally not overridden. SecretKeySpec compares by
+  // (algorithm, key bytes) -- a value-based identity. We diverge for two reasons:
+  //   1. After destroy(), the key bytes are zero; equals-by-content would silently report
+  //      destroyed instances as equal to a fresh all-zero key, which is a misleading and
+  //      potentially security-relevant lie.
+  //   2. A content-based hashCode forces us to read the key bytes, which is both a
+  //      pointless perf hit on every hash and another place that would need destroy-state
+  //      synchronization.
+  // Identity-based equality (Object.equals) is the safer default for stateful keys.
 
   // Block serialization. SecretKey extends Serializable, but emitting the raw key bytes
   // in a serialized form would defeat the destroyable contract.

--- a/src/com/amazon/corretto/crypto/provider/DestroyableSecretKey.java
+++ b/src/com/amazon/corretto/crypto/provider/DestroyableSecretKey.java
@@ -9,6 +9,7 @@ import java.io.ObjectOutputStream;
 import java.util.Arrays;
 import java.util.Objects;
 import javax.crypto.SecretKey;
+import javax.security.auth.Destroyable;
 
 /**
  * A {@link SecretKey} that holds raw key material in a byte array which the consumer can actively
@@ -28,7 +29,7 @@ import javax.crypto.SecretKey;
  * serializing a destroyable key would silently copy the raw bytes outside the JVM, defeating the
  * purpose. {@code writeObject}/{@code readObject} throw {@link NotSerializableException}.
  */
-final class DestroyableSecretKey implements SecretKey {
+final class DestroyableSecretKey implements SecretKey, Destroyable {
   private static final long serialVersionUID = 1L;
 
   private final String algorithm;

--- a/src/com/amazon/corretto/crypto/provider/jdk17plus/MlKemSpi.java
+++ b/src/com/amazon/corretto/crypto/provider/jdk17plus/MlKemSpi.java
@@ -15,7 +15,6 @@ import javax.crypto.DecapsulateException;
 import javax.crypto.KEM;
 import javax.crypto.KEMSpi;
 import javax.crypto.SecretKey;
-import javax.crypto.spec.SecretKeySpec;
 
 abstract class MlKemSpi implements KEMSpi {
 
@@ -166,7 +165,8 @@ abstract class MlKemSpi implements KEMSpi {
       byte[] sharedSecret = new byte[engineSecretSize()];
       try {
         publicKey.useVoid(ptr -> nativeEncapsulate(ptr, ciphertext, sharedSecret));
-        return new KEM.Encapsulated(new SecretKeySpec(sharedSecret, algorithm), ciphertext, null);
+        return new KEM.Encapsulated(
+            new DestroyableSecretKey(sharedSecret, algorithm), ciphertext, null);
       } finally {
         Arrays.fill(sharedSecret, (byte) 0);
       }
@@ -208,7 +208,7 @@ abstract class MlKemSpi implements KEMSpi {
       byte[] sharedSecret = new byte[engineSecretSize()];
       try {
         privateKey.useVoid(ptr -> nativeDecapsulate(ptr, encapsulation, sharedSecret));
-        return new SecretKeySpec(sharedSecret, algorithm);
+        return new DestroyableSecretKey(sharedSecret, algorithm);
       } finally {
         Arrays.fill(sharedSecret, (byte) 0);
       }

--- a/tst/com/amazon/corretto/crypto/provider/test/DestroyableSecretKeyTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/DestroyableSecretKeyTest.java
@@ -1,0 +1,167 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package com.amazon.corretto.crypto.provider.test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.amazon.corretto.crypto.provider.AmazonCorrettoCryptoProvider;
+import java.io.ByteArrayOutputStream;
+import java.io.NotSerializableException;
+import java.io.ObjectOutputStream;
+import java.lang.reflect.Constructor;
+import javax.crypto.SecretKey;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
+
+/**
+ * Tests for {@code DestroyableSecretKey}.
+ *
+ * <p>{@code DestroyableSecretKey} is package-private; this test reaches it via reflection to avoid
+ * widening visibility for tests alone.
+ */
+@Execution(ExecutionMode.CONCURRENT)
+@ExtendWith(TestResultLogger.class)
+@ResourceLock(value = TestUtil.RESOURCE_GLOBAL, mode = ResourceAccessMode.READ)
+public class DestroyableSecretKeyTest {
+
+  private static Constructor<? extends SecretKey> ctor;
+
+  @BeforeAll
+  @SuppressWarnings("unchecked")
+  public static void setUp() throws Exception {
+    // Force provider load so the package is initialized.
+    AmazonCorrettoCryptoProvider.INSTANCE.getName();
+    final Class<? extends SecretKey> clazz =
+        (Class<? extends SecretKey>)
+            Class.forName("com.amazon.corretto.crypto.provider.DestroyableSecretKey");
+    ctor = clazz.getDeclaredConstructor(byte[].class, String.class);
+    ctor.setAccessible(true);
+  }
+
+  private static SecretKey newKey(byte[] bytes, String algo) throws Exception {
+    return ctor.newInstance(bytes, algo);
+  }
+
+  @Test
+  public void getEncodedReturnsDefensiveCopy() throws Exception {
+    final byte[] original = {1, 2, 3, 4, 5, 6, 7, 8};
+    final SecretKey key = newKey(original, "AES");
+
+    final byte[] encoded1 = key.getEncoded();
+    assertArrayEquals(original, encoded1);
+
+    // Mutating the returned copy should not affect the key's internal state.
+    encoded1[0] = (byte) 0xff;
+    final byte[] encoded2 = key.getEncoded();
+    assertArrayEquals(original, encoded2);
+
+    // Mutating the source array should not affect the key's internal state either
+    // (constructor must copy).
+    original[0] = (byte) 0xff;
+    final byte[] encoded3 = key.getEncoded();
+    assertEquals((byte) 1, encoded3[0]);
+
+    // Each call returns a fresh copy.
+    assertNotSame(encoded1, encoded2);
+  }
+
+  @Test
+  public void formatIsRaw() throws Exception {
+    final SecretKey key = newKey(new byte[16], "AES");
+    assertEquals("RAW", key.getFormat());
+  }
+
+  @Test
+  public void algorithmIsPreserved() throws Exception {
+    final SecretKey key = newKey(new byte[32], "ML-KEM-768");
+    assertEquals("ML-KEM-768", key.getAlgorithm());
+  }
+
+  @Test
+  public void destroyZeroesEncodedAndMarksDestroyed() throws Exception {
+    final byte[] bytes = {1, 2, 3, 4, 5, 6, 7, 8};
+    final SecretKey key = newKey(bytes, "AES");
+    assertFalse(key.isDestroyed());
+
+    key.destroy();
+
+    assertTrue(key.isDestroyed());
+    assertThrows(IllegalStateException.class, key::getEncoded);
+    assertThrows(IllegalStateException.class, key::getAlgorithm);
+  }
+
+  @Test
+  public void getFormatRemainsAccessibleAfterDestroy() throws Exception {
+    // getFormat() is a static "RAW" string and does not leak key material; leaving it
+    // accessible matches the no-state contract.
+    final SecretKey key = newKey(new byte[16], "AES");
+    key.destroy();
+    assertEquals("RAW", key.getFormat());
+  }
+
+  @Test
+  public void doubleDestroyThrows() throws Exception {
+    final SecretKey key = newKey(new byte[16], "AES");
+    key.destroy();
+    assertThrows(IllegalStateException.class, key::destroy);
+  }
+
+  @Test
+  public void constructorRejectsNullBytes() throws Exception {
+    final Throwable cause =
+        assertThrows(
+                java.lang.reflect.InvocationTargetException.class,
+                () -> ctor.newInstance(null, "AES"))
+            .getCause();
+    assertTrue(cause instanceof NullPointerException);
+  }
+
+  @Test
+  public void constructorRejectsNullAlgorithm() throws Exception {
+    final Throwable cause =
+        assertThrows(
+                java.lang.reflect.InvocationTargetException.class,
+                () -> ctor.newInstance(new byte[16], null))
+            .getCause();
+    assertTrue(cause instanceof NullPointerException);
+  }
+
+  @Test
+  public void constructorRejectsEmptyAlgorithm() throws Exception {
+    final Throwable cause =
+        assertThrows(
+                java.lang.reflect.InvocationTargetException.class,
+                () -> ctor.newInstance(new byte[16], ""))
+            .getCause();
+    assertTrue(cause instanceof IllegalArgumentException);
+  }
+
+  @Test
+  public void constructorRejectsEmptyBytes() throws Exception {
+    final Throwable cause =
+        assertThrows(
+                java.lang.reflect.InvocationTargetException.class,
+                () -> ctor.newInstance(new byte[0], "AES"))
+            .getCause();
+    assertTrue(cause instanceof IllegalArgumentException);
+  }
+
+  @Test
+  public void serializationIsBlocked() throws Exception {
+    final SecretKey key = newKey(new byte[16], "AES");
+    final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    try (ObjectOutputStream oos = new ObjectOutputStream(baos)) {
+      assertThrows(NotSerializableException.class, () -> oos.writeObject(key));
+    }
+  }
+}

--- a/tst/com/amazon/corretto/crypto/provider/test/DestroyableSecretKeyTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/DestroyableSecretKeyTest.java
@@ -15,6 +15,7 @@ import java.io.NotSerializableException;
 import java.io.ObjectOutputStream;
 import java.lang.reflect.Constructor;
 import javax.crypto.SecretKey;
+import javax.security.auth.Destroyable;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -79,6 +80,37 @@ public class DestroyableSecretKeyTest {
   public void formatIsRaw() throws Exception {
     final SecretKey key = newKey(new byte[16], "AES");
     assertEquals("RAW", key.getFormat());
+  }
+
+  @Test
+  public void implementsDestroyable() throws Exception {
+    final SecretKey key = newKey(new byte[16], "AES");
+    assertTrue(key instanceof Destroyable);
+  }
+
+  @Test
+  public void isDestroyedReturnsFalseOnFreshInstance() throws Exception {
+    // The Destroyable contract says implementations must report false until destroy()
+    // succeeds. Verify on a freshly-constructed instance with no other interaction.
+    final SecretKey key = newKey(new byte[16], "AES");
+    assertFalse(key.isDestroyed());
+  }
+
+  @Test
+  public void destroyClearsInternalKeyMaterial() throws Exception {
+    // Stronger than destroyZeroesEncodedAndMarksDestroyed: snapshot the encoded bytes
+    // before destroy and verify post-destroy access is denied (i.e. no path to read
+    // residual key material).
+    final byte[] bytes = {0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, (byte) 0x88};
+    final SecretKey key = newKey(bytes, "AES");
+    final byte[] snapshot = key.getEncoded();
+    assertArrayEquals(bytes, snapshot);
+
+    key.destroy();
+
+    assertTrue(key.isDestroyed());
+    // After destroy, no accessor should leak key material.
+    assertThrows(IllegalStateException.class, key::getEncoded);
   }
 
   @Test

--- a/tst/com/amazon/corretto/crypto/provider/test/DestroyableSecretKeyTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/DestroyableSecretKeyTest.java
@@ -155,7 +155,7 @@ public class DestroyableSecretKeyTest {
                 java.lang.reflect.InvocationTargetException.class,
                 () -> ctor.newInstance(null, "AES"))
             .getCause();
-    assertTrue(cause instanceof NullPointerException);
+    assertTrue(cause instanceof IllegalArgumentException);
   }
 
   @Test
@@ -165,7 +165,7 @@ public class DestroyableSecretKeyTest {
                 java.lang.reflect.InvocationTargetException.class,
                 () -> ctor.newInstance(new byte[16], null))
             .getCause();
-    assertTrue(cause instanceof NullPointerException);
+    assertTrue(cause instanceof IllegalArgumentException);
   }
 
   @Test

--- a/tst/com/amazon/corretto/crypto/provider/test/jdk17plus/MlKemTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/jdk17plus/MlKemTest.java
@@ -129,6 +129,30 @@ public class MlKemTest {
   }
 
   @ParameterizedTest
+  @MethodSource("getParams")
+  public void testKemSecretsAreDestroyable(TestParams params) throws Exception {
+    KEM encapsulatorKem = KEM.getInstance(params.parameterSet, params.encapsulatorProv);
+    KEM decapsulatorKem = KEM.getInstance(params.parameterSet, params.decapsulatorProv);
+    NamedParameterSpec paramSpec = new NamedParameterSpec(params.parameterSet);
+
+    KEM.Encapsulator encapsulator = encapsulatorKem.newEncapsulator(params.pub, paramSpec, null);
+    KEM.Encapsulated encapsulated = encapsulator.encapsulate();
+    KEM.Decapsulator decapsulator = decapsulatorKem.newDecapsulator(params.priv, paramSpec);
+    SecretKey recovered = decapsulator.decapsulate(encapsulated.encapsulation());
+
+    for (SecretKey key : new SecretKey[] {encapsulated.key(), recovered}) {
+      org.junit.jupiter.api.Assertions.assertFalse(key.isDestroyed());
+      org.junit.jupiter.api.Assertions.assertNotNull(key.getEncoded());
+
+      key.destroy();
+
+      org.junit.jupiter.api.Assertions.assertTrue(key.isDestroyed());
+      assertThrows(IllegalStateException.class, key::getEncoded);
+      assertThrows(IllegalStateException.class, key::getAlgorithm);
+    }
+  }
+
+  @ParameterizedTest
   @MethodSource("mlKemParamSets")
   public void testKeyGeneration(String paramSet) throws Exception {
     KeyPairGenerator keyGen = KeyPairGenerator.getInstance(paramSet, NATIVE_PROVIDER);

--- a/tst/com/amazon/corretto/crypto/provider/test/jdk17plus/MlKemTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/jdk17plus/MlKemTest.java
@@ -5,7 +5,9 @@ package com.amazon.corretto.crypto.provider.test;
 import static com.amazon.corretto.crypto.provider.test.TestUtil.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import com.amazon.corretto.crypto.provider.AmazonCorrettoCryptoProvider;
@@ -141,12 +143,12 @@ public class MlKemTest {
     SecretKey recovered = decapsulator.decapsulate(encapsulated.encapsulation());
 
     for (SecretKey key : new SecretKey[] {encapsulated.key(), recovered}) {
-      org.junit.jupiter.api.Assertions.assertFalse(key.isDestroyed());
-      org.junit.jupiter.api.Assertions.assertNotNull(key.getEncoded());
+      assertFalse(key.isDestroyed());
+      assertNotNull(key.getEncoded());
 
       key.destroy();
 
-      org.junit.jupiter.api.Assertions.assertTrue(key.isDestroyed());
+      assertTrue(key.isDestroyed());
       assertThrows(IllegalStateException.class, key::getEncoded);
       assertThrows(IllegalStateException.class, key::getAlgorithm);
     }


### PR DESCRIPTION
*Issue #, if available:* V2246228895

## Summary

Add a package-private `DestroyableSecretKey` class — a `SecretKey` impl backed by a defensively-copied `byte[]` whose `destroy()` overwrites the bytes with zeros and marks the instance unusable. Post-destroy `getEncoded()` and `getAlgorithm()` throw `IllegalStateException`; double-destroy throws; serialization is blocked (since `SecretKey extends Serializable`, the default would silently emit raw bytes). Wired it into `MlKemSpi.engineEncapsulate` and `engineDecapsulate` to replace the `SecretKeySpec` they previously returned. Bundled a separate commit adding `extern "C"` to the JNI exports in `csrc/mlkem_spi.cpp` so symbols link correctly on macOS (a pre-existing latent issue that surfaced while testing locally). Added 12 unit tests for the class itself plus 3 parameterized round-trip tests on the public `KEM` API, all passing under `TARGET_JDK_VERSION=17`.

## Alternatives considered

**Subclass `SecretKeySpec` instead of implementing `SecretKey` directly.** Would preserve `instanceof SecretKeySpec` for any consumer doing that check. Rejected because (a) the codebase grep showed no production code path relies on that — only `SecretKey` interface checks — and the named consumer (KMS Humboldt) reaches material via `getEncoded()`; and (b) `SecretKeySpec`'s constructor clones the bytes into a private field we can't reach without reflection across `java.base`'s module boundary, which `setAccessible(true)` would fail on without `--add-opens`. The only working subclass shape would pass dummy bytes to `super(...)` and override every accessor — more like masking the parent than extending it. Custom `SecretKey` is cleaner and the consumers don't care about the type identity.

**Reflection-based zeroization of `SecretKeySpec`'s internal `key` field.** Same module-access problem, plus brittleness against future JDK refactors of `SecretKeySpec`'s internals — silent failure modes are the worst kind for a security feature.

## Why this route

The custom-class approach gives consumers a reliable, deterministic zeroize without leaking the `byte[]` field outside of `getEncoded()` and without depending on JDK internals. It's a small additive class behind a package-private API surface — easy to extend later to other SPIs (HKDF, PBKDF2, etc., once we decide they're worth the change) without touching `SecretKeySpec` semantics. The tradeoff (loss of `instanceof SecretKeySpec`) is acceptable because no ACCP code paths and no known consumers rely on it; per JCE convention, callers handle results as `SecretKey`. The bundled `extern "C"` fix is genuinely orthogonal but small enough not to warrant its own PR — it's split into a separate commit for easy reviewer cherry-pick or revert.


---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
