### PR TITLE
Optimize in-place AES-GCM TLS encryption

### DIFF
--- a/benchmarks/lib/src/jmh/java/com/amazon/corretto/crypto/provider/benchmarks/AesGcmTlsHeapByteBuffer.java
+++ b/benchmarks/lib/src/jmh/java/com/amazon/corretto/crypto/provider/benchmarks/AesGcmTlsHeapByteBuffer.java
@@ -1,0 +1,109 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package com.amazon.corretto.crypto.provider.benchmarks;
+
+import com.amazon.corretto.crypto.provider.AmazonCorrettoCryptoProvider;
+import java.nio.ByteBuffer;
+import java.security.Key;
+import java.util.concurrent.TimeUnit;
+import javax.crypto.Cipher;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+/** Models the heap-buffer, exact-in-place AES-GCM operation used by Kafka's TLS record layer. */
+@State(Scope.Thread)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+public class AesGcmTlsHeapByteBuffer {
+  private static final int TAG_LENGTH = 16;
+  private static final byte[] TLS_RECORD_AAD = new byte[5];
+
+  @Param({"1024", "16384"})
+  public int recordSize;
+
+  @Param({AmazonCorrettoCryptoProvider.PROVIDER_NAME, "SunJCE"})
+  public String provider;
+
+  private Key key;
+  private byte[] iv;
+  private byte[] plaintext;
+  private byte[] ciphertext;
+  private Cipher encryptor;
+  private Cipher decryptor;
+  private ByteBuffer encryptionRecord;
+  private ByteBuffer decryptionRecord;
+
+  @Setup(Level.Trial)
+  public void setupTrial() throws Exception {
+    BenchmarkUtils.setupProvider(provider);
+    key = new SecretKeySpec(BenchmarkUtils.getRandBytes(16), "AES");
+    iv = BenchmarkUtils.getRandBytes(12);
+    plaintext = BenchmarkUtils.getRandBytes(recordSize);
+    encryptor = Cipher.getInstance("AES/GCM/NoPadding", provider);
+    decryptor = Cipher.getInstance("AES/GCM/NoPadding", provider);
+
+    final Cipher ciphertextGenerator = Cipher.getInstance("AES/GCM/NoPadding", provider);
+    final GCMParameterSpec parameters = new GCMParameterSpec(128, iv);
+    ciphertextGenerator.init(Cipher.ENCRYPT_MODE, key, parameters);
+    ciphertextGenerator.updateAAD(TLS_RECORD_AAD);
+    ciphertext = ciphertextGenerator.doFinal(plaintext);
+
+    // Kafka's SslTransportLayer creates all three SSLEngine buffers with ByteBuffer.allocate.
+    encryptionRecord = ByteBuffer.allocate(recordSize + TAG_LENGTH);
+    decryptionRecord = ByteBuffer.allocate(recordSize + TAG_LENGTH);
+  }
+
+  @Setup(Level.Invocation)
+  public void resetRecords() {
+    encryptionRecord.clear();
+    encryptionRecord.put(plaintext);
+    encryptionRecord.clear();
+
+    decryptionRecord.clear();
+    decryptionRecord.put(ciphertext);
+    decryptionRecord.clear();
+  }
+
+  @Benchmark
+  public int encryptTlsRecordInPlace() throws Exception {
+    incrementIv();
+    encryptor.init(Cipher.ENCRYPT_MODE, key, new GCMParameterSpec(128, iv));
+    encryptor.updateAAD(TLS_RECORD_AAD);
+
+    final ByteBuffer input = encryptionRecord.duplicate();
+    input.limit(recordSize);
+    encryptionRecord.position(0);
+    encryptionRecord.limit(recordSize + TAG_LENGTH);
+    return encryptor.doFinal(input, encryptionRecord);
+  }
+
+  @Benchmark
+  public int decryptTlsRecordInPlace() throws Exception {
+    decryptor.init(Cipher.DECRYPT_MODE, key, new GCMParameterSpec(128, iv));
+    decryptor.updateAAD(TLS_RECORD_AAD);
+
+    final ByteBuffer input = decryptionRecord.duplicate();
+    input.limit(recordSize + TAG_LENGTH);
+    decryptionRecord.position(0);
+    decryptionRecord.limit(recordSize);
+    return decryptor.doFinal(input, decryptionRecord);
+  }
+
+  private void incrementIv() {
+    for (int i = iv.length - 1; i >= 0; i--) {
+      iv[i]++;
+      if (iv[i] != 0) {
+        return;
+      }
+    }
+  }
+}

--- a/csrc/aes_gcm.cpp
+++ b/csrc/aes_gcm.cpp
@@ -179,6 +179,67 @@ static int cryptFinish(raii_env& env, int opMode, java_buffer resultBuf, unsigne
     return outl;
 }
 
+// Process a small, in-place encryption without repeatedly entering critical regions for the same
+// Java array. This is the shape used by SSLEngine: plaintext and ciphertext share one heap buffer,
+// and a TLS record is well below CHUNK_SIZE.
+static int encryptInPlaceSinglePass(raii_env& env,
+    java_buffer input,
+    jint inputOffset,
+    java_buffer result,
+    jint resultOffset,
+    unsigned int tagLen,
+    raii_cipher_ctx& ctx)
+{
+    if (unlikely(result.len() < input.len())) {
+        throw java_ex(EX_ARRAYOOB, "Tried to process more data than would fit in the output buffer");
+    }
+    if (unlikely(tagLen > result.len() - input.len())) {
+        throw java_ex(EX_SHORTBUF, "No space for GCM tag");
+    }
+
+    jni_borrow buffer(env, input, "input/output");
+    uint8_t* const arrayBase = buffer.data() - inputOffset;
+    uint8_t* const output = arrayBase + resultOffset;
+    const uint8_t* const plaintext = arrayBase + inputOffset;
+
+    int updateLength;
+    if (unlikely(!EVP_CipherUpdate(ctx, output, &updateLength, plaintext, input.len()))) {
+        throw java_ex::from_openssl(EX_RUNTIME_CRYPTO, "CipherUpdate failed");
+    }
+    if (unlikely(updateLength < 0 || static_cast<size_t>(updateLength) > result.len())) {
+        env.fatal_error("Buffer overrun in cipher update");
+    }
+
+    int finalLength;
+    if (unlikely(!EVP_CipherFinal_ex(ctx, output + updateLength, &finalLength))) {
+        throw java_ex::from_openssl(EX_RUNTIME_CRYPTO, "CipherFinal failed");
+    }
+    if (unlikely(finalLength < 0
+            || static_cast<size_t>(updateLength + finalLength) > result.len() - tagLen)) {
+        env.fatal_error("Buffer overrun in cipher final");
+    }
+
+    const int ciphertextLength = updateLength + finalLength;
+    if (unlikely(!EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_GET_TAG, tagLen, output + ciphertextLength))) {
+        throw java_ex(EX_RUNTIME_CRYPTO, "Failed to get GCM tag");
+    }
+
+    return ciphertextLength + tagLen;
+}
+
+namespace {
+void updateAAD_loop(raii_env& env, EVP_CIPHER_CTX* ctx, java_buffer aadData)
+{
+    jni_borrow aad(env, aadData, "aad");
+
+    int outl_ignored;
+    // Usually AAD is fairly small, so let's not worry about dropping locks periodically
+    if (!EVP_CipherUpdate(ctx, NULL, &outl_ignored, aad, aad.len())) {
+        throw java_ex::from_openssl(EX_RUNTIME_CRYPTO, "Failed to update AAD state");
+    }
+}
+}
+
 JNIEXPORT int JNICALL Java_com_amazon_corretto_crypto_provider_AesGcmSpi_oneShotEncrypt(JNIEnv* pEnv,
     jclass,
     jlong ctxPtr,
@@ -191,7 +252,9 @@ JNIEXPORT int JNICALL Java_com_amazon_corretto_crypto_provider_AesGcmSpi_oneShot
     jint resultOffset,
     jint tagLen,
     jbyteArray keyArray,
-    jbyteArray ivArray)
+    jbyteArray ivArray,
+    jbyteArray aadBuffer,
+    jint aadSize)
 {
     try {
         raii_env env(pEnv);
@@ -199,15 +262,26 @@ JNIEXPORT int JNICALL Java_com_amazon_corretto_crypto_provider_AesGcmSpi_oneShot
 
         initializeContext(env, ctxPtr, ctx, sameKey, keyArray, ivArray, NATIVE_MODE_ENCRYPT);
 
+        if (aadSize != 0) {
+            updateAAD_loop(env, ctx, java_buffer::from_array(env, aadBuffer, 0, aadSize));
+        }
+
         java_buffer input = java_buffer::from_array(env, inputArray, inoffset, inlen);
         java_buffer result = java_buffer::from_array(env, resultArray, resultOffset);
 
-        int outoffset = updateLoop(env, result, input, ctx);
-        if (outoffset < 0)
-            return 0;
+        int outputLength;
+        // IsSameObject must run before opening the critical region in
+        // encryptInPlaceSinglePass. JNI calls are forbidden while it is open.
+        if (inlen <= CHUNK_SIZE && env->IsSameObject(inputArray, resultArray)) {
+            outputLength = encryptInPlaceSinglePass(env, input, inoffset, result, resultOffset, tagLen, ctx);
+        } else {
+            int updateLength = updateLoop(env, result, input, ctx);
+            if (updateLength < 0)
+                return 0;
 
-        result = result.subrange(outoffset);
-        int finalOffset = cryptFinish(env, NATIVE_MODE_ENCRYPT, result, tagLen, ctx);
+            result = result.subrange(updateLength);
+            outputLength = updateLength + cryptFinish(env, NATIVE_MODE_ENCRYPT, result, tagLen, ctx);
+        }
 
         if (!ctxPtr && ctxOut) {
             // Context is new, but caller does want it back
@@ -215,7 +289,7 @@ JNIEXPORT int JNICALL Java_com_amazon_corretto_crypto_provider_AesGcmSpi_oneShot
             env->SetLongArrayRegion(ctxOut, 0 /* start position */, 1 /* number of elements */, &tmpPtr);
         }
 
-        return finalOffset + outoffset;
+        return outputLength;
     } catch (java_ex& ex) {
         ex.throw_to_java(pEnv);
         return -1;
@@ -262,19 +336,6 @@ JNIEXPORT jint JNICALL Java_com_amazon_corretto_crypto_provider_AesGcmSpi_encryp
         ex.throw_to_java(pEnv);
         return -1;
     }
-}
-
-namespace {
-void updateAAD_loop(raii_env& env, EVP_CIPHER_CTX* ctx, java_buffer aadData)
-{
-    jni_borrow aad(env, aadData, "aad");
-
-    int outl_ignored;
-    // Usually AAD is fairly small, so let's not worry about dropping locks periodically
-    if (!EVP_CipherUpdate(ctx, NULL, &outl_ignored, aad, aad.len())) {
-        throw java_ex::from_openssl(EX_RUNTIME_CRYPTO, "Failed to update AAD state");
-    }
-}
 }
 
 JNIEXPORT void JNICALL Java_com_amazon_corretto_crypto_provider_AesGcmSpi_encryptUpdateAAD(

--- a/src/com/amazon/corretto/crypto/provider/AesGcmSpi.java
+++ b/src/com/amazon/corretto/crypto/provider/AesGcmSpi.java
@@ -46,9 +46,8 @@ final class AesGcmSpi extends CipherSpi {
   private static final int NATIVE_MODE_DECRYPT = 0;
 
   /**
-   * Performs an encryption operation in a single call. AAD data is not supported in this mode. The
-   * native-side code will take care of periodically dropping any buffer locks it has to allow GC to
-   * make progress.
+   * Performs an encryption operation in a single call. The native-side code will take care of
+   * periodically dropping any buffer locks it has to allow GC to make progress.
    *
    * @param ctxPtr Optional Context pointer
    * @param ctxPtrOut Optional out parameter to recieve new context
@@ -60,6 +59,8 @@ final class AesGcmSpi extends CipherSpi {
    * @param tagLen Length of GCM tag
    * @param key AES key
    * @param iv Initialization vector
+   * @param aadBuffer AAD data buffer; the data must start from offset zero in this buffer
+   * @param aadSize Size of AAD data; any data in the buffer beyond this point is ignored
    * @return Actual number of bytes written
    */
   private static native int oneShotEncrypt(
@@ -73,7 +74,9 @@ final class AesGcmSpi extends CipherSpi {
       int resultOffset,
       int tagLen,
       byte[] key,
-      byte[] iv);
+      byte[] iv,
+      byte[] aadBuffer,
+      int aadSize);
 
   /**
    * Performs a decryption operation in a single call. Unlike oneShotEncrypt, AAD mode is supported.
@@ -194,7 +197,7 @@ final class AesGcmSpi extends CipherSpi {
 
   private final AccessibleByteArrayOutputStream decryptInputBuf =
       new AccessibleByteArrayOutputStream(0, Integer.MAX_VALUE);
-  private final AccessibleByteArrayOutputStream decryptAADBuf =
+  private final AccessibleByteArrayOutputStream aadBuffer =
       new AccessibleByteArrayOutputStream(0, Integer.MAX_VALUE);
 
   AesGcmSpi(final AmazonCorrettoCryptoProvider provider) {
@@ -466,6 +469,7 @@ final class AesGcmSpi extends CipherSpi {
           checkOutputBuffer(inputLen, output, outputOffset, false);
 
           lazyInit();
+          flushBufferedAAD();
 
           // If we have an overlap, we'll need to clone the input buffer before we potentially start
           // overwriting it.
@@ -494,16 +498,27 @@ final class AesGcmSpi extends CipherSpi {
     if (hasConsumedData) {
       throw new IllegalStateException("AAD data cannot be updated after calling update()");
     }
+    if (opMode < 0) {
+      throw new IllegalStateException("Cipher not initialized");
+    }
+    if (opMode == NATIVE_MODE_ENCRYPT) {
+      checkNeedReset();
+    }
 
-    // Older (<= 1.0.1) versions of openssl don't allow AAD data to be provided before the AEAD tag
-    if (opMode == NATIVE_MODE_DECRYPT) {
-      decryptAADBuf.write(bytes, offset, length);
+    // Buffer AAD until the first data operation. This allows the common updateAAD() + doFinal()
+    // sequence to initialize the native context, process AAD, and encrypt in a single JNI call.
+    // Decryption already requires this buffering because older (<= 1.0.1) OpenSSL versions don't
+    // allow AAD to be provided before the AEAD tag.
+    aadBuffer.write(bytes, offset, length);
+  }
+
+  private void flushBufferedAAD() {
+    if (aadBuffer.isEmpty()) {
       return;
     }
 
-    lazyInit();
-
-    internalUpdateAAD(bytes, offset, length);
+    internalUpdateAAD(aadBuffer.getDataBuffer(), 0, aadBuffer.size());
+    aadBuffer.reset();
   }
 
   private void internalUpdateAAD(byte[] bytes, int offset, int length) {
@@ -586,8 +601,10 @@ final class AesGcmSpi extends CipherSpi {
 
       if (!contextInitialized) {
         // Context has not been initialized, meaning the user called doFinal immediately after
-        // init(). In this case
-        // we make a single native call to perform the encryption operation in one go.
+        // init(), optionally with updateAAD() in between. In this case we make a single native call
+        // to perform the encryption operation in one go.
+        final int finalAadSize = aadBuffer.size();
+        final byte[] finalAad = finalAadSize == 0 ? EMPTY_ARRAY : aadBuffer.getDataBuffer();
 
         if (context != null) {
           return context.use(
@@ -603,7 +620,9 @@ final class AesGcmSpi extends CipherSpi {
                       finalOutputOffset,
                       tagLength,
                       key,
-                      iv));
+                      iv,
+                      finalAad,
+                      finalAadSize));
         }
         // We don't have an existing context, however we might want to save one
         if (saveNativeContext()) {
@@ -620,7 +639,9 @@ final class AesGcmSpi extends CipherSpi {
                   finalOutputOffset,
                   tagLength,
                   key,
-                  iv);
+                  iv,
+                  finalAad,
+                  finalAadSize);
           context = new NativeEvpCipherCtx(ptrOut[0]);
           return outLen;
         }
@@ -636,9 +657,11 @@ final class AesGcmSpi extends CipherSpi {
             finalOutputOffset,
             tagLength,
             key,
-            iv);
+            iv,
+            finalAad,
+            finalAadSize);
       }
-      // Context is initialized, which means either updateAAD or update has been invoked after init
+      // Context is initialized, which means update() has been invoked after init().
 
       // We need to make sure to add resultLength here; engineUpdate in encrypt mode produces
       // incremental output (unlike in decrypt mode) and so we need to carry forward whatever
@@ -737,12 +760,12 @@ final class AesGcmSpi extends CipherSpi {
                     tagLength,
                     key,
                     iv,
-                    // The cost of calling decryptAADBuf.getDataBuffer() when its buffer is empty
+                    // The cost of calling aadBuffer.getDataBuffer() when its buffer is empty
                     // is significant for 16-byte decrypt operations (approximately a 7%
                     // performance hit). To avoid this, we reuse the same empty array instead in
                     // this common-case path.
-                    decryptAADBuf.isEmpty() ? EMPTY_ARRAY : decryptAADBuf.getDataBuffer(),
-                    decryptAADBuf.size()));
+                    aadBuffer.isEmpty() ? EMPTY_ARRAY : aadBuffer.getDataBuffer(),
+                    aadBuffer.size()));
       }
 
       // We don't have an existing context, however we might want to save one
@@ -762,11 +785,11 @@ final class AesGcmSpi extends CipherSpi {
                 key,
                 iv,
 
-                // The cost of calling decryptAADBuf.getDataBuffer() when its buffer is empty is
+                // The cost of calling aadBuffer.getDataBuffer() when its buffer is empty is
                 // significant for 16-byte decrypt operations (approximately a 7% performance hit).
                 // To avoid this, we reuse the same empty array
-                decryptAADBuf.isEmpty() ? EMPTY_ARRAY : decryptAADBuf.getDataBuffer(),
-                decryptAADBuf.size());
+                aadBuffer.isEmpty() ? EMPTY_ARRAY : aadBuffer.getDataBuffer(),
+                aadBuffer.size());
         context = new NativeEvpCipherCtx(ptrOut[0]);
         return outlen;
       }
@@ -784,11 +807,11 @@ final class AesGcmSpi extends CipherSpi {
           key,
           iv,
 
-          // The cost of calling decryptAADBuf.getDataBuffer() when its buffer is empty is
+          // The cost of calling aadBuffer.getDataBuffer() when its buffer is empty is
           // significant for 16-byte decrypt operations (approximately a 7% performance hit).
           // To avoid this, we reuse the same empty array
-          decryptAADBuf.isEmpty() ? EMPTY_ARRAY : decryptAADBuf.getDataBuffer(),
-          decryptAADBuf.size());
+          aadBuffer.isEmpty() ? EMPTY_ARRAY : aadBuffer.getDataBuffer(),
+          aadBuffer.size());
     } catch (final AEADBadTagException e) {
       final int maxFillSize = output.length - outputOffset;
       final int endIndex = outputOffset + Math.min(maxFillSize, engineGetOutputSize(inputLen));
@@ -1029,7 +1052,7 @@ final class AesGcmSpi extends CipherSpi {
       context = null;
     }
     decryptInputBuf.reset();
-    decryptAADBuf.reset();
+    aadBuffer.reset();
 
     hasConsumedData = false;
     contextInitialized = false;

--- a/tst/com/amazon/corretto/crypto/provider/test/AesTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/AesTest.java
@@ -145,6 +145,45 @@ public class AesTest {
   }
 
   @Test
+  public void tlsHeapBufferInPlaceWithAad() throws GeneralSecurityException {
+    final byte[] plaintext = TestUtil.getRandomBytes(16 * 1024);
+    final byte[] aad = TestUtil.getRandomBytes(5);
+    final GCMParameterSpec parameters = new GCMParameterSpec(128, nonce);
+
+    jceC.init(Cipher.ENCRYPT_MODE, key, parameters);
+    jceC.updateAAD(aad);
+    final byte[] expected = jceC.doFinal(plaintext);
+
+    final byte[] inPlaceRecord = Arrays.copyOf(plaintext, plaintext.length + 16);
+    final ByteBuffer input = ByteBuffer.wrap(inPlaceRecord);
+    input.limit(plaintext.length);
+    final ByteBuffer output = ByteBuffer.wrap(inPlaceRecord);
+
+    amznC.init(Cipher.ENCRYPT_MODE, key, parameters);
+    amznC.updateAAD(aad);
+    assertEquals(expected.length, amznC.doFinal(input, output));
+    assertArrayEquals(expected, inPlaceRecord);
+
+    // A caller that supplies data through update() must flush all buffered AAD before the first
+    // plaintext chunk while preserving the streaming result.
+    nonce[0]++;
+    final GCMParameterSpec streamingParameters = new GCMParameterSpec(128, nonce);
+    jceC.init(Cipher.ENCRYPT_MODE, key, streamingParameters);
+    jceC.updateAAD(aad);
+    final byte[] expectedStreaming = jceC.doFinal(plaintext);
+
+    final byte[] actualStreaming = new byte[expectedStreaming.length];
+    amznC.init(Cipher.ENCRYPT_MODE, key, streamingParameters);
+    amznC.updateAAD(aad, 0, 2);
+    amznC.updateAAD(aad, 2, aad.length - 2);
+    final int updateLength = amznC.update(plaintext, 0, 1024, actualStreaming, 0);
+    final int finalLength =
+        amznC.doFinal(plaintext, 1024, plaintext.length - 1024, actualStreaming, updateLength);
+    assertEquals(expectedStreaming.length, updateLength + finalLength);
+    assertArrayEquals(expectedStreaming, actualStreaming);
+  }
+
+  @Test
   public void amzn2jce_nonatomic() throws Throwable {
     amznC.init(Cipher.ENCRYPT_MODE, key, new GCMParameterSpec(128, nonce));
     ByteArrayOutputStream os = new ByteArrayOutputStream();


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Optimize the heap-buffer AES-GCM encryption shape used by JSSE TLS records:

1. `Cipher.init(...)`
2. `Cipher.updateAAD(...)` with the TLS record header
3. `Cipher.doFinal(input, output)` where the input and output `ByteBuffer`s share a heap array

Previously, `updateAAD` eagerly initialized the native context and sent the AAD through a separate native call. The subsequent `doFinal` also entered critical regions separately for the input, output, and final/tag output. For a one-shot TLS record this meant three JNI calls and repeated pins of the same heap array.

This change:

- buffers encryption AAD until the first data operation, allowing `updateAAD` + `doFinal` to use the existing one-shot native call;
- flushes buffered AAD before `update` for streaming callers, preserving their existing path;
- processes same-array one-shot inputs up to `CHUNK_SIZE` under one critical region for update, final, and tag output;
- leaves separate-array and larger inputs on the existing chunked path; and
- adds a Kafka/JSSE-shaped JMH benchmark and regression coverage for both one-shot in-place and streaming encryption.

There is no cipher, key, IV, tag, output-layout, or API-semantics change. The fast path performs the same AWS-LC operations and only reduces Java/native transitions and array pinning.

Benchmark results on macOS arm64 with OpenJDK 17.0.18, based on `bb4b9dd`:

| Heap in-place TLS record | `main` | This change | Delta |
| --- | ---: | ---: | ---: |
| 1 KiB, JMH mean | 0.654 us/op | 0.524 us/op | -19.9% |
| 16 KiB, clean repeat mean | 2.027 us/op | 1.951 us/op | -3.7% |
| 16 KiB, pooled median (20 iterations) | 2.025 us/op | 1.940 us/op | -4.2% |

The pooled 16 KiB trimmed means were 2.028 and 1.941 us/op (-4.3%). These are operation-level microbenchmarks, not claims about whole-application CPU; the application-level ceiling depends on the share of CPU spent encrypting TLS records and the record-size distribution.

Validation:

- `./gradlew build` (all test/build variants passed; zero failures)
- 158,917 successful main-suite tests, plus lazy/eager native-context variants and integration checks
- Kafka-shaped 16 KiB heap/in-place regression test against SunJCE output
- JMH fast path run under `-Xcheck:jni` with no JNI critical-region warnings

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
