### PR TITLE
Update README supported-algorithms list

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Cipher algorithms:
   * PKCS7Padding is also accepted with AES/CBC and it is treated the same as PKCS5.
 * AES/CBC/ISO10126Padding
     * AES_\<n\>/CBC/ISO10126Padding, where n can be 128, 192, or 256
-* AES/CFB/NoPadding (non-FIPS builds only)
+* AES/CFB/NoPadding
     * AES_\<n\>/CFB/NoPadding, where n can be 128 or 256
 * RSA/ECB/NoPadding
 * RSA/ECB/PKCS1Padding
@@ -80,16 +80,16 @@ Signature algorithms:
 * NONEwithRSASSA-PSS
 * NONEwithRSA
 * Ed25519 (also registered under the alias EdDSA)
-* Ed25519ph (non-FIPS builds only)
-* NONEwithEd25519ph (non-FIPS builds only)
-* ML-DSA, ML-DSA-ExtMu (non-FIPS builds only)
+* Ed25519ph
+* NONEwithEd25519ph
+* ML-DSA, ML-DSA-ExtMu
 
 KeyPairGenerator:
 * EC
 * RSA
 * Ed25519 (also registered under the alias EdDSA)
 * X25519 (JDK 12+, also registered under the alias XDH)
-* ML-DSA, ML-DSA-44, ML-DSA-65, ML-DSA-87 (non-FIPS builds only)
+* ML-DSA, ML-DSA-44, ML-DSA-65, ML-DSA-87
 * ML-KEM, ML-KEM-512, ML-KEM-768, ML-KEM-1024 (JDK 17+ builds only, also see [ML-KEM Considerations](#ml-kem-considerations))
 
 KeyGenerator:
@@ -129,7 +129,7 @@ KeyFactory:
 * RSA
 * Ed25519 (JDK 15+, opt-in; also registered under the alias EdDSA). Please refer to [system properties](https://github.com/corretto/amazon-corretto-crypto-provider#other-system-properties) for more information.
 * X25519 (JDK 12+, also registered under the alias XDH)
-* ML-DSA, ML-DSA-44, ML-DSA-65, ML-DSA-87 (non-FIPS builds only)
+* ML-DSA, ML-DSA-44, ML-DSA-65, ML-DSA-87
 * ML-KEM, ML-KEM-512, ML-KEM-768, ML-KEM-1024 (JDK 17+ builds only, also see [ML-KEM Considerations](#ml-kem-considerations))
 
 AlgorithmParameters:

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Cipher algorithms:
   * PKCS7Padding is also accepted with AES/CBC and it is treated the same as PKCS5.
 * AES/CBC/ISO10126Padding
     * AES_\<n\>/CBC/ISO10126Padding, where n can be 128, 192, or 256
-* AES/CFB/NoPadding
+* AES/CFB/NoPadding (non-FIPS builds only)
     * AES_\<n\>/CFB/NoPadding, where n can be 128 or 256
 * RSA/ECB/NoPadding
 * RSA/ECB/PKCS1Padding
@@ -79,33 +79,39 @@ Signature algorithms:
 * RSASSA-PSS
 * NONEwithRSASSA-PSS
 * NONEwithRSA
-* ED25519
-* ED25519ph
-* NONEwithED25519ph
-* ML-DSA
-* ML-DSA-ExtMu
+* Ed25519 (also registered under the alias EdDSA)
+* Ed25519ph (non-FIPS builds only)
+* NONEwithEd25519ph (non-FIPS builds only)
+* ML-DSA, ML-DSA-ExtMu (non-FIPS builds only)
 
 KeyPairGenerator:
 * EC
 * RSA
-* ED25519
-* X25519 (JDK 12+)
+* Ed25519 (also registered under the alias EdDSA)
+* X25519 (JDK 12+, also registered under the alias XDH)
+* ML-DSA, ML-DSA-44, ML-DSA-65, ML-DSA-87 (non-FIPS builds only)
+* ML-KEM, ML-KEM-512, ML-KEM-768, ML-KEM-1024 (JDK 17+ builds only, also see [ML-KEM Considerations](#ml-kem-considerations))
 
 KeyGenerator:
 * AES
 
 KeyAgreement:
 * ECDH
-* X25519 (JDK 12+)
+* X25519 (JDK 12+, also registered under the alias XDH)
 
 KEM algorithms:
-* ML-KEM (JDK 17+ LTS, also see [ML-KEM Considerations](#ml-kem-considerations))
+* ML-KEM, ML-KEM-512, ML-KEM-768, ML-KEM-1024 (JDK 17+ LTS, also see [ML-KEM Considerations](#ml-kem-considerations))
 
 SecretKeyFactory:
 * HkdfWithHmacSHA1
 * HkdfWithHmacSHA256
 * HkdfWithHmacSHA384
 * HkdfWithHmacSHA512
+* PBKDF2WithHmacSHA1
+* PBKDF2WithHmacSHA224
+* PBKDF2WithHmacSHA256
+* PBKDF2WithHmacSHA384
+* PBKDF2WithHmacSHA512
 * ConcatenationKdfWithSHA256
 * ConcatenationKdfWithSHA384
 * ConcatenationKdfWithSHA512
@@ -121,8 +127,10 @@ SecureRandom:
 KeyFactory:
 * EC
 * RSA
-* ED25519 (JDK 15+). Please refer to [system properties](https://github.com/corretto/amazon-corretto-crypto-provider#other-system-properties) for more information.
-* X25519 (JDK 12+)
+* Ed25519 (JDK 15+, opt-in; also registered under the alias EdDSA). Please refer to [system properties](https://github.com/corretto/amazon-corretto-crypto-provider#other-system-properties) for more information.
+* X25519 (JDK 12+, also registered under the alias XDH)
+* ML-DSA, ML-DSA-44, ML-DSA-65, ML-DSA-87 (non-FIPS builds only)
+* ML-KEM, ML-KEM-512, ML-KEM-768, ML-KEM-1024 (JDK 17+ builds only, also see [ML-KEM Considerations](#ml-kem-considerations))
 
 AlgorithmParameters:
 * EC. Please refer to [system properties](https://github.com/corretto/amazon-corretto-crypto-provider#other-system-properties) for more information.


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

The README's "Supported Algorithms" section had drifted from what ACCP actually registers. I reconciled it two ways and merged the results:

1. **From source** — read the `addService(...)` / `addSignatures()` calls in `AmazonCorrettoCryptoProvider`, including the build/mode-conditional registrations (`shouldRegisterMLDSA`, `shouldRegisterMLKEM`, `shouldRegisterAesCfb`, `shouldRegisterX25519`, `shouldRegisterEd25519ph`, `shouldRegisterEdKeyFactory`).
2. **Programmatically** — enumerated `Provider.getServices()` on a live ACCP instance (2.6.0, non-FIPS, JDK 17) and grouped by service type.

Notes:
- The `getServices()` dump reflects the default build (non-FIPS, JDK 17), so `ML-KEM` is absent from it (compiled out of the default build) and the ML-DSA/AES-CFB/Ed25519ph entries are present; the README annotates these gating conditions rather than omitting the algorithms.
- The Cipher section already describes full transformations (e.g. `AES/CBC/PKCS5Padding`) rather than the bare registration names (`AES/CBC` + `SupportedModes`), which is the more useful form for callers; left as-is aside from the AES/CFB FIPS annotation.
- SHA3-in-RSASSA-PSS (#555) is a digest accepted within `PSSParameterSpec`, not a separately registered service, so it does not appear in `getServices()` and needs no new list entry.

Verified the reconciliation by diffing the updated README against the `getServices()` output.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.