### PR TITLE
Support PKCS#1 v1.5 RSA signatures with SHA3

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ Signature algorithms:
 * SHA256withRSA
 * SHA384withRSA
 * SHA512withRSA
+* SHA3-224withRSA
+* SHA3-256withRSA
+* SHA3-384withRSA
+* SHA3-512withRSA
 * NONEwithECDSA
 * SHA1withECDSA
 * SHA1withECDSAinP1363Format

--- a/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
+++ b/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
@@ -293,6 +293,15 @@ public final class AmazonCorrettoCryptoProvider extends java.security.Provider {
       }
     }
 
+    // PKCS#1 v1.5 RSA signatures with the SHA3 family. The JCA algorithm names retain the hyphen
+    // (e.g. "SHA3-256withRSA"), which isn't a legal Java identifier, so the backing classes use an
+    // underscore (e.g. EvpSignature$SHA3_256withRSA).
+    for (final String sha3 : asList("SHA3-224", "SHA3-256", "SHA3-384", "SHA3-512")) {
+      final String algorithm = format("%swithRSA", sha3);
+      final String className = format("EvpSignature$%swithRSA", sha3.replace("-", "_"));
+      addService("Signature", algorithm, className);
+    }
+
     addService("Signature", "RSASSA-PSS", "EvpSignature$RSASSA_PSS");
     addService("Signature", "NONEwithRSASSA-PSS", "NoneWithRsa$Pss");
     addService("Signature", "NONEwithRSA", "NoneWithRsa$Pkcs15");

--- a/src/com/amazon/corretto/crypto/provider/EvpSignature.java
+++ b/src/com/amazon/corretto/crypto/provider/EvpSignature.java
@@ -547,6 +547,30 @@ class EvpSignature extends EvpSignatureBase {
     }
   }
 
+  static final class SHA3_224withRSA extends EvpSignature {
+    SHA3_224withRSA(final AmazonCorrettoCryptoProvider provider) {
+      super(provider, EvpKeyType.RSA, RSA_PKCS1_PADDING, "SHA3-224", false);
+    }
+  }
+
+  static final class SHA3_256withRSA extends EvpSignature {
+    SHA3_256withRSA(final AmazonCorrettoCryptoProvider provider) {
+      super(provider, EvpKeyType.RSA, RSA_PKCS1_PADDING, "SHA3-256", false);
+    }
+  }
+
+  static final class SHA3_384withRSA extends EvpSignature {
+    SHA3_384withRSA(final AmazonCorrettoCryptoProvider provider) {
+      super(provider, EvpKeyType.RSA, RSA_PKCS1_PADDING, "SHA3-384", false);
+    }
+  }
+
+  static final class SHA3_512withRSA extends EvpSignature {
+    SHA3_512withRSA(final AmazonCorrettoCryptoProvider provider) {
+      super(provider, EvpKeyType.RSA, RSA_PKCS1_PADDING, "SHA3-512", false);
+    }
+  }
+
   static final class RSASSA_PSS extends EvpSignature {
     RSASSA_PSS(final AmazonCorrettoCryptoProvider provider) {
       super(provider, EvpKeyType.RSA, RSA_PKCS1_PSS_PADDING, null, false);

--- a/tst/com/amazon/corretto/crypto/provider/test/EvpSignatureSpecificTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/EvpSignatureSpecificTest.java
@@ -687,6 +687,11 @@ public final class EvpSignatureSpecificTest {
           || algorithm.startsWith("ML-DSA")) {
         continue;
       }
+      // SHA3 PKCS#1 v1.5 RSA signatures don't fit this test's "SHAxwith..." name pattern; they are
+      // covered separately by testRsaPkcs1Sha3.
+      if (algorithm.startsWith("SHA3-")) {
+        continue;
+      }
       String bcAlgorithm = algorithm;
       AlgorithmParameterSpec keyGenSpec = null;
       String keyGenAlgorithm = null;
@@ -840,6 +845,51 @@ public final class EvpSignatureSpecificTest {
       nativeSig.setParameter(spec);
       simpleCorrectnessSignVerify(
           "RSASSA-PSS/" + digest + "+MGF1-" + mgfDigest, pair, sunSig, nativeSig);
+    }
+  }
+
+  // PKCS#1 v1.5 RSA signature algorithms using the SHA3 family. The JCA algorithm names retain the
+  // hyphen (e.g. "SHA3-256withRSA").
+  static String[] sha3RsaAlgorithms() {
+    return new String[] {
+      "SHA3-224withRSA", "SHA3-256withRSA", "SHA3-384withRSA", "SHA3-512withRSA"
+    };
+  }
+
+  /**
+   * ACCP supports PKCS#1 v1.5 RSA signatures with the SHA3 family. Round-trip within ACCP and
+   * cross-verify against BouncyCastle and SunRsaSign in both directions.
+   *
+   * <p>SunRsaSign only gained SHA3 support in JDK 17, so its cross-check is gated on that;
+   * BouncyCastle supports it regardless and exercises ACCP's signatures on all JDKs.
+   */
+  @ParameterizedTest
+  @MethodSource("sha3RsaAlgorithms")
+  public void testRsaPkcs1Sha3(final String algorithm) throws Throwable {
+    final KeyPairGenerator kg = KeyPairGenerator.getInstance("RSA", NATIVE_PROVIDER);
+    kg.initialize(2048);
+    final KeyPair pair = kg.generateKeyPair();
+
+    // ACCP sign -> ACCP verify.
+    final Signature signer = Signature.getInstance(algorithm, NATIVE_PROVIDER);
+    signer.initSign(pair.getPrivate());
+    signer.update(MESSAGE);
+    final byte[] signature = signer.sign();
+    final Signature verifier = Signature.getInstance(algorithm, NATIVE_PROVIDER);
+    verifier.initVerify(pair.getPublic());
+    verifier.update(MESSAGE);
+    assertTrue(verifier.verify(signature), "ACCP->ACCP: " + algorithm);
+
+    // Cross-verify against BouncyCastle in both directions.
+    final Signature bcSig = Signature.getInstance(algorithm, TestUtil.BC_PROVIDER);
+    final Signature nativeSig = Signature.getInstance(algorithm, NATIVE_PROVIDER);
+    simpleCorrectnessSignVerify(algorithm, pair, bcSig, nativeSig);
+
+    // Cross-verify against SunRsaSign in both directions when available (JDK 17+).
+    if (JAVA_VERSION >= 17) {
+      final Signature sunSig = Signature.getInstance(algorithm, "SunRsaSign");
+      final Signature nativeSig2 = Signature.getInstance(algorithm, NATIVE_PROVIDER);
+      simpleCorrectnessSignVerify(algorithm, pair, sunSig, nativeSig2);
     }
   }
 


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Follow-up to #555 (SHA3 for RSASSA-PSS). That PR did not cover the PKCS#1 v1.5 RSA signature algorithms (`SHAxwithRSA`), which remained SHA2-only: they are registered as fixed, individually-named `EvpSignature` classes hardcoded to a digest, and no SHA3 variants existed.

**Change.** Register `SHA3-224withRSA`, `SHA3-256withRSA`, `SHA3-384withRSA`, `SHA3-512withRSA`, backed by new `EvpSignature$SHA3_<n>withRSA` classes. The JCA algorithm names keep the hyphen (`SHA3-256withRSA`), which isn't a legal Java identifier, so the backing class names use an underscore — the registration maps between the two, the same way `RSASSA-PSS` maps to `EvpSignature$RSASSA_PSS`.

No native changes are needed:
- ACCP's signing path passes the digest to AWS-LC as an `EVP_MD*` pointer via `EVP_DigestSignInit` and sets `RSA_PKCS1_PADDING`; it's digest-agnostic.
- The digest name (`"SHA3-256"`) resolves through `Utils.getMdPtr` → `jceDigestNameToAwsLcName`, which already preserves the SHA3 hyphen (from #555).
- AWS-LC's `kPKCS1SigPrefixes` DigestInfo table already includes `NID_sha3_224/256/384/512`.

**Tests** (mirroring #555's considerations):
- Added `testRsaPkcs1Sha3`, parameterized over the four SHA3 RSA algorithms: ACCP sign/verify round-trip, plus cross-verification against BouncyCastle (both directions, all JDKs) and SunRsaSign (both directions, gated to JDK 17+ where SunRsaSign gained SHA3 support).
- Excluded `SHA3-*` from `simpleCorrectnessSHAAlgorithms`, whose `SHAxwith...` name regex can't parse the SHA3 names — this mirrors the existing `RSASSA-PSS` exclusion there; coverage is provided by `testRsaPkcs1Sha3` instead.
- Verified the new tests actually exercise the feature by removing the registration and confirming exactly the four cases fail with "no such algorithm: SHA3-*withRSA".

**Verification.**
- `EvpSignatureSpecificTest`: all pass (0 failed).
- No regressions: `EvpSignatureTest` (67,398 cases) also passes.
- `spotlessJavaCheck` clean.

Note: validated on a non-FIPS build locally (JDK 17). SHA3 is present in AWS-LC's FIPS module, so this is expected to work in FIPS builds as well, but that path was not exercised locally.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.