### PR TITLE
Make ACCP X25519 usable by JSSE for TLS 1.3

### DIFF
--- a/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
+++ b/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
@@ -236,7 +236,8 @@ public final class AmazonCorrettoCryptoProvider extends java.security.Provider {
               "SupportedKeyClasses",
               "java.security.interfaces.XECPublicKey|java.security.interfaces.XECPrivateKey");
       // Register under both the "XDH" and "X25519" names, mirroring the dual registration used for
-      // KeyPairGenerator/KeyFactory. JSSE's TLS 1.3 handshake requests KeyAgreement.getInstance("XDH"),
+      // KeyPairGenerator/KeyFactory. JSSE's TLS 1.3 handshake requests
+      // KeyAgreement.getInstance("XDH"),
       // so without the "XDH" alias it silently fails over to another provider (e.g. SunEC).
       addService("KeyAgreement", "XDH", "EvpKeyAgreement$XDH", xdhKeyAgreementAttributes);
       addService("KeyAgreement", "X25519", "EvpKeyAgreement$XDH", xdhKeyAgreementAttributes);

--- a/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
+++ b/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
@@ -231,13 +231,15 @@ public final class AmazonCorrettoCryptoProvider extends java.security.Provider {
             "java.security.interfaces.ECPublicKey|java.security.interfaces.ECPrivateKey"));
 
     if (shouldRegisterX25519) {
-      addService(
-          "KeyAgreement",
-          "X25519",
-          "EvpKeyAgreement$XDH",
+      final Map<String, String> xdhKeyAgreementAttributes =
           singletonMap(
               "SupportedKeyClasses",
-              "java.security.interfaces.XECPublicKey|java.security.interfaces.XECPrivateKey"));
+              "java.security.interfaces.XECPublicKey|java.security.interfaces.XECPrivateKey");
+      // Register under both the "XDH" and "X25519" names, mirroring the dual registration used for
+      // KeyPairGenerator/KeyFactory. JSSE's TLS 1.3 handshake requests KeyAgreement.getInstance("XDH"),
+      // so without the "XDH" alias it silently fails over to another provider (e.g. SunEC).
+      addService("KeyAgreement", "XDH", "EvpKeyAgreement$XDH", xdhKeyAgreementAttributes);
+      addService("KeyAgreement", "X25519", "EvpKeyAgreement$XDH", xdhKeyAgreementAttributes);
     }
 
     if (shouldRegisterEcParams) {

--- a/src/com/amazon/corretto/crypto/provider/EvpKeyPairGenerator.java
+++ b/src/com/amazon/corretto/crypto/provider/EvpKeyPairGenerator.java
@@ -31,8 +31,9 @@ abstract class EvpKeyPairGenerator extends KeyPairGeneratorSpi {
     // initialize(int, SecureRandom) before generateKeyPair(). The keysize is
     // fixed by the underlying algorithm, so there is nothing to configure, and
     // ACCP's generator always uses libcrypto's DRBG regardless of |random|.
-    // Note: initialize(AlgorithmParameterSpec, SecureRandom) is intentionally
-    // left to throw UnsupportedOperationException via the default SPI impl.
+    // Note: initialize(AlgorithmParameterSpec, SecureRandom) inherits the default
+    // SPI impl (throws UnsupportedOperationException) unless a subclass overrides
+    // it (e.g. XDHGen accepts NamedParameterSpec.X25519).
   }
 
   // Provides an appropriate KeyFactory for this key type

--- a/src/com/amazon/corretto/crypto/provider/XDHGen.java
+++ b/src/com/amazon/corretto/crypto/provider/XDHGen.java
@@ -18,6 +18,21 @@ class XDHGen extends EvpKeyPairGenerator {
   // KeyPairGenerator for the TLS 1.3 handshake.
   private static final String X25519_CURVE_NAME = "X25519";
 
+  // java.security.spec.NamedParameterSpec is a JDK 11+ type not available at our bytecode target,
+  // so it is resolved reflectively. Null on JDKs that lack it; shouldRegisterX25519 already gates
+  // this SPI to JDK 12+, so the class is present whenever initialize(...) is reachable.
+  private static final Class<?> NAMED_PARAMETER_SPEC_CLASS;
+
+  static {
+    Class<?> clazz = null;
+    try {
+      clazz = Class.forName("java.security.spec.NamedParameterSpec");
+    } catch (final ClassNotFoundException e) {
+      // JDK 10 or older; getNamedCurve will reject all specs, which is correct there.
+    }
+    NAMED_PARAMETER_SPEC_CLASS = clazz;
+  }
+
   XDHGen(AmazonCorrettoCryptoProvider provider) {
     super(provider, EvpKeyType.XDH);
   }
@@ -52,16 +67,14 @@ class XDHGen extends EvpKeyPairGenerator {
     // Nothing else to configure: generateKeyPair() always produces an X25519 key pair.
   }
 
-  // Returns the curve name if |params| is a java.security.spec.NamedParameterSpec, else null.
-  // Uses reflection because NamedParameterSpec is a JDK 11+ type not available at our bytecode
-  // target. shouldRegisterX25519 already gates this SPI to JDK 12+, so the type is present at
-  // runtime whenever this method is reachable.
+  // Returns the curve name if |params| is a java.security.spec.NamedParameterSpec (or a subclass,
+  // matching SunEC's instanceof semantics -- NamedParameterSpec is not final), else null.
   private static String getNamedCurve(final AlgorithmParameterSpec params) {
-    if (!"java.security.spec.NamedParameterSpec".equals(params.getClass().getName())) {
+    if (NAMED_PARAMETER_SPEC_CLASS == null || !NAMED_PARAMETER_SPEC_CLASS.isInstance(params)) {
       return null;
     }
     try {
-      final Method getName = params.getClass().getMethod("getName");
+      final Method getName = NAMED_PARAMETER_SPEC_CLASS.getMethod("getName");
       return (String) getName.invoke(params);
     } catch (final ReflectiveOperationException e) {
       return null;

--- a/src/com/amazon/corretto/crypto/provider/XDHGen.java
+++ b/src/com/amazon/corretto/crypto/provider/XDHGen.java
@@ -2,15 +2,68 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.amazon.corretto.crypto.provider;
 
+import java.lang.reflect.Method;
+import java.security.InvalidAlgorithmParameterException;
 import java.security.KeyFactory;
 import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
 import java.security.PrivateKey;
+import java.security.SecureRandom;
+import java.security.spec.AlgorithmParameterSpec;
 
 class XDHGen extends EvpKeyPairGenerator {
 
+  // The only XDH curve ACCP supports natively is X25519. This is the standard curve name carried by
+  // java.security.spec.NamedParameterSpec.X25519, which JSSE passes when initializing the XDH
+  // KeyPairGenerator for the TLS 1.3 handshake.
+  private static final String X25519_CURVE_NAME = "X25519";
+
   XDHGen(AmazonCorrettoCryptoProvider provider) {
     super(provider, EvpKeyType.XDH);
+  }
+
+  /**
+   * Accepts the standard {@code NamedParameterSpec} initialization used by JSSE (and application
+   * code) for X25519. ACCP always generates X25519 XDH keys, so any spec naming the X25519 curve is
+   * a no-op; any other spec (e.g. X448) is rejected so the JCA can fail over to a provider that
+   * supports it rather than silently producing an X25519 key.
+   *
+   * <p>{@code NamedParameterSpec} was introduced in JDK 11, but ACCP's main sources are compiled for
+   * an older bytecode target, so the spec's curve name is read reflectively rather than by importing
+   * the type directly.
+   */
+  @Override
+  public void initialize(final AlgorithmParameterSpec params, final SecureRandom random)
+      throws InvalidAlgorithmParameterException {
+    if (params == null) {
+      throw new InvalidAlgorithmParameterException("params must not be null");
+    }
+    final String curveName = getNamedCurve(params);
+    if (curveName == null) {
+      throw new InvalidAlgorithmParameterException(
+          "Unsupported AlgorithmParameterSpec: " + params.getClass().getName());
+    }
+    if (!X25519_CURVE_NAME.equalsIgnoreCase(curveName)) {
+      throw new InvalidAlgorithmParameterException(
+          "Unsupported curve: " + curveName + ". ACCP's XDH only supports X25519.");
+    }
+    // Nothing else to configure: generateKeyPair() always produces an X25519 key pair.
+  }
+
+  // Returns the curve name if |params| is a java.security.spec.NamedParameterSpec, else null.
+  // Uses reflection because NamedParameterSpec is a JDK 11+ type not available at our bytecode
+  // target. shouldRegisterX25519 already gates this SPI to JDK 11+, so the type is present at
+  // runtime whenever this method is reachable.
+  private static String getNamedCurve(final AlgorithmParameterSpec params) {
+    if (!"java.security.spec.NamedParameterSpec".equals(params.getClass().getName())) {
+      return null;
+    }
+    try {
+      final Method getName = params.getClass().getMethod("getName");
+      return (String) getName.invoke(params);
+    } catch (final ReflectiveOperationException e) {
+      return null;
+    }
   }
 
   @Override

--- a/src/com/amazon/corretto/crypto/provider/XDHGen.java
+++ b/src/com/amazon/corretto/crypto/provider/XDHGen.java
@@ -31,6 +31,8 @@ class XDHGen extends EvpKeyPairGenerator {
    * <p>{@code NamedParameterSpec} was introduced in JDK 11, but ACCP's main sources are compiled
    * for an older bytecode target, so the spec's curve name is read reflectively rather than by
    * importing the type directly.
+   *
+   * <p>The {@code random} parameter is ignored; key generation always draws from AWS-LC's DRBG.
    */
   @Override
   public void initialize(final AlgorithmParameterSpec params, final SecureRandom random)

--- a/src/com/amazon/corretto/crypto/provider/XDHGen.java
+++ b/src/com/amazon/corretto/crypto/provider/XDHGen.java
@@ -28,9 +28,9 @@ class XDHGen extends EvpKeyPairGenerator {
    * a no-op; any other spec (e.g. X448) is rejected so the JCA can fail over to a provider that
    * supports it rather than silently producing an X25519 key.
    *
-   * <p>{@code NamedParameterSpec} was introduced in JDK 11, but ACCP's main sources are compiled for
-   * an older bytecode target, so the spec's curve name is read reflectively rather than by importing
-   * the type directly.
+   * <p>{@code NamedParameterSpec} was introduced in JDK 11, but ACCP's main sources are compiled
+   * for an older bytecode target, so the spec's curve name is read reflectively rather than by
+   * importing the type directly.
    */
   @Override
   public void initialize(final AlgorithmParameterSpec params, final SecureRandom random)

--- a/src/com/amazon/corretto/crypto/provider/XDHGen.java
+++ b/src/com/amazon/corretto/crypto/provider/XDHGen.java
@@ -54,7 +54,7 @@ class XDHGen extends EvpKeyPairGenerator {
 
   // Returns the curve name if |params| is a java.security.spec.NamedParameterSpec, else null.
   // Uses reflection because NamedParameterSpec is a JDK 11+ type not available at our bytecode
-  // target. shouldRegisterX25519 already gates this SPI to JDK 11+, so the type is present at
+  // target. shouldRegisterX25519 already gates this SPI to JDK 12+, so the type is present at
   // runtime whenever this method is reachable.
   private static String getNamedCurve(final AlgorithmParameterSpec params) {
     if (!"java.security.spec.NamedParameterSpec".equals(params.getClass().getName())) {

--- a/tst/com/amazon/corretto/crypto/provider/test/EvpKeyAgreementSpecificTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/EvpKeyAgreementSpecificTest.java
@@ -109,6 +109,19 @@ public class EvpKeyAgreementSpecificTest {
     assertArrayEquals(aliceSecret, bobSecret);
   }
 
+  // ACCP registers KeyAgreement under the "XDH" name, whose SupportedKeyClasses (XECPublicKey /
+  // XECPrivateKey) also match X448 keys. ACCP only supports X25519, so init'ing with a (SunEC) X448
+  // key must fail with InvalidKeyException, letting the JCA fall through to another provider. This
+  // is the KeyAgreement-side twin of
+  // KeyPairGeneratorTest.initializeWithUnsupportedNamedParameterSpecThrows.
+  @Test
+  public void xdhKeyAgreementRejectsX448Key() throws Exception {
+    TestUtil.assumeMinimumJavaVersion(17);
+    final KeyPair x448KeyPair = KeyPairGenerator.getInstance("X448").generateKeyPair();
+    final KeyAgreement accpAgreement = KeyAgreement.getInstance("XDH", NATIVE_PROVIDER);
+    assertThrows(InvalidKeyException.class, () -> accpAgreement.init(x448KeyPair.getPrivate()));
+  }
+
   @Test
   public void evilEcKeys() {
     final Key privKey = EC_KEYPAIR.getPrivate();

--- a/tst/com/amazon/corretto/crypto/provider/test/EvpKeyAgreementTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/EvpKeyAgreementTest.java
@@ -20,6 +20,7 @@ import java.security.KeyPairGenerator;
 import java.security.PrivateKey;
 import java.security.Provider;
 import java.security.PublicKey;
+import java.security.Security;
 import java.security.interfaces.ECPublicKey;
 import java.security.spec.AlgorithmParameterSpec;
 import java.security.spec.ECFieldFp;
@@ -70,6 +71,9 @@ public class EvpKeyAgreementTest {
     MASTER_PARAMS_LIST.add(buildEcdhParameters(EcGenTest.EXPLICIT_CURVE, "Explicit Curve"));
     if (TestUtil.JAVA_VERSION >= 11) {
       MASTER_PARAMS_LIST.add(buildX25519Parameters());
+      // JSSE requests KeyAgreement.getInstance("XDH") for the TLS 1.3 x25519 handshake, so ACCP must
+      // answer under the "XDH" name as well as "X25519". See P470070813.
+      MASTER_PARAMS_LIST.add(buildXdhParameters());
     }
   }
 
@@ -170,6 +174,18 @@ public class EvpKeyAgreementTest {
         KeyPairGenerator.getInstance("X25519", NATIVE_PROVIDER),
         NATIVE_PROVIDER,
         NATIVE_PROVIDER,
+        Arrays.asList());
+  }
+
+  // Exercises ACCP's KeyAgreement registered under the "XDH" name (the name JSSE uses) and verifies
+  // it interoperates with SunEC's XDH KeyAgreement, matching the real TLS handshake topology.
+  private static TestParams buildXdhParameters() throws GeneralSecurityException, IOException {
+    return new TestParams(
+        "XDH",
+        "XDH(X25519)",
+        KeyPairGenerator.getInstance("XDH", NATIVE_PROVIDER),
+        NATIVE_PROVIDER,
+        Security.getProvider("SunEC"),
         Arrays.asList());
   }
 

--- a/tst/com/amazon/corretto/crypto/provider/test/EvpKeyAgreementTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/EvpKeyAgreementTest.java
@@ -71,7 +71,8 @@ public class EvpKeyAgreementTest {
     MASTER_PARAMS_LIST.add(buildEcdhParameters(EcGenTest.EXPLICIT_CURVE, "Explicit Curve"));
     if (TestUtil.JAVA_VERSION >= 11) {
       MASTER_PARAMS_LIST.add(buildX25519Parameters());
-      // JSSE requests KeyAgreement.getInstance("XDH") for the TLS 1.3 x25519 handshake, so ACCP must
+      // JSSE requests KeyAgreement.getInstance("XDH") for the TLS 1.3 x25519 handshake, so ACCP
+      // must
       // answer under the "XDH" name as well as "X25519". See P470070813.
       MASTER_PARAMS_LIST.add(buildXdhParameters());
     }

--- a/tst/com/amazon/corretto/crypto/provider/test/KeyPairGeneratorTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/KeyPairGeneratorTest.java
@@ -57,7 +57,8 @@ public class KeyPairGeneratorTest {
 
   // Regression test for P470070813: JSSE's TLS 1.3 x25519 handshake initializes the XDH
   // KeyPairGenerator with NamedParameterSpec.X25519. ACCP previously threw
-  // UnsupportedOperationException from initialize(), causing the JCA to silently fail over to SunEC.
+  // UnsupportedOperationException from initialize(), causing the JCA to silently fail over to
+  // SunEC.
   @Test
   public void initializeWithNamedParameterSpecX25519() throws Exception {
     TestUtil.assumeMinimumJavaVersion(11);

--- a/tst/com/amazon/corretto/crypto/provider/test/KeyPairGeneratorTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/KeyPairGeneratorTest.java
@@ -5,11 +5,14 @@ package com.amazon.corretto.crypto.provider.test;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.security.InvalidAlgorithmParameterException;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
 import java.security.PublicKey;
+import java.security.SecureRandom;
+import java.security.spec.AlgorithmParameterSpec;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.parallel.Execution;
@@ -50,5 +53,41 @@ public class KeyPairGeneratorTest {
     assertEquals("X.509", publicKey.getFormat());
     assertEquals("XDH", publicKey.getAlgorithm());
     assertEquals(44, publicKey.getEncoded().length);
+  }
+
+  // Regression test for P470070813: JSSE's TLS 1.3 x25519 handshake initializes the XDH
+  // KeyPairGenerator with NamedParameterSpec.X25519. ACCP previously threw
+  // UnsupportedOperationException from initialize(), causing the JCA to silently fail over to SunEC.
+  @Test
+  public void initializeWithNamedParameterSpecX25519() throws Exception {
+    TestUtil.assumeMinimumJavaVersion(11);
+    final KeyPairGenerator keyPairGenerator = getXECKeyPairGenerator();
+    keyPairGenerator.initialize(namedParameterSpec("X25519"), new SecureRandom());
+    final KeyPair keyPair = keyPairGenerator.generateKeyPair();
+    assertNotNull(keyPair);
+    assertEquals("XDH", keyPair.getPrivate().getAlgorithm());
+    assertEquals("XDH", keyPair.getPublic().getAlgorithm());
+    assertEquals(48, keyPair.getPrivate().getEncoded().length);
+    assertEquals(44, keyPair.getPublic().getEncoded().length);
+  }
+
+  // ACCP only supports X25519, so an XDH generator asked for another curve (e.g. X448) must reject
+  // the spec so the JCA can fail over rather than silently emit an X25519 key.
+  @Test
+  public void initializeWithUnsupportedNamedParameterSpecThrows() throws Exception {
+    TestUtil.assumeMinimumJavaVersion(11);
+    final KeyPairGenerator keyPairGenerator = getXECKeyPairGenerator();
+    assertThrows(
+        InvalidAlgorithmParameterException.class,
+        () -> keyPairGenerator.initialize(namedParameterSpec("X448"), new SecureRandom()));
+  }
+
+  // Builds a java.security.spec.NamedParameterSpec (JDK 11+) reflectively so this test class can
+  // continue to compile against ACCP's lower bytecode target.
+  private static AlgorithmParameterSpec namedParameterSpec(final String name) throws Exception {
+    return (AlgorithmParameterSpec)
+        Class.forName("java.security.spec.NamedParameterSpec")
+            .getConstructor(String.class)
+            .newInstance(name);
   }
 }

--- a/tst/com/amazon/corretto/crypto/provider/test/KeyPairGeneratorTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/KeyPairGeneratorTest.java
@@ -61,7 +61,7 @@ public class KeyPairGeneratorTest {
   // SunEC.
   @Test
   public void initializeWithNamedParameterSpecX25519() throws Exception {
-    TestUtil.assumeMinimumJavaVersion(11);
+    TestUtil.assumeMinimumJavaVersion(17);
     final KeyPairGenerator keyPairGenerator = getKeyPairGenerator("XDH");
     keyPairGenerator.initialize(namedParameterSpec("X25519"), new SecureRandom());
     final KeyPair keyPair = keyPairGenerator.generateKeyPair();
@@ -76,7 +76,7 @@ public class KeyPairGeneratorTest {
   // the spec so the JCA can fail over rather than silently emit an X25519 key.
   @Test
   public void initializeWithUnsupportedNamedParameterSpecThrows() throws Exception {
-    TestUtil.assumeMinimumJavaVersion(11);
+    TestUtil.assumeMinimumJavaVersion(17);
     final KeyPairGenerator keyPairGenerator = getKeyPairGenerator("XDH");
     assertThrows(
         InvalidAlgorithmParameterException.class,

--- a/tst/com/amazon/corretto/crypto/provider/test/KeyPairGeneratorTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/KeyPairGeneratorTest.java
@@ -13,6 +13,7 @@ import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.SecureRandom;
 import java.security.spec.AlgorithmParameterSpec;
+import java.security.spec.ECGenParameterSpec;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.parallel.Execution;
@@ -60,10 +61,10 @@ public class KeyPairGeneratorTest {
   // UnsupportedOperationException from initialize(), causing the JCA to silently fail over to
   // SunEC.
   @Test
-  public void initializeWithNamedParameterSpecX25519() throws Exception {
+  public void initializeWithNamedParameterSpecX25519() throws InvalidAlgorithmParameterException {
     TestUtil.assumeMinimumJavaVersion(17);
     final KeyPairGenerator keyPairGenerator = getKeyPairGenerator("XDH");
-    keyPairGenerator.initialize(namedParameterSpec("X25519"), new SecureRandom());
+    keyPairGenerator.initialize(TestUtil.namedParameterSpec("X25519"), new SecureRandom());
     final KeyPair keyPair = keyPairGenerator.generateKeyPair();
     assertNotNull(keyPair);
     assertEquals("XDH", keyPair.getPrivate().getAlgorithm());
@@ -75,21 +76,32 @@ public class KeyPairGeneratorTest {
   // ACCP only supports X25519, so an XDH generator asked for another curve (e.g. X448) must reject
   // the spec so the JCA can fail over rather than silently emit an X25519 key.
   @Test
-  public void initializeWithUnsupportedNamedParameterSpecThrows() throws Exception {
+  public void initializeWithUnsupportedNamedParameterSpecThrows() {
     TestUtil.assumeMinimumJavaVersion(17);
     final KeyPairGenerator keyPairGenerator = getKeyPairGenerator("XDH");
     assertThrows(
         InvalidAlgorithmParameterException.class,
-        () -> keyPairGenerator.initialize(namedParameterSpec("X448"), new SecureRandom()));
+        () -> keyPairGenerator.initialize(TestUtil.namedParameterSpec("X448"), new SecureRandom()));
   }
 
-  // Builds a java.security.spec.NamedParameterSpec (JDK 11+) reflectively so this test class can
-  // continue to compile against ACCP's lower bytecode target.
-  private static AlgorithmParameterSpec namedParameterSpec(final String name) throws Exception {
-    return (AlgorithmParameterSpec)
-        Class.forName("java.security.spec.NamedParameterSpec")
-            .getConstructor(String.class)
-            .newInstance(name);
+  // A null spec is rejected (rather than NPE'ing or silently generating a key).
+  @Test
+  public void initializeWithNullParamsThrows() {
+    TestUtil.assumeMinimumJavaVersion(17);
+    final KeyPairGenerator keyPairGenerator = getKeyPairGenerator("XDH");
+    assertThrows(
+        InvalidAlgorithmParameterException.class,
+        () -> keyPairGenerator.initialize((AlgorithmParameterSpec) null, new SecureRandom()));
+  }
+
+  // A non-NamedParameterSpec (e.g. ECGenParameterSpec) is rejected so the JCA can fail over.
+  @Test
+  public void initializeWithNonNamedParameterSpecThrows() {
+    TestUtil.assumeMinimumJavaVersion(17);
+    final KeyPairGenerator keyPairGenerator = getKeyPairGenerator("XDH");
+    assertThrows(
+        InvalidAlgorithmParameterException.class,
+        () -> keyPairGenerator.initialize(new ECGenParameterSpec("secp256r1"), new SecureRandom()));
   }
 
   @Test

--- a/tst/com/amazon/corretto/crypto/provider/test/MiscSingleThreadedTests.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/MiscSingleThreadedTests.java
@@ -17,9 +17,11 @@ import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.MessageDigest;
 import java.security.Provider;
+import java.security.SecureRandom;
 import java.security.Security;
 import java.security.Signature;
 import javax.crypto.Cipher;
+import javax.crypto.KeyAgreement;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -89,6 +91,46 @@ public class MiscSingleThreadedTests {
       assertNotEquals(
           ((Provider) TestUtil.NATIVE_PROVIDER).getName(),
           Cipher.getInstance("AES").getProvider().getName());
+    } finally {
+      restoreProviders(oldProviders);
+    }
+  }
+
+  /**
+   * Regression test for P470070813. JSSE's TLS 1.3 x25519 handshake looks up the "XDH"
+   * KeyPairGenerator and KeyAgreement <em>without</em> naming a provider, then initializes the
+   * KeyPairGenerator with a NamedParameterSpec. ACCP previously (a) threw from
+   * XDHGen.initialize(AlgorithmParameterSpec) and (b) did not register KeyAgreement under the "XDH"
+   * name, so the JCA silently failed over to SunEC for both operations. This test installs ACCP as
+   * the highest-priority provider and asserts that ACCP — not another provider — actually serves
+   * each operation, which is exactly the signal an isolated, provider-named test misses.
+   */
+  @Test
+  public void xdhUsableByDefaultProviderLookup() throws Exception {
+    // XDH is only registered on JDK versions where ACCP registers X25519 (getJavaVersion() > 11).
+    TestUtil.assumeMinimumJavaVersion(17);
+    final Provider[] oldProviders = saveProviders();
+    try {
+      AmazonCorrettoCryptoProvider.install();
+
+      // Default (unnamed) lookup + NamedParameterSpec init, as JSSE does. Pre-fix this silently
+      // failed over to SunEC because XDHGen.initialize(AlgorithmParameterSpec) threw.
+      final KeyPairGenerator kpg = KeyPairGenerator.getInstance("XDH");
+      kpg.initialize(TestUtil.namedParameterSpec("X25519"), new SecureRandom());
+      final KeyPair keyPair = kpg.generateKeyPair();
+      assertEquals(
+          NATIVE_PROVIDER.getName(),
+          kpg.getProvider().getName(),
+          "XDH KeyPairGenerator silently failed over to another provider");
+
+      // Default (unnamed) lookup for KeyAgreement.XDH. Pre-fix this resolved to SunEC because ACCP
+      // only registered KeyAgreement under the "X25519" name.
+      final KeyAgreement ka = KeyAgreement.getInstance("XDH");
+      ka.init(keyPair.getPrivate());
+      assertEquals(
+          NATIVE_PROVIDER.getName(),
+          ka.getProvider().getName(),
+          "XDH KeyAgreement silently failed over to another provider");
     } finally {
       restoreProviders(oldProviders);
     }

--- a/tst/com/amazon/corretto/crypto/provider/test/MiscSingleThreadedTests.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/MiscSingleThreadedTests.java
@@ -102,8 +102,8 @@ public class MiscSingleThreadedTests {
    * KeyPairGenerator with a NamedParameterSpec. ACCP previously (a) threw from
    * XDHGen.initialize(AlgorithmParameterSpec) and (b) did not register KeyAgreement under the "XDH"
    * name, so the JCA silently failed over to SunEC for both operations. This test installs ACCP as
-   * the highest-priority provider and asserts that ACCP — not another provider — actually serves
-   * each operation, which is exactly the signal an isolated, provider-named test misses.
+   * the highest-priority provider and asserts that ACCP (not another provider) actually serves each
+   * operation, which is exactly the signal an isolated, provider-named test misses.
    */
   @Test
   public void xdhUsableByDefaultProviderLookup() throws Exception {

--- a/tst/com/amazon/corretto/crypto/provider/test/TestUtil.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/TestUtil.java
@@ -21,6 +21,7 @@ import java.security.NoSuchAlgorithmException;
 import java.security.Provider;
 import java.security.SecureRandom;
 import java.security.Security;
+import java.security.spec.AlgorithmParameterSpec;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
@@ -466,6 +467,22 @@ public class TestUtil {
 
   public static void assumeMinimumJavaVersion(int minVersion) {
     Assumptions.assumeTrue(JAVA_VERSION >= minVersion);
+  }
+
+  /**
+   * Builds a {@code java.security.spec.NamedParameterSpec} (a JDK 11+ type) reflectively so callers
+   * can continue to compile against ACCP's lower bytecode target. Only call on JDK 11+ (e.g. after
+   * {@link #assumeMinimumJavaVersion(int)}).
+   */
+  public static AlgorithmParameterSpec namedParameterSpec(final String name) {
+    try {
+      return (AlgorithmParameterSpec)
+          Class.forName("java.security.spec.NamedParameterSpec")
+              .getConstructor(String.class)
+              .newInstance(name);
+    } catch (final ReflectiveOperationException e) {
+      throw new AssertionError("Unable to construct NamedParameterSpec", e);
+    }
   }
 
   public static synchronized Provider[] saveProviders() {


### PR DESCRIPTION
## Summary

Resolves P470070813.

JSSE's TLS 1.3 x25519 handshake uses the `XDH` algorithm name and initializes the `KeyPairGenerator` with `NamedParameterSpec`. Two JCA-integration defects prevented JSSE from ever using ACCP's X25519 implementation, causing a silent fallback to SunEC for **both** the ephemeral keygen and the ECDH key agreement.

### Defect 1 — `KeyPairGenerator.XDH` rejected `NamedParameterSpec`
`XDHGen` did not override `initialize(AlgorithmParameterSpec, SecureRandom)`, so it inherited `KeyPairGeneratorSpi`'s `UnsupportedOperationException`. When JSSE (`XDHKeyExchange$XDHEPossession`) called `initialize(NamedParameterSpec.X25519, ...)`, `KeyPairGenerator$Delegate` transparently failed over to SunEC.

**Fix:** `XDHGen` now accepts a `NamedParameterSpec` naming X25519 (a no-op, since ACCP always generates X25519 XDH keys) and rejects any other curve with `InvalidAlgorithmParameterException` so the JCA can still fail over (e.g. for X448) rather than silently emit an X25519 key. `NamedParameterSpec` is a JDK 11+ type and ACCP's main sources compile to an older bytecode target, so the curve name is read reflectively — the same pattern already used in `EcParameters`. This SPI is already gated to JDK 11+ via `shouldRegisterX25519`.

### Defect 2 — `KeyAgreement.XDH` not registered
ACCP registered `KeyAgreement` only under the `X25519` name (added in #500), but JSSE calls `KeyAgreement.getInstance("XDH")`, which fell through to SunEC.

**Fix:** Register `EvpKeyAgreement$XDH` under both `XDH` and `X25519`, mirroring the dual registration already used for `KeyPairGenerator`/`KeyFactory`.

## Testing

- `KeyPairGeneratorTest`: new `initialize(NamedParameterSpec.X25519)` test asserting keygen runs on ACCP, plus a negative test that an unsupported curve (X448) throws `InvalidAlgorithmParameterException`.
- `EvpKeyAgreementTest`: new `XDH`-name `KeyAgreement` variant that generates keys via ACCP's `XDH` `KeyPairGenerator` and performs pairwise agreement interop with **SunEC** (matching the real cross-provider TLS handshake).

I manually confirmed the pre-fix failover (both keygen and KA landing on `sun.security.ec.*`) and the post-fix behavior (ACCP used end-to-end, shared secret matches SunEC) before writing the regression tests.


---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.