### PR TITLE
Replace WipeMode enum with SecretInputArray / SecretOutputArray subclasses

### DIFF
--- a/csrc/aes_xts.cpp
+++ b/csrc/aes_xts.cpp
@@ -89,13 +89,12 @@ extern "C" JNIEXPORT void JNICALL Java_com_amazon_corretto_crypto_provider_AesXt
         // GetArrayLength must be called BEFORE any JBAC ctor; see csrc/buffer.h.
         const jsize jPackedTweakKeyLen = env->GetArrayLength(jPackedTweakKey);
         const jsize jInputArrLen = env->GetArrayLength(jinput);
-        const jsize jOutputArrLen = env->GetArrayLength(joutput);
 
-        // No WIPE_OUTPUT here: ciphertext is not sensitive, plaintext input is read-only.
-        // Plain RAII suffices; no commitBack() needed.
-        JByteArrayCritical packedTweakKey(env, jPackedTweakKey, jPackedTweakKeyLen, WipeMode::WIPE_INPUT);
-        JByteArrayCritical input(env, jinput, jInputArrLen, WipeMode::WIPE_INPUT);
-        JByteArrayCritical output(env, joutput, jOutputArrLen, WipeMode::NO_WIPE);
+        // No SecretOutputArray here: ciphertext is not sensitive, plaintext input is
+        // read-only. Plain RAII suffices.
+        SecretInputArray packedTweakKey(env, jPackedTweakKey, jPackedTweakKeyLen);
+        SecretInputArray input(env, jinput, jInputArrLen);
+        JByteArrayCritical output(env, joutput);
 
         AesXtsCipher cipher(true, packedTweakKey.get() + AES_XTS_KEY_INDEX_START, packedTweakKey.get());
         cipher.encrypt(input.get() + inputOffset, inputLen, output.get() + outputOffset);
@@ -119,11 +118,11 @@ extern "C" JNIEXPORT void JNICALL Java_com_amazon_corretto_crypto_provider_AesXt
         const jsize jInputArrLen = env->GetArrayLength(jinput);
 
         // Same buffer holds plaintext on entry and ciphertext on exit; native copy held
-        // plaintext mid-call, so we WIPE_OUTPUT (cleanse + commit ciphertext back).
-        // Declared first so its dtor runs last, after packedTweakKey's critical region
-        // has been released.
-        JByteArrayCritical input(env, jinput, jInputArrLen, WipeMode::WIPE_OUTPUT);
-        JByteArrayCritical packedTweakKey(env, jPackedTweakKey, jPackedTweakKeyLen, WipeMode::WIPE_INPUT);
+        // plaintext mid-call, so we use SecretOutputArray (cleanse + commit ciphertext
+        // back). Declared first so its dtor runs last, after packedTweakKey's critical
+        // region has been released.
+        SecretOutputArray input(env, jinput, jInputArrLen);
+        SecretInputArray packedTweakKey(env, jPackedTweakKey, jPackedTweakKeyLen);
 
         AesXtsCipher cipher(true, packedTweakKey.get() + AES_XTS_KEY_INDEX_START, packedTweakKey.get());
         cipher.encrypt(input.get() + inputOffset, inputLen, input.get() + outputOffset);
@@ -145,14 +144,13 @@ extern "C" JNIEXPORT void JNICALL Java_com_amazon_corretto_crypto_provider_AesXt
     try {
         // GetArrayLength must be called BEFORE any JBAC ctor; see csrc/buffer.h.
         const jsize jPackedTweakKeyLen = env->GetArrayLength(jPackedTweakKey);
-        const jsize jInputArrLen = env->GetArrayLength(jinput);
         const jsize jOutputArrLen = env->GetArrayLength(joutput);
 
-        // |output| (WIPE_OUTPUT) declared first so its dtor runs last, after the other
-        // buffers' critical regions have been released; see csrc/buffer.h.
-        JByteArrayCritical output(env, joutput, jOutputArrLen, WipeMode::WIPE_OUTPUT);
-        JByteArrayCritical packedTweakKey(env, jPackedTweakKey, jPackedTweakKeyLen, WipeMode::WIPE_INPUT);
-        JByteArrayCritical input(env, jinput, jInputArrLen, WipeMode::NO_WIPE);
+        // SecretOutputArray declared first so its dtor runs last, after the other
+        // criticals are released.
+        SecretOutputArray output(env, joutput, jOutputArrLen);
+        SecretInputArray packedTweakKey(env, jPackedTweakKey, jPackedTweakKeyLen);
+        JByteArrayCritical input(env, jinput);
 
         AesXtsCipher cipher(false, packedTweakKey.get() + AES_XTS_KEY_INDEX_START, packedTweakKey.get());
         cipher.decrypt(input.get() + inputOffset, inputLen, output.get() + outputOffset);
@@ -177,10 +175,10 @@ extern "C" JNIEXPORT void JNICALL Java_com_amazon_corretto_crypto_provider_AesXt
         const jsize jPackedTweakKeyLen = env->GetArrayLength(jPackedTweakKey);
         const jsize jInputArrLen = env->GetArrayLength(jinput);
 
-        // Same buffer holds ciphertext on entry and plaintext on exit; WIPE_OUTPUT cleanses
-        // any native copy and commits the plaintext back.
-        JByteArrayCritical input(env, jinput, jInputArrLen, WipeMode::WIPE_OUTPUT);
-        JByteArrayCritical packedTweakKey(env, jPackedTweakKey, jPackedTweakKeyLen, WipeMode::WIPE_INPUT);
+        // Same buffer holds ciphertext on entry and plaintext on exit; SecretOutputArray
+        // cleanses any native copy and commits the plaintext back.
+        SecretOutputArray input(env, jinput, jInputArrLen);
+        SecretInputArray packedTweakKey(env, jPackedTweakKey, jPackedTweakKeyLen);
 
         AesXtsCipher cipher(false, packedTweakKey.get() + AES_XTS_KEY_INDEX_START, packedTweakKey.get());
         cipher.decrypt(input.get() + inputOffset, inputLen, input.get() + outputOffset);

--- a/csrc/buffer.cpp
+++ b/csrc/buffer.cpp
@@ -70,13 +70,13 @@ void JByteArrayCritical::cleanse_and_stash(
     OPENSSL_cleanse(src, len);
 }
 
-JByteArrayCritical::JByteArrayCritical(JNIEnv* env, jbyteArray jarray, jsize len, WipeMode mode)
+// ---- Base class: non-sensitive critical region ----
+
+JByteArrayCritical::JByteArrayCritical(JNIEnv* env, jbyteArray jarray)
     : ptr_(nullptr)
     , env_(env)
     , jarray_(jarray)
-    , len_(len)
     , is_copy_(JNI_FALSE)
-    , mode_(mode)
     , released_(false)
 {
     ptr_ = env->GetPrimitiveArrayCritical(jarray, &is_copy_);
@@ -86,35 +86,16 @@ JByteArrayCritical::JByteArrayCritical(JNIEnv* env, jbyteArray jarray, jsize len
 #ifndef NDEBUG
     ++s_open_criticals;
 #endif
-
-    // Reserve stash capacity now that we know whether the JVM made a copy. Skipping this
-    // allocation entirely on the pinned path (HotSpot's typical behavior) is the
-    // optimization. release() must remain allocation-free and noexcept, so the reserve()
-    // happens here rather than later -- but if it throws, the partially-constructed JBAC's
-    // dtor won't run (ctor never finished), so we'd leak the critical region. Catch
-    // bad_alloc, release the critical region ourselves, and rethrow to preserve the
-    // original failure mode.
-    if (mode_ == WipeMode::WIPE_OUTPUT && is_copy_ && len_ > 0) {
-        try {
-            stash_.reserve(static_cast<size_t>(len_));
-        } catch (...) {
-            env_->ReleasePrimitiveArrayCritical(jarray_, ptr_, JNI_ABORT);
-#ifndef NDEBUG
-            --s_open_criticals;
-#endif
-            ptr_ = nullptr;
-            throw java_ex(EX_OOM, "Failed to allocate stash buffer for sensitive output array");
-        }
-    }
 }
 
 JByteArrayCritical::~JByteArrayCritical()
 {
-    // RAII fallback for the single-WIPE_OUTPUT-per-scope case: end the critical region
-    // and commit any stashed writes. Multi-WIPE_OUTPUT scopes must drive these manually
-    // (see class comment); calls here will be no-ops if the caller already did.
+    // RAII fallback. Subclass dtors must run their cleanup BEFORE this base dtor, since
+    // doRelease() is dispatched through a virtual call -- by the time we reach ~JBAC, the
+    // derived object's vtable slice is gone and a virtual call would resolve to the base.
+    // SecretOutputArray::~SecretOutputArray() therefore calls release() itself before
+    // chaining here.
     release();
-    commitBack();
 }
 
 void JByteArrayCritical::release() noexcept
@@ -124,69 +105,119 @@ void JByteArrayCritical::release() noexcept
     }
     released_ = true;
 #ifndef NDEBUG
-    assert(s_open_criticals > 0 && "release() would underflow s_open_criticals; unbalanced ctor/release()");
+    assert(s_open_criticals > 0 && "release() called with negative open criticals, should never happen");
     --s_open_criticals;
 #endif
-
-    // Pinned or non-sensitive: ptr_ aliases the Java array (or is opaque to us). The
-    // ReleasePrimitiveArrayCritical mode parameter is per the JNI spec:
-    //   0           -- copy back any modifications, then free the native buffer (the
-    //                  default; commits writes back to the Java array on the copy path).
-    //   JNI_COMMIT  -- copy back, but keep the native buffer alive.
-    //   JNI_ABORT   -- free the native buffer WITHOUT copying back (used below on the
-    //                  wipe path so cleansed zeros don't reach the Java array).
-    // Mode 0 here commits any writes that already landed in the Java array; for the
-    // pinned WIPE_* paths we must not mutate the array, which mode 0 also satisfies (no
-    // rewrite occurs when ptr_ IS the array). See:
-    // https://docs.oracle.com/javase/8/docs/technotes/guides/jni/spec/functions.html#ReleasePrimitiveArrayCritical
-    if (!is_copy_ || mode_ == WipeMode::NO_WIPE) {
-        env_->ReleasePrimitiveArrayCritical(jarray_, ptr_, 0);
-        return;
-    }
-
-    // Wipe path on the JVM-copy variant. For WIPE_OUTPUT, stash the caller's writes
-    // (allocation-free; capacity was reserved in the ctor). Cleanse the native copy in
-    // both cases, then JNI_ABORT to free without copying the cleansed bytes back.
-    if (mode_ == WipeMode::WIPE_OUTPUT) {
-        JByteArrayCritical::cleanse_and_stash(static_cast<uint8_t*>(ptr_), len_, stash_);
-    } else if (len_ > 0) { // WIPE_INPUT
-        OPENSSL_cleanse(ptr_, len_);
-    }
-    env_->ReleasePrimitiveArrayCritical(jarray_, ptr_, JNI_ABORT);
-    // The stashed bytes (if any) are committed in commitBack(), which the dtor or
-    // caller invokes after every critical region on the thread is closed.
+    doRelease();
 }
 
-void JByteArrayCritical::commitBack()
+void JByteArrayCritical::doRelease() noexcept
 {
-    if (mode_ != WipeMode::WIPE_OUTPUT) {
-        return;
-    }
-    // Tripping this assertion means another JByteArrayCritical's critical region is
-    // still open on this thread. SetByteArrayRegion is forbidden in that state. See the
-    // class comment in buffer.h for the call-site pattern (single WIPE_OUTPUT per scope
-    // declared first; multi-WIPE_OUTPUT requires manual release()/commitBack() ordering).
-    //
-    // Not directly unit-tested: assert() calls abort() on failure, which is incompatible
-    // with the in-process test harness, and constructing a JByteArrayCritical needs a real
-    // JNIEnv. Code review of new call sites is the primary defense; this assertion is the
-    // backstop that fires in any debug-mode test run that misuses the API.
-#ifndef NDEBUG
-    assert(s_open_criticals == 0 && "commitBack() called while a critical region is still open on this thread");
-#endif
-   if (stash_.empty()) {
-      return;
-   }
-    env_->SetByteArrayRegion(jarray_,
-        0,
-        static_cast<jsize>(stash_.size()),
-        reinterpret_cast<const jbyte*>(stash_.data()));
-    stash_.clear(); // idempotent: subsequent calls are no-ops
+    // Default base behavior: mode-0 release. Per JNI spec, mode 0 means "copy back any
+    // modifications, then free the native buffer." For the pinned path ptr_ aliases the
+    // Java array so there is nothing to copy back. See:
+    // https://docs.oracle.com/javase/8/docs/technotes/guides/jni/spec/functions.html#ReleasePrimitiveArrayCritical
+    env_->ReleasePrimitiveArrayCritical(jarray_, ptr_, 0);
 }
 
 unsigned char* JByteArrayCritical::get()
 {
     return released_ ? nullptr : static_cast<unsigned char*>(ptr_);
+}
+
+// ---- SecretInputArray: cleanse-on-release ----
+
+SecretInputArray::SecretInputArray(JNIEnv* env, jbyteArray jarray, jsize len)
+    : JByteArrayCritical(env, jarray)
+    , len_(len)
+{
+}
+
+void SecretInputArray::doRelease() noexcept
+{
+    if (is_copy_) {
+        // Caller did not write through get(). Cleanse the native copy and discard via
+        // JNI_ABORT to avoid mode-0's commit-back of zeros to the Java array.
+        if (len_ > 0) {
+            OPENSSL_cleanse(ptr_, len_);
+        }
+        env_->ReleasePrimitiveArrayCritical(jarray_, ptr_, JNI_ABORT);
+    } else {
+        // Pinned: ptr_ aliases the Java array; mutating it is forbidden. Mode-0 release.
+        env_->ReleasePrimitiveArrayCritical(jarray_, ptr_, 0);
+    }
+}
+
+// ---- SecretOutputArray: cleanse-and-stash, with deferred commit-back ----
+
+SecretOutputArray::SecretOutputArray(JNIEnv* env, jbyteArray jarray, jsize len)
+    : JByteArrayCritical(env, jarray)
+    , len_(len)
+{
+    // Reserve stash capacity now (after we know is_copy_) so doRelease() is allocation-
+    // free and noexcept. Skipping the allocation on the pinned path (HotSpot's typical
+    // behavior) is a meaningful optimization. If reserve() throws, the base class has
+    // already entered the critical region; we must release it ourselves before rethrow,
+    // since the dtor of a partially-constructed-derived object will NOT run.
+    if (is_copy_ && len_ > 0) {
+        try {
+            stash_.reserve(static_cast<size_t>(len_));
+        } catch (...) {
+            env_->ReleasePrimitiveArrayCritical(jarray_, ptr_, JNI_ABORT);
+#ifndef NDEBUG
+            --s_open_criticals;
+#endif
+            ptr_ = nullptr;
+            released_ = true; // mark released so base dtor skips its release()
+            throw java_ex(EX_OOM, "Failed to allocate stash buffer for sensitive output array");
+        }
+    }
+}
+
+SecretOutputArray::~SecretOutputArray()
+{
+    // Run derived release() while our vtable is still intact (so doRelease() dispatches
+    // to SecretOutputArray::doRelease, stashing bytes). Then commit any stashed bytes.
+    // The base class dtor will call release() too, but it'll be a no-op (idempotent).
+    release();
+    commitBack();
+}
+
+void SecretOutputArray::doRelease() noexcept
+{
+    if (is_copy_) {
+        // Stash the caller's writes (allocation-free; capacity reserved in the ctor),
+        // cleanse the native copy, then JNI_ABORT to free without copying the cleansed
+        // bytes back. The stash is committed later by commitBack().
+        JByteArrayCritical::cleanse_and_stash(static_cast<uint8_t*>(ptr_), len_, stash_);
+        env_->ReleasePrimitiveArrayCritical(jarray_, ptr_, JNI_ABORT);
+    } else {
+        // Pinned: caller's writes already landed in the Java array; mode-0 release.
+        env_->ReleasePrimitiveArrayCritical(jarray_, ptr_, 0);
+    }
+}
+
+void SecretOutputArray::commitBack()
+{
+    // Tripping this assertion means another JByteArrayCritical's critical region is
+    // still open on this thread. SetByteArrayRegion is forbidden in that state. See the
+    // class comment in buffer.h for the call-site patterns.
+    //
+    // Not directly unit-tested: assert() calls abort() on failure, which is incompatible
+    // with the in-process test harness, and constructing a SecretOutputArray needs a
+    // real JNIEnv. Code review of new call sites is the primary defense; this assertion
+    // is the backstop that fires in any debug-mode test run that misuses the API.
+#ifndef NDEBUG
+    assert(s_open_criticals == 0 && "commitBack() called while a critical region is still open on this thread");
+#endif
+    if (stash_.empty()) {
+        return;
+    }
+    env_->SetByteArrayRegion(jarray_,
+        0,
+        static_cast<jsize>(stash_.size()),
+        reinterpret_cast<const jbyte*>(stash_.data()));
+    stash_.clear(); // idempotent: subsequent calls are no-ops
 }
 
 SimpleBuffer::SimpleBuffer(int size)

--- a/csrc/buffer.h
+++ b/csrc/buffer.h
@@ -557,97 +557,30 @@ public:
     void zeroize() { OPENSSL_cleanse(&m_storage, sizeof(m_storage)); }
 };
 
-// Wipe modes for JByteArrayCritical. Callers must specify intent explicitly; there is no
-// default. Each mode reflects what the buffer holds and how its native copy must be handled
-// when the JVM returns one (GetPrimitiveArrayCritical may pin or copy at the JVM's discretion).
+// {Get,Release}PrimitiveArrayCritical wrapper. Treat the bytes as opaque (they may be
+// pinned to the Java array or copied at the JVM's discretion). On release, modifications
+// are committed back to the Java array via mode-0 release. Use this for non-sensitive
+// buffers (salt, info, ciphertext) where no zeroization or special handling is needed.
 //
-//   NO_WIPE:     Default release (mode 0). Use for non-sensitive buffers (salt, info, ciphertext).
-//   WIPE_INPUT:  Sensitive read-only buffer (key, password, plaintext-in). Caller does not write
-//                through get(). On the copy path, the native buffer is OPENSSL_cleansed and
-//                discarded via JNI_ABORT; the Java array is preserved unchanged.
-//   WIPE_OUTPUT: Sensitive buffer the caller writes through (derived key, plaintext-out). On the
-//                copy path, the bytes the caller wrote are stashed in a SecureAlloc-backed
-//                vector, the native buffer is OPENSSL_cleansed and discarded via JNI_ABORT, and
-//                the stashed bytes are committed back to the Java array via SetByteArrayRegion
-//                AFTER all critical regions on the thread have been released.
-enum class WipeMode {
-    NO_WIPE,
-    WIPE_INPUT,
-    WIPE_OUTPUT,
-};
-
-// Please follow the guidelines outlined in {Get,Release}PrimitiveArrayCritical when using this class:
-// https://docs.oracle.com/javase/8/docs/technotes/guides/jni/spec/functions.html#GetPrimitiveArrayCritical_ReleasePrimitiveArrayCritical
+// For sensitive buffers, prefer the SecretInputArray / SecretOutputArray subclasses
+// declared below; they encode wipe semantics in the type rather than relying on a flag.
 //
-// JNI requires that no non-Release JNI calls be made while ANY critical region on the
-// thread is open. Notably, SetByteArrayRegion is forbidden. WIPE_OUTPUT eventually calls
-// SetByteArrayRegion to commit the caller's writes back to the Java array.
+// Spec: https://docs.oracle.com/javase/8/docs/technotes/guides/jni/spec/functions.html#GetPrimitiveArrayCritical_ReleasePrimitiveArrayCritical
 //
-// The class supports two usage patterns:
-//
-// 1. Single WIPE_OUTPUT per scope (the common case): rely on RAII. Declare the
-//    WIPE_OUTPUT first so it destructs LAST under C++'s LIFO order, after every other
-//    JByteArrayCritical's critical region has ended. The dtor handles everything.
-//
-//        const jsize outLen    = env->GetArrayLength(jOutput);
-//        const jsize secretLen = env->GetArrayLength(jSecret);
-//        const jsize saltLen   = env->GetArrayLength(jSalt);
-//        // All GetArrayLength calls happen BEFORE the first ctor (see ctor docs below).
-//        JByteArrayCritical output(env, jOutput, outLen, WipeMode::WIPE_OUTPUT);  // declared FIRST
-//        JByteArrayCritical secret(env, jSecret, secretLen, WipeMode::WIPE_INPUT);
-//        JByteArrayCritical salt(env, jSalt, saltLen, WipeMode::NO_WIPE);
-//        // ... algorithm ...
-//        // Destruction at scope exit (reverse order):
-//        //   1. salt   -> ends salt's critical region (mode 0)
-//        //   2. secret -> ends secret's critical region (cleanse + JNI_ABORT)
-//        //   3. output -> ends output's critical region, then SetByteArrayRegion
-//        //                (safe: no other criticals are open at this point)
-//
-// 2. Multiple WIPE_OUTPUTs in one scope: the caller MUST drive release() and
-//    commitBack() manually so that ALL criticals are closed before ANY commit runs:
-//
-//        const jsize aLen        = env->GetArrayLength(jA);
-//        const jsize bLen        = env->GetArrayLength(jB);
-//        const jsize passwordLen = env->GetArrayLength(jPassword);
-//        JByteArrayCritical out1(env, jA, aLen, WipeMode::WIPE_OUTPUT);
-//        JByteArrayCritical out2(env, jB, bLen, WipeMode::WIPE_OUTPUT);
-//        JByteArrayCritical password(env, jPassword, passwordLen, WipeMode::WIPE_INPUT);
-//        // ... algorithm writes through out1, out2 ...
-//        // Close every critical region first:
-//        password.release();
-//        out2.release();
-//        out1.release();
-//        // Now no critical regions are open; safe to SetByteArrayRegion:
-//        out2.commitBack();
-//        out1.commitBack();
-//        // Subsequent dtor calls are no-ops (release/commit are idempotent).
-//
-//    Without the manual sequence, RAII alone would invoke out2's auto-commitBack while
-//    out1's critical region was still open -- a JNI rule violation.
+// JNI rule: while ANY JByteArrayCritical (or subclass) is in its critical region on the
+// thread, no other non-Release JNI calls (including GetArrayLength, SetByteArrayRegion,
+// etc.) may run. Callers MUST therefore compute every GetArrayLength they need BEFORE
+// constructing any JByteArrayCritical (or subclass), and SecretOutputArray's commitBack()
+// must run only after every critical region on the thread has been released.
 class JByteArrayCritical {
 public:
-    // |len| MUST be the result of env->GetArrayLength(jarray). Callers compute it
-    // before constructing any JByteArrayCritical so that all GetArrayLength calls
-    // happen outside any critical region (GetArrayLength is a non-Release JNI call,
-    // and JNI forbids non-Release JNI calls while any critical region on the thread
-    // is open).
-    JByteArrayCritical(JNIEnv* env, jbyteArray jarray, jsize len, WipeMode mode);
-    // Destructor calls release() and (for WIPE_OUTPUT) commitBack() if the caller has
-    // not done so. Safe for the single-WIPE_OUTPUT-per-scope case; the multi-output
-    // case requires the explicit pattern documented above.
-    ~JByteArrayCritical();
+    JByteArrayCritical(JNIEnv* env, jbyteArray jarray);
+    virtual ~JByteArrayCritical();
     unsigned char* get();
 
-    // End the critical region. For WIPE_OUTPUT on the copy path, also OPENSSL_cleanses
-    // the native buffer, frees it via JNI_ABORT, and stashes the caller's writes for a
-    // later commitBack(). Idempotent and noexcept (allocations happen in the ctor).
+    // End the critical region. Idempotent and noexcept. The dtor calls release() if the
+    // caller didn't.
     void release() noexcept;
-
-    // For WIPE_OUTPUT only: commit stashed bytes back to the Java array via
-    // SetByteArrayRegion. No-op for other modes or when no native copy was made.
-    // Idempotent. MUST be called only after release() has run on this object AND every
-    // OTHER JByteArrayCritical on the thread has exited its critical region.
-    void commitBack();
 
     // Exposed for unit testing of the cleanse-and-stash logic without a real JVM. Copies
     // |len| bytes from |src| into |dst| (resizing |dst| accordingly), then OPENSSL_cleanses
@@ -661,16 +594,96 @@ public:
     JByteArrayCritical(JByteArrayCritical&&) = delete;
     JByteArrayCritical& operator=(JByteArrayCritical&&) = delete;
 
-private:
+protected:
+    // Subclass hook: called from release() exactly once, after the released_ guard has
+    // been set. Default: ReleasePrimitiveArrayCritical(..., 0). Subclasses override this
+    // to perform OPENSSL_cleanse and/or use JNI_ABORT instead of mode 0. Must be noexcept.
+    virtual void doRelease() noexcept;
+
     void* ptr_;
     JNIEnv* env_;
     jbyteArray jarray_;
-    jsize len_;
     jboolean is_copy_;
-    WipeMode mode_;
     bool released_;
-    // Pre-allocated in the ctor for WIPE_OUTPUT on the copy path so release() is
-    // allocation-free and noexcept. Cleared by commitBack() to make it idempotent.
+};
+
+// Sensitive read-only Java byte array (key material, password, plaintext-in). The caller
+// MUST NOT write through get(). On release, if the JVM returned a copy, it is
+// OPENSSL_cleansed and discarded via JNI_ABORT so that no copy of the secret remains on
+// the C heap; the Java array is preserved unchanged. On the pinned path the wipe is a
+// no-op (mutating the Java array is forbidden).
+//
+// |len| must be env->GetArrayLength(jarray) computed BEFORE entering any critical region.
+class SecretInputArray : public JByteArrayCritical {
+public:
+    SecretInputArray(JNIEnv* env, jbyteArray jarray, jsize len);
+    ~SecretInputArray() override = default;
+
+protected:
+    void doRelease() noexcept override;
+
+private:
+    jsize len_;
+};
+
+// Sensitive caller-writable Java byte array (derived key, plaintext-out). On release, if
+// the JVM returned a copy, the caller's writes are stashed in a SecureAlloc-backed vector
+// (allocation reserved in the ctor), the native buffer is OPENSSL_cleansed and discarded
+// via JNI_ABORT, and the stashed bytes are committed back to the Java array via
+// SetByteArrayRegion. On the pinned path the writes already landed in the Java array and
+// no commit-back is needed.
+//
+// Usage patterns (single WIPE_OUTPUT per scope vs. multi-WIPE_OUTPUT) are described in
+// the body of the class comment below.
+//
+//   1. Single SecretOutputArray per scope: declare it FIRST so its dtor runs LAST under
+//      C++'s LIFO destruction. The dtor handles release() and commitBack() automatically:
+//
+//          SecretOutputArray output(env, jOutput, jOutputLen);  // declared FIRST
+//          SecretInputArray secret(env, jSecret, jSecretLen);
+//          JByteArrayCritical salt(env, jSalt);
+//          // ... algorithm ...
+//          // Destruction at scope exit:
+//          //   1. salt   -> ends salt's critical region (mode 0)
+//          //   2. secret -> ends secret's critical region (cleanse + JNI_ABORT)
+//          //   3. output -> ends output's critical region, then SetByteArrayRegion
+//          //                (safe: no other criticals are open at this point)
+//
+//   2. Multiple SecretOutputArrays in one scope: the caller MUST drive release() and
+//      commitBack() manually so all criticals are closed before any commit runs:
+//
+//          SecretOutputArray out1(env, jA, jALen);
+//          SecretOutputArray out2(env, jB, jBLen);
+//          SecretInputArray password(env, jPassword, jPasswordLen);
+//          // ... algorithm writes through out1, out2 ...
+//          password.release();
+//          out2.release();
+//          out1.release();
+//          // Now no critical regions are open; safe to SetByteArrayRegion:
+//          out2.commitBack();
+//          out1.commitBack();
+//          // Subsequent dtor calls are no-ops (release/commit are idempotent).
+//
+//      Without the manual sequence, RAII alone would invoke out2's auto-commitBack while
+//      out1's critical region was still open -- a JNI rule violation.
+//
+// |len| must be env->GetArrayLength(jarray) computed BEFORE entering any critical region.
+class SecretOutputArray : public JByteArrayCritical {
+public:
+    SecretOutputArray(JNIEnv* env, jbyteArray jarray, jsize len);
+    ~SecretOutputArray() override;
+
+    // Commit stashed bytes back to the Java array via SetByteArrayRegion. No-op when no
+    // native copy was made. Idempotent. MUST be called only after release() of this
+    // object AND every other JByteArrayCritical on the thread has exited its critical
+    // region.
+    void commitBack();
+
+protected:
+    void doRelease() noexcept override;
+
+private:
+    jsize len_;
     std::vector<uint8_t, SecureAlloc<uint8_t> > stash_;
 };
 

--- a/csrc/hkdf.cpp
+++ b/csrc/hkdf.cpp
@@ -24,14 +24,12 @@ extern "C" JNIEXPORT void JNICALL Java_com_amazon_corretto_crypto_provider_HkdfS
         // GetArrayLength must be called BEFORE any JBAC ctor; see csrc/buffer.h.
         const jsize jOutputLen = env->GetArrayLength(jOutput);
         const jsize jSecretLen = env->GetArrayLength(jSecret);
-        const jsize jSaltLen = env->GetArrayLength(jSalt);
-        const jsize jInfoLen = env->GetArrayLength(jInfo);
 
-        // |output| (WIPE_OUTPUT) declared first so it destructs last; see csrc/buffer.h.
-        JByteArrayCritical output(env, jOutput, jOutputLen, WipeMode::WIPE_OUTPUT);
-        JByteArrayCritical secret(env, jSecret, jSecretLen, WipeMode::WIPE_INPUT);
-        JByteArrayCritical salt(env, jSalt, jSaltLen, WipeMode::NO_WIPE);
-        JByteArrayCritical info(env, jInfo, jInfoLen, WipeMode::NO_WIPE);
+        // SecretOutputArray declared first so it destructs last; see csrc/buffer.h.
+        SecretOutputArray output(env, jOutput, jOutputLen);
+        SecretInputArray secret(env, jSecret, jSecretLen);
+        JByteArrayCritical salt(env, jSalt);
+        JByteArrayCritical info(env, jInfo);
         EVP_MD const* digest = digest_code_to_EVP_MD(digestCode);
 
         if (HKDF(output.get(), outputLen, digest, secret.get(), secretLen, salt.get(), saltLen, info.get(), infoLen)
@@ -59,11 +57,10 @@ extern "C" JNIEXPORT void JNICALL Java_com_amazon_corretto_crypto_provider_HkdfS
         // GetArrayLength must be called BEFORE any JBAC ctor; see csrc/buffer.h.
         const jsize jOutputLen = env->GetArrayLength(jOutput);
         const jsize jSecretLen = env->GetArrayLength(jSecret);
-        const jsize jSaltLen = env->GetArrayLength(jSalt);
 
-        JByteArrayCritical output(env, jOutput, jOutputLen, WipeMode::WIPE_OUTPUT);
-        JByteArrayCritical secret(env, jSecret, jSecretLen, WipeMode::WIPE_INPUT);
-        JByteArrayCritical salt(env, jSalt, jSaltLen, WipeMode::NO_WIPE);
+        SecretOutputArray output(env, jOutput, jOutputLen);
+        SecretInputArray secret(env, jSecret, jSecretLen);
+        JByteArrayCritical salt(env, jSalt);
         EVP_MD const* digest = digest_code_to_EVP_MD(digestCode);
 
         size_t out_len = 0;
@@ -92,11 +89,10 @@ extern "C" JNIEXPORT void JNICALL Java_com_amazon_corretto_crypto_provider_HkdfS
         // GetArrayLength must be called BEFORE any JBAC ctor; see csrc/buffer.h.
         const jsize jOutputLen = env->GetArrayLength(jOutput);
         const jsize jPrkLen = env->GetArrayLength(jPrk);
-        const jsize jInfoLen = env->GetArrayLength(jInfo);
 
-        JByteArrayCritical output(env, jOutput, jOutputLen, WipeMode::WIPE_OUTPUT);
-        JByteArrayCritical prk(env, jPrk, jPrkLen, WipeMode::WIPE_INPUT);
-        JByteArrayCritical info(env, jInfo, jInfoLen, WipeMode::NO_WIPE);
+        SecretOutputArray output(env, jOutput, jOutputLen);
+        SecretInputArray prk(env, jPrk, jPrkLen);
+        JByteArrayCritical info(env, jInfo);
         EVP_MD const* digest = digest_code_to_EVP_MD(digestCode);
 
         if (HKDF_expand(output.get(), outputLen, digest, prk.get(), prkLen, info.get(), infoLen) != 1) {

--- a/csrc/pbkdf2.cpp
+++ b/csrc/pbkdf2.cpp
@@ -24,14 +24,13 @@ Java_com_amazon_corretto_crypto_provider_Pbkdf2SecretKeyFactorySpi_pbkdf2(JNIEnv
         // non-Release JNI call and JNI forbids them while any critical region is open.
         const jsize jOutputLen = env->GetArrayLength(jOutput);
         const jsize jPasswordLen = env->GetArrayLength(jPassword);
-        const jsize jSaltLen = env->GetArrayLength(jSalt);
 
-        // |output| (WIPE_OUTPUT) is declared FIRST so its dtor runs LAST, after every
-        // other JBAC's critical region has been released. WIPE_OUTPUT's release path
-        // calls SetByteArrayRegion, which JNI forbids while any critical region is held.
-        JByteArrayCritical output(env, jOutput, jOutputLen, WipeMode::WIPE_OUTPUT);
-        JByteArrayCritical password(env, jPassword, jPasswordLen, WipeMode::WIPE_INPUT);
-        JByteArrayCritical salt(env, jSalt, jSaltLen, WipeMode::NO_WIPE);
+        // |output| (SecretOutputArray) is declared FIRST so its dtor runs LAST, after every
+        // other JBAC's critical region has been released. Its release path calls
+        // SetByteArrayRegion, which JNI forbids while any critical region is held.
+        SecretOutputArray output(env, jOutput, jOutputLen);
+        SecretInputArray password(env, jPassword, jPasswordLen);
+        JByteArrayCritical salt(env, jSalt);
         EVP_MD const* digest = digest_code_to_EVP_MD(digestCode);
 
         if (PKCS5_PBKDF2_HMAC(reinterpret_cast<const char*>(password.get()), passwordLen, salt.get(), saltLen,


### PR DESCRIPTION
## Status

Draft.

## Summary

Follow-up to #547 per [prasden's suggestion](https://github.com/corretto/amazon-corretto-crypto-provider/pull/547#discussion_r3438916640). Encodes wipe semantics in the type rather than a runtime `WipeMode` flag, so callers can't accidentally tag a secret with `NO_WIPE`.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.