### PR TITLE
Validate native AES buffer ranges

### DIFF
--- a/csrc/aes_cbc.cpp
+++ b/csrc/aes_cbc.cpp
@@ -26,6 +26,46 @@ static bool is_encryption_mode(jint op_mode)
     return op_mode == com_amazon_corretto_crypto_provider_AesCbcSpi_ENC_MODE;
 }
 
+static void check_unprocessed_input(jint unprocessed_input)
+{
+    if (unprocessed_input < 0 || unprocessed_input > AES_CBC_BLOCK_SIZE_IN_BYTES) {
+        // This should not be reachable since we check this in Java.
+        throw java_ex(EX_ERROR, "unprocessed_input is not in [0, 16] range.");
+    }
+}
+
+static size_t output_size(
+    jint op_mode, jint padding, jint input_len, jint unprocessed_input, bool do_final)
+{
+    // Mirror AesCbcSpi's update/final allocation rules so the entire native write span is checked.
+    if (input_len < 0) {
+        throw java_ex(EX_ARRAYOOB, "Negative input length");
+    }
+    check_unprocessed_input(unprocessed_input);
+
+    const size_t total = static_cast<size_t>(input_len) + static_cast<size_t>(unprocessed_input);
+    const size_t remainder = total % AES_CBC_BLOCK_SIZE_IN_BYTES;
+    if (do_final) {
+        // Padded encryption always appends enough bytes to complete one final block.
+        const bool adds_padding_block
+            = padding != com_amazon_corretto_crypto_provider_AesCbcSpi_NO_PADDING
+            && is_encryption_mode(op_mode);
+        return adds_padding_block ? total + AES_CBC_BLOCK_SIZE_IN_BYTES - remainder : total;
+    }
+
+    if (total == 0) {
+        return 0;
+    }
+    if (padding == com_amazon_corretto_crypto_provider_AesCbcSpi_NO_PADDING
+        || is_encryption_mode(op_mode)
+        || remainder != 0) {
+        return total - remainder;
+    }
+
+    // AWS-LC may touch the withheld block even though it is not included in the return value.
+    return total;
+}
+
 class AesCbcCipher {
     JNIEnv* jenv_;
     EVP_CIPHER_CTX* ctx_;
@@ -48,14 +88,6 @@ class AesCbcCipher {
         }
 
         return true;
-    }
-
-    static void check_unprocessed_input(int unprocessed_input)
-    {
-        if (unprocessed_input < 0 || unprocessed_input > 16) {
-            // This should not be reachable since we check this in Java.
-            throw java_ex(EX_ERROR, "unprocessed_input is not in [0, 16] range.");
-        }
     }
 
 public:
@@ -133,7 +165,7 @@ public:
 
     int update(uint8_t const* input, int input_len, uint8_t* output, int unprocessed_input)
     {
-        check_unprocessed_input(unprocessed_input);
+        AmazonCorrettoCryptoProvider::check_unprocessed_input(unprocessed_input);
         int result = 0;
         if (output_clobbers_input(input, input_len, output, unprocessed_input)) {
             SimpleBuffer temp(input_len + unprocessed_input);
@@ -324,12 +356,13 @@ extern "C" JNIEXPORT jint JNICALL Java_com_amazon_corretto_crypto_provider_AesCb
 
         // update
         JIOBlobs io_blobs(env, inputDirect, inputArray, outputDirect, outputArray);
-        int result = aes_cbc_cipher.extended_update(is_iso10126, is_enc, lastBlock, io_blobs.get_input() + inputOffset,
-            inputLen, io_blobs.get_output() + outputOffset, 0);
+        uint8_t* input = io_blobs.get_input(inputOffset, inputLen);
+        uint8_t* output = io_blobs.get_output(outputOffset, output_size(opMode, padding, inputLen, 0, true));
+        int result = aes_cbc_cipher.extended_update(is_iso10126, is_enc, lastBlock, input, inputLen, output, 0);
 
         // final
         result += aes_cbc_cipher.extended_do_final(
-            is_iso10126, is_enc, lastBlock, io_blobs.get_output() + outputOffset + result, inputLen - result);
+            is_iso10126, is_enc, lastBlock, output + result, inputLen - result);
 
         return result;
 
@@ -368,9 +401,15 @@ extern "C" JNIEXPORT jint JNICALL Java_com_amazon_corretto_crypto_provider_AesCb
 
         // update
         JIOBlobs io_blobs(env, inputDirect, inputArray, outputDirect, outputArray);
-
-        return aes_cbc_cipher.extended_update(is_iso10126_padding(padding), is_encryption_mode(opMode), lastBlock,
-            io_blobs.get_input() + inputOffset, inputLen, io_blobs.get_output() + outputOffset, 0);
+        uint8_t* input = io_blobs.get_input(inputOffset, inputLen);
+        uint8_t* output = io_blobs.get_output(outputOffset, output_size(opMode, padding, inputLen, 0, false));
+        return aes_cbc_cipher.extended_update(is_iso10126_padding(padding),
+            is_encryption_mode(opMode),
+            lastBlock,
+            input,
+            inputLen,
+            output,
+            0);
 
     } catch (java_ex& ex) {
         ex.throw_to_java(env);
@@ -398,9 +437,16 @@ extern "C" JNIEXPORT jint JNICALL Java_com_amazon_corretto_crypto_provider_AesCb
 
         // update
         JIOBlobs io_blobs(env, inputDirect, inputArray, outputDirect, outputArray);
-
-        return aes_cbc_cipher.extended_update(is_iso10126_padding(padding), is_encryption_mode(opMode), lastBlock,
-            io_blobs.get_input() + inputOffset, inputLen, io_blobs.get_output() + outputOffset, unprocessedInput);
+        uint8_t* input = io_blobs.get_input(inputOffset, inputLen);
+        uint8_t* output
+            = io_blobs.get_output(outputOffset, output_size(opMode, padding, inputLen, unprocessedInput, false));
+        return aes_cbc_cipher.extended_update(is_iso10126_padding(padding),
+            is_encryption_mode(opMode),
+            lastBlock,
+            input,
+            inputLen,
+            output,
+            unprocessedInput);
 
     } catch (java_ex& ex) {
         ex.throw_to_java(env);
@@ -429,18 +475,20 @@ extern "C" JNIEXPORT jint JNICALL Java_com_amazon_corretto_crypto_provider_AesCb
 
         bool is_iso10126 = is_iso10126_padding(padding);
         bool is_enc = is_encryption_mode(opMode);
-
         int up = unprocessedInput;
 
         // update
         JIOBlobs io_blobs(env, inputDirect, inputArray, outputDirect, outputArray);
-        int result = aes_cbc_cipher.extended_update(is_iso10126, is_enc, lastBlock, io_blobs.get_input() + inputOffset,
-            inputLen, io_blobs.get_output() + outputOffset, up);
+        uint8_t* input = io_blobs.get_input(inputOffset, inputLen);
+        uint8_t* output
+            = io_blobs.get_output(outputOffset, output_size(opMode, padding, inputLen, unprocessedInput, true));
+        int result = aes_cbc_cipher.extended_update(
+            is_iso10126, is_enc, lastBlock, input, inputLen, output, up);
 
         // final
         up = (inputLen + unprocessedInput) - result;
         result += aes_cbc_cipher.extended_do_final(
-            is_iso10126, is_enc, lastBlock, io_blobs.get_output() + outputOffset + result, up);
+            is_iso10126, is_enc, lastBlock, output + result, up);
 
         return result;
 

--- a/csrc/aes_cfb.cpp
+++ b/csrc/aes_cfb.cpp
@@ -152,9 +152,10 @@ extern "C" JNIEXPORT jint JNICALL Java_com_amazon_corretto_crypto_provider_AesCf
 
         // update and final
         JIOBlobs io_blobs(env, nullptr, inputArray, nullptr, outputArray);
-        int result
-            = aes_cfb_cipher.update(io_blobs.get_input() + inputOffset, inputLen, io_blobs.get_output() + outputOffset);
-        result += aes_cfb_cipher.do_final(io_blobs.get_output() + outputOffset + result);
+        uint8_t* input = io_blobs.get_input(inputOffset, inputLen);
+        uint8_t* output = io_blobs.get_output(outputOffset, inputLen);
+        int result = aes_cfb_cipher.update(input, inputLen, output);
+        result += aes_cfb_cipher.do_final(output + result);
 
         return result;
 
@@ -190,8 +191,9 @@ extern "C" JNIEXPORT jint JNICALL Java_com_amazon_corretto_crypto_provider_AesCf
 
         // update
         JIOBlobs io_blobs(env, nullptr, inputArray, nullptr, outputArray);
-        return aes_cfb_cipher.update(
-            io_blobs.get_input() + inputOffset, inputLen, io_blobs.get_output() + outputOffset);
+        uint8_t* input = io_blobs.get_input(inputOffset, inputLen);
+        uint8_t* output = io_blobs.get_output(outputOffset, inputLen);
+        return aes_cfb_cipher.update(input, inputLen, output);
 
     } catch (java_ex& ex) {
         ex.throw_to_java(env);
@@ -214,8 +216,9 @@ extern "C" JNIEXPORT jint JNICALL Java_com_amazon_corretto_crypto_provider_AesCf
 
         // update
         JIOBlobs io_blobs(env, nullptr, inputArray, nullptr, outputArray);
-        return aes_cfb_cipher.update(
-            io_blobs.get_input() + inputOffset, inputLen, io_blobs.get_output() + outputOffset);
+        uint8_t* input = io_blobs.get_input(inputOffset, inputLen);
+        uint8_t* output = io_blobs.get_output(outputOffset, inputLen);
+        return aes_cfb_cipher.update(input, inputLen, output);
 
     } catch (java_ex& ex) {
         ex.throw_to_java(env);
@@ -239,9 +242,10 @@ extern "C" JNIEXPORT jint JNICALL Java_com_amazon_corretto_crypto_provider_AesCf
 
         // update and final
         JIOBlobs io_blobs(env, nullptr, inputArray, nullptr, outputArray);
-        int result
-            = aes_cfb_cipher.update(io_blobs.get_input() + inputOffset, inputLen, io_blobs.get_output() + outputOffset);
-        result += aes_cfb_cipher.do_final(io_blobs.get_output() + outputOffset + result);
+        uint8_t* input = io_blobs.get_input(inputOffset, inputLen);
+        uint8_t* output = io_blobs.get_output(outputOffset, inputLen);
+        int result = aes_cfb_cipher.update(input, inputLen, output);
+        result += aes_cfb_cipher.do_final(output + result);
 
         return result;
 

--- a/csrc/aes_xts.cpp
+++ b/csrc/aes_xts.cpp
@@ -98,7 +98,8 @@ extern "C" JNIEXPORT void JNICALL Java_com_amazon_corretto_crypto_provider_AesXt
         JByteArrayCritical output(env, joutput, jOutputArrLen, WipeMode::NO_WIPE);
 
         AesXtsCipher cipher(true, packedTweakKey.get() + AES_XTS_KEY_INDEX_START, packedTweakKey.get());
-        cipher.encrypt(input.get() + inputOffset, inputLen, output.get() + outputOffset);
+        cipher.encrypt(
+            input.get(inputOffset, inputLen), inputLen, output.get(outputOffset, inputLen));
 
     } catch (java_ex& ex) {
         ex.throw_to_java(env);
@@ -126,7 +127,8 @@ extern "C" JNIEXPORT void JNICALL Java_com_amazon_corretto_crypto_provider_AesXt
         JByteArrayCritical packedTweakKey(env, jPackedTweakKey, jPackedTweakKeyLen, WipeMode::WIPE_INPUT);
 
         AesXtsCipher cipher(true, packedTweakKey.get() + AES_XTS_KEY_INDEX_START, packedTweakKey.get());
-        cipher.encrypt(input.get() + inputOffset, inputLen, input.get() + outputOffset);
+        cipher.encrypt(
+            input.get(inputOffset, inputLen), inputLen, input.get(outputOffset, inputLen));
 
     } catch (java_ex& ex) {
         ex.throw_to_java(env);
@@ -155,7 +157,8 @@ extern "C" JNIEXPORT void JNICALL Java_com_amazon_corretto_crypto_provider_AesXt
         JByteArrayCritical input(env, jinput, jInputArrLen, WipeMode::NO_WIPE);
 
         AesXtsCipher cipher(false, packedTweakKey.get() + AES_XTS_KEY_INDEX_START, packedTweakKey.get());
-        cipher.decrypt(input.get() + inputOffset, inputLen, output.get() + outputOffset);
+        cipher.decrypt(
+            input.get(inputOffset, inputLen), inputLen, output.get(outputOffset, inputLen));
 
     } catch (java_ex& ex) {
         ex.throw_to_java(env);
@@ -183,7 +186,8 @@ extern "C" JNIEXPORT void JNICALL Java_com_amazon_corretto_crypto_provider_AesXt
         JByteArrayCritical packedTweakKey(env, jPackedTweakKey, jPackedTweakKeyLen, WipeMode::WIPE_INPUT);
 
         AesXtsCipher cipher(false, packedTweakKey.get() + AES_XTS_KEY_INDEX_START, packedTweakKey.get());
-        cipher.decrypt(input.get() + inputOffset, inputLen, input.get() + outputOffset);
+        cipher.decrypt(
+            input.get(inputOffset, inputLen), inputLen, input.get(outputOffset, inputLen));
 
     } catch (java_ex& ex) {
         ex.throw_to_java(env);

--- a/csrc/buffer.cpp
+++ b/csrc/buffer.cpp
@@ -189,6 +189,17 @@ unsigned char* JByteArrayCritical::get()
     return released_ ? nullptr : static_cast<unsigned char*>(ptr_);
 }
 
+unsigned char* JByteArrayCritical::get(size_t offset, size_t len)
+{
+    if (unlikely(released_)) {
+        return nullptr;
+    }
+    if (unlikely(!check_bounds(static_cast<size_t>(len_), offset, len))) {
+        throw java_ex(EX_ARRAYOOB, "Attempted to access outside the bounds of the array");
+    }
+    return static_cast<unsigned char*>(ptr_) + offset;
+}
+
 SimpleBuffer::SimpleBuffer(int size)
     : buffer_(nullptr)
 {
@@ -243,28 +254,52 @@ JIOBlobs::JIOBlobs(JNIEnv* env,
                    jbyteArray inputArray,
                    jobject outputDirectByteBuffer,
                    jbyteArray outputArray)
-    : env_(env)
+    : input_ptr_(nullptr)
+    , output_ptr_(nullptr)
+    , input_len_(0)
+    , output_len_(0)
+    , env_(env)
     , input_array_(inputArray)
     , output_array_(outputArray)
 {
+    if (inputDirectByteBuffer != nullptr && inputArray != nullptr) {
+        throw java_ex(
+            EX_ERROR,
+            "THIS SHOULD NOT BE REACHABLE. Both inputDirectByteBuffer and inputArray cannot be provided.");
+    }
+    if (outputDirectByteBuffer != nullptr && outputArray != nullptr) {
+        throw java_ex(
+            EX_ERROR,
+            "THIS SHOULD NOT BE REACHABLE. Both outputDirectByteBuffer and outputArray cannot be provided.");
+    }
+
+    // Gather all buffer lengths before entering a critical region.
+    if (inputDirectByteBuffer != nullptr) {
+        const jlong capacity = env->GetDirectBufferCapacity(inputDirectByteBuffer);
+        if (capacity < 0) {
+            throw java_ex(EX_ERROR, "GetDirectBufferCapacity failed.");
+        }
+        input_len_ = static_cast<size_t>(capacity);
+    } else if (inputArray != nullptr) {
+        input_len_ = static_cast<size_t>(env->GetArrayLength(inputArray));
+    }
+
+    if (outputDirectByteBuffer != nullptr) {
+        const jlong capacity = env->GetDirectBufferCapacity(outputDirectByteBuffer);
+        if (capacity < 0) {
+            throw java_ex(EX_ERROR, "GetDirectBufferCapacity failed.");
+        }
+        output_len_ = static_cast<size_t>(capacity);
+    } else if (outputArray != nullptr) {
+        output_len_ = static_cast<size_t>(env->GetArrayLength(outputArray));
+    }
+
     // First, we need to deal with buffers that are direct ByteBuffers.
     if (inputDirectByteBuffer != nullptr) {
-        // One should be null. In the Java layer, we ensure this.
-        if (inputArray != nullptr) {
-            throw java_ex(
-                EX_ERROR,
-                "THIS SHOULD NOT BE REACHABLE. Both inputDirectByteBuffer and inputArray cannot be provided.");
-        }
         input_ptr_ = (uint8_t*)env->GetDirectBufferAddress(inputDirectByteBuffer);
     }
 
     if (outputDirectByteBuffer != nullptr) {
-        // One should be null. In the Java layer, we ensure this.
-        if (outputArray != nullptr) {
-            throw java_ex(
-                EX_ERROR,
-                "THIS SHOULD NOT BE REACHABLE. Both outputDirectByteBuffer and outputArray cannot be provided.");
-        }
         output_ptr_ = (inputDirectByteBuffer == outputDirectByteBuffer)
             ? input_ptr_
             : ((uint8_t*)env->GetDirectBufferAddress(outputDirectByteBuffer));
@@ -312,6 +347,22 @@ JIOBlobs::~JIOBlobs()
 
 uint8_t* JIOBlobs::get_input() { return input_ptr_; }
 
+uint8_t* JIOBlobs::get_input(size_t offset, size_t len)
+{
+    if (unlikely(!check_bounds(input_len_, offset, len))) {
+        throw java_ex(EX_ARRAYOOB, "Attempted to access outside the bounds of the input buffer");
+    }
+    return input_ptr_ + offset;
+}
+
 uint8_t* JIOBlobs::get_output() { return output_ptr_; }
+
+uint8_t* JIOBlobs::get_output(size_t offset, size_t len)
+{
+    if (unlikely(!check_bounds(output_len_, offset, len))) {
+        throw java_ex(EX_ARRAYOOB, "Attempted to access outside the bounds of the output buffer");
+    }
+    return output_ptr_ + offset;
+}
 
 } // end of namespace AmazonCorrettoCryptoProvider

--- a/csrc/buffer.h
+++ b/csrc/buffer.h
@@ -637,6 +637,7 @@ public:
     // case requires the explicit pattern documented above.
     ~JByteArrayCritical();
     unsigned char* get();
+    unsigned char* get(size_t offset, size_t len);
 
     // End the critical region. For WIPE_OUTPUT on the copy path, also OPENSSL_cleanses
     // the native buffer, frees it via JNI_ABORT, and stashes the caller's writes for a
@@ -730,7 +731,9 @@ public:
         jbyteArray outputArray);
     ~JIOBlobs();
     uint8_t* get_input();
+    uint8_t* get_input(size_t offset, size_t len);
     uint8_t* get_output();
+    uint8_t* get_output(size_t offset, size_t len);
 
     // deleting copy & move operations to satisfy rule of five
     JIOBlobs(const JIOBlobs&) = delete;
@@ -742,6 +745,8 @@ private:
     // The native pointers that are either backed by a direct ByteBuffer or a byte array.
     uint8_t* input_ptr_;
     uint8_t* output_ptr_;
+    size_t input_len_;
+    size_t output_len_;
     JNIEnv* env_;
     // In case the blobs are backed by byte arrays, we need to keep a reference that is used when the destructor is
     // invoked.


### PR DESCRIPTION
*Description of changes:*
Track array lengths and direct-buffer capacities in JIOBlobs and add range-checked accessors for native pointers.

Validate input and output spans in the AES-XTS, AES-CFB, and AES-CBC native entry points. Account for CBC buffering and padding when determining the maximum writable output span.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
