### PR TITLE
Native ML-KEM SPKI encode/decode for regular FIPS (follow-up to #564)

### DIFF
--- a/csrc/java_evp_keys.cpp
+++ b/csrc/java_evp_keys.cpp
@@ -38,8 +38,11 @@ JNIEXPORT jbyteArray JNICALL Java_com_amazon_corretto_crypto_provider_EvpKey_enc
         EVP_PKEY* key = reinterpret_cast<EVP_PKEY*>(keyHandle);
         OPENSSL_buffer_auto der;
 
-        // This next line allocates memory
-        int derLen = i2d_PUBKEY(key, &der);
+        // This next line allocates memory. AWS-LC-FIPS 3.1.0 has no i2d_PUBKEY for ML-KEM, so
+        // hand-roll its SubjectPublicKeyInfo (byte-identical to i2d_PUBKEY in non-FIPS builds).
+        // TODO [AWS-LC-FIPS 4.x]: drop the encodeMLKEMPublicKey fallback once the FIPS module has i2d_PUBKEY.
+        int derLen = (EVP_PKEY_id(key) == EVP_PKEY_KEM) ? static_cast<int>(encodeMLKEMPublicKey(key, &der))
+                                                        : i2d_PUBKEY(key, &der);
         CHECK_OPENSSL(derLen > 0);
         if (!(result = env->NewByteArray(derLen))) {
             throw_java_ex(EX_OOM, "Unable to allocate DER array");
@@ -733,6 +736,56 @@ JNIEXPORT jbyteArray JNICALL Java_com_amazon_corretto_crypto_provider_EvpMlDsaPr
     return result;
 }
 #endif // !defined(FIPS_BUILD) || defined(EXPERIMENTAL_FIPS_BUILD)
+
+/*
+ * Class:     com_amazon_corretto_crypto_provider_EvpKemPrivateKey
+ * Method:    encodeMlKemPrivateKey
+ * Signature: (J)[B
+ */
+JNIEXPORT jbyteArray JNICALL Java_com_amazon_corretto_crypto_provider_EvpKemPrivateKey_encodeMlKemPrivateKey(
+    JNIEnv* pEnv, jclass, jlong keyHandle)
+{
+    jbyteArray result = NULL;
+
+    try {
+        raii_env env(pEnv);
+
+        EVP_PKEY* key = reinterpret_cast<EVP_PKEY*>(keyHandle);
+        CHECK_OPENSSL(EVP_PKEY_id(key) == EVP_PKEY_KEM);
+
+        uint8_t* der;
+        size_t der_len;
+        CBB cbb;
+        CHECK_OPENSSL(CBB_init(&cbb, 0));
+        // Prefer the standard PKCS8 marshal, which yields the compact seed format in non-FIPS and
+        // experimental-FIPS builds. AWS-LC-FIPS 3.1.0 cannot marshal ML-KEM private keys (no
+        // priv_encode) and lacks seed support, so on failure fall back to hand-rolled expanded-format
+        // PKCS8 after clearing the error queue. Mirrors encodeMlDsaPrivateKey above.
+        // TODO [AWS-LC-FIPS 4.x]: drop the encodeExpandedMLKEMPrivateKey fallback once the FIPS module has priv_encode.
+        if (EVP_marshal_private_key(&cbb, key)) {
+            if (!CBB_finish(&cbb, &der, &der_len)) {
+                OPENSSL_free(der);
+                throw_java_ex(EX_RUNTIME_CRYPTO, "Error finalizing seed ML-KEM key");
+            }
+        } else {
+            ERR_clear_error();
+            der_len = encodeExpandedMLKEMPrivateKey(key, &der);
+        }
+        CBB_cleanup(&cbb);
+
+        if (!(result = env->NewByteArray(der_len))) {
+            OPENSSL_free(der);
+            throw_java_ex(EX_OOM, "Unable to allocate DER array");
+        }
+        // This may throw, if it does we'll just keep the exception state as we return.
+        env->SetByteArrayRegion(result, 0, der_len, (const jbyte*)der);
+        OPENSSL_free(der);
+    } catch (java_ex& ex) {
+        ex.throw_to_java(pEnv);
+    }
+
+    return result;
+}
 
 /*
  * Class:     com_amazon_corretto_crypto_provider_EvpKemKey

--- a/csrc/java_evp_keys.cpp
+++ b/csrc/java_evp_keys.cpp
@@ -38,11 +38,25 @@ JNIEXPORT jbyteArray JNICALL Java_com_amazon_corretto_crypto_provider_EvpKey_enc
         EVP_PKEY* key = reinterpret_cast<EVP_PKEY*>(keyHandle);
         OPENSSL_buffer_auto der;
 
-        // This next line allocates memory. AWS-LC-FIPS 3.1.0 has no i2d_PUBKEY for ML-KEM, so
-        // hand-roll its SubjectPublicKeyInfo (byte-identical to i2d_PUBKEY in non-FIPS builds).
-        // TODO [AWS-LC-FIPS 4.x]: drop the encodeMLKEMPublicKey fallback once the FIPS module has i2d_PUBKEY.
-        int derLen = (EVP_PKEY_id(key) == EVP_PKEY_KEM) ? static_cast<int>(encodeMLKEMPublicKey(key, &der))
-                                                        : i2d_PUBKEY(key, &der);
+        // This next line allocates memory. On failure i2d_PUBKEY leaves |der| untouched.
+        int derLen = i2d_PUBKEY(key, &der);
+        if (derLen <= 0 && EVP_PKEY_id(key) == EVP_PKEY_KEM) {
+            // AWS-LC-FIPS 3.1.0 has no pub_encode for ML-KEM, so i2d_PUBKEY raises
+            // UNSUPPORTED_ALGORITHM there; hand-roll the SubjectPublicKeyInfo instead. The
+            // hand-rolled encoding is byte-identical to what i2d_PUBKEY produces in non-FIPS builds.
+            //
+            // Preferring i2d_PUBKEY over an unconditional divert is what keeps this correct: unlike
+            // the library, encodeMLKEMPublicKey has to infer the algorithm OID from the raw
+            // public-key length, and AWS-LC registers legacy Kyber-R3 under the same EVP_PKEY_KEM
+            // type with the exact same key lengths (see mlkemNidForPublicKeyLen). Whenever the
+            // library can encode the key itself it does, using the key's real OID; the length-based
+            // inference is only reached in regular FIPS, where no non-ML-KEM EVP_PKEY_KEM key can
+            // exist (ACCP only ever generates ML-KEM, and the FIPS module has no pub_decode/
+            // priv_decode at all, so the only decoders are ACCP's, which reject non-ML-KEM OIDs).
+            // TODO [AWS-LC-FIPS 4.x]: drop the encodeMLKEMPublicKey fallback once the FIPS module has i2d_PUBKEY.
+            ERR_clear_error();
+            derLen = static_cast<int>(encodeMLKEMPublicKey(key, &der));
+        }
         CHECK_OPENSSL(derLen > 0);
         if (!(result = env->NewByteArray(derLen))) {
             throw_java_ex(EX_OOM, "Unable to allocate DER array");
@@ -753,33 +767,37 @@ JNIEXPORT jbyteArray JNICALL Java_com_amazon_corretto_crypto_provider_EvpKemPriv
         EVP_PKEY* key = reinterpret_cast<EVP_PKEY*>(keyHandle);
         CHECK_OPENSSL(EVP_PKEY_id(key) == EVP_PKEY_KEM);
 
-        uint8_t* der;
-        size_t der_len;
+        OPENSSL_buffer_auto der;
+        size_t der_len = 0;
         CBB cbb;
         CHECK_OPENSSL(CBB_init(&cbb, 0));
         // Prefer the standard PKCS8 marshal, which yields the compact seed format in non-FIPS and
         // experimental-FIPS builds. AWS-LC-FIPS 3.1.0 cannot marshal ML-KEM private keys (no
         // priv_encode) and lacks seed support, so on failure fall back to hand-rolled expanded-format
-        // PKCS8 after clearing the error queue. Mirrors encodeMlDsaPrivateKey above.
+        // PKCS8 after clearing the error queue. Preferring the library encoder also keeps every
+        // non-ML-KEM EVP_PKEY_KEM key off encodeExpandedMLKEMPrivateKey's length-based OID
+        // inference; see the equivalent note in encodePublicKey above. Mirrors
+        // encodeMlDsaPrivateKey above.
         // TODO [AWS-LC-FIPS 4.x]: drop the encodeExpandedMLKEMPrivateKey fallback once the FIPS module has priv_encode.
         if (EVP_marshal_private_key(&cbb, key)) {
             if (!CBB_finish(&cbb, &der, &der_len)) {
-                OPENSSL_free(der);
+                // CBB_finish does not write |der| on failure, and the CBB still owns its buffer.
+                CBB_cleanup(&cbb);
                 throw_java_ex(EX_RUNTIME_CRYPTO, "Error finalizing seed ML-KEM key");
             }
+            // A successful CBB_finish hands the buffer to |der| and cleans the CBB up itself.
         } else {
             ERR_clear_error();
+            // Clean the CBB up before calling a helper that throws on failure.
+            CBB_cleanup(&cbb);
             der_len = encodeExpandedMLKEMPrivateKey(key, &der);
         }
-        CBB_cleanup(&cbb);
 
         if (!(result = env->NewByteArray(der_len))) {
-            OPENSSL_free(der);
             throw_java_ex(EX_OOM, "Unable to allocate DER array");
         }
         // This may throw, if it does we'll just keep the exception state as we return.
-        env->SetByteArrayRegion(result, 0, der_len, (const jbyte*)der);
-        OPENSSL_free(der);
+        env->SetByteArrayRegion(result, 0, der_len, der);
     } catch (java_ex& ex) {
         ex.throw_to_java(pEnv);
     }

--- a/csrc/java_evp_keys.cpp
+++ b/csrc/java_evp_keys.cpp
@@ -699,30 +699,33 @@ JNIEXPORT jbyteArray JNICALL Java_com_amazon_corretto_crypto_provider_EvpMlDsaPr
         EVP_PKEY* key = reinterpret_cast<EVP_PKEY*>(keyHandle);
         CHECK_OPENSSL(EVP_PKEY_id(key) == EVP_PKEY_PQDSA);
 
-        uint8_t* der;
-        size_t der_len;
+        OPENSSL_buffer_auto der;
+        size_t der_len = 0;
         CBB cbb;
         CHECK_OPENSSL(CBB_init(&cbb, 0));
-        // Failure below may just indicate that we don't have the seed, so retry with |encodeExpandedMLDSAPrivateKey|
-        // and encode in PKCS8 (RFC 5208) format after clearing the error queue.
+        // Failure below may just indicate that we don't have the seed, so retry with
+        // |encodeExpandedMLDSAPrivateKey| and encode in PKCS8 (RFC 5208) format. Scope away the errors
+        // that expected failure queues; the guard has to be set before the call, since ERR_set_mark
+        // marks the newest error rather than deleting it.
+        ErrorQueueMark error_mark;
         if (EVP_marshal_private_key(&cbb, key)) {
             if (!CBB_finish(&cbb, &der, &der_len)) {
-                OPENSSL_free(der);
+                // CBB_finish does not write |der| on failure, and the CBB still owns its buffer.
+                CBB_cleanup(&cbb);
                 throw_java_ex(EX_RUNTIME_CRYPTO, "Error finalizing seed ML-DSA key");
             }
+            // A successful CBB_finish hands the buffer to |der| and cleans the CBB up itself.
         } else {
-            ERR_clear_error();
+            // Clean the CBB up before calling a helper that throws on failure.
+            CBB_cleanup(&cbb);
             der_len = encodeExpandedMLDSAPrivateKey(key, &der);
         }
-        CBB_cleanup(&cbb);
 
         if (!(result = env->NewByteArray(der_len))) {
-            OPENSSL_free(der);
             throw_java_ex(EX_OOM, "Unable to allocate DER array");
         }
         // This may throw, if it does we'll just keep the exception state as we return.
-        env->SetByteArrayRegion(result, 0, der_len, (const jbyte*)der);
-        OPENSSL_free(der);
+        env->SetByteArrayRegion(result, 0, der_len, der);
     } catch (java_ex& ex) {
         ex.throw_to_java(pEnv);
     }

--- a/csrc/java_evp_keys.cpp
+++ b/csrc/java_evp_keys.cpp
@@ -38,6 +38,12 @@ JNIEXPORT jbyteArray JNICALL Java_com_amazon_corretto_crypto_provider_EvpKey_enc
         EVP_PKEY* key = reinterpret_cast<EVP_PKEY*>(keyHandle);
         OPENSSL_buffer_auto der;
 
+        // Scope away the errors a failed i2d_PUBKEY queues: for ML-KEM in regular FIPS that failure is
+        // expected and handled below. The guard has to be set before the call, since ERR_set_mark marks
+        // the newest error rather than deleting it. CHECK_OPENSSL below still sees (and reports) the
+        // errors, because the guard does not unwind until this scope exits.
+        ErrorQueueMark error_mark;
+
         // This next line allocates memory. On failure i2d_PUBKEY leaves |der| untouched.
         int derLen = i2d_PUBKEY(key, &der);
         if (derLen <= 0 && EVP_PKEY_id(key) == EVP_PKEY_KEM) {
@@ -54,7 +60,6 @@ JNIEXPORT jbyteArray JNICALL Java_com_amazon_corretto_crypto_provider_EvpKey_enc
             // exist (ACCP only ever generates ML-KEM, and the FIPS module has no pub_decode/
             // priv_decode at all, so the only decoders are ACCP's, which reject non-ML-KEM OIDs).
             // TODO [AWS-LC-FIPS 4.x]: drop the encodeMLKEMPublicKey fallback once the FIPS module has i2d_PUBKEY.
-            ERR_clear_error();
             derLen = static_cast<int>(encodeMLKEMPublicKey(key, &der));
         }
         CHECK_OPENSSL(derLen > 0);
@@ -774,11 +779,14 @@ JNIEXPORT jbyteArray JNICALL Java_com_amazon_corretto_crypto_provider_EvpKemPriv
         // Prefer the standard PKCS8 marshal, which yields the compact seed format in non-FIPS and
         // experimental-FIPS builds. AWS-LC-FIPS 3.1.0 cannot marshal ML-KEM private keys (no
         // priv_encode) and lacks seed support, so on failure fall back to hand-rolled expanded-format
-        // PKCS8 after clearing the error queue. Preferring the library encoder also keeps every
-        // non-ML-KEM EVP_PKEY_KEM key off encodeExpandedMLKEMPrivateKey's length-based OID
-        // inference; see the equivalent note in encodePublicKey above. Mirrors
-        // encodeMlDsaPrivateKey above.
+        // PKCS8. Preferring the library encoder also keeps every non-ML-KEM EVP_PKEY_KEM key off
+        // encodeExpandedMLKEMPrivateKey's length-based OID inference; see the equivalent note in
+        // encodePublicKey above. Mirrors encodeMlDsaPrivateKey above.
         // TODO [AWS-LC-FIPS 4.x]: drop the encodeExpandedMLKEMPrivateKey fallback once the FIPS module has priv_encode.
+        //
+        // Scope away the errors the expected marshal failure queues; the guard has to be set before the
+        // call, since ERR_set_mark marks the newest error rather than deleting it.
+        ErrorQueueMark error_mark;
         if (EVP_marshal_private_key(&cbb, key)) {
             if (!CBB_finish(&cbb, &der, &der_len)) {
                 // CBB_finish does not write |der| on failure, and the CBB still owns its buffer.
@@ -787,7 +795,6 @@ JNIEXPORT jbyteArray JNICALL Java_com_amazon_corretto_crypto_provider_EvpKemPriv
             }
             // A successful CBB_finish hands the buffer to |der| and cleans the CBB up itself.
         } else {
-            ERR_clear_error();
             // Clean the CBB up before calling a helper that throws on failure.
             CBB_cleanup(&cbb);
             der_len = encodeExpandedMLKEMPrivateKey(key, &der);

--- a/csrc/keyutils.cpp
+++ b/csrc/keyutils.cpp
@@ -13,9 +13,10 @@
 
 namespace AmazonCorrettoCryptoProvider {
 
-// Parses an ML-KEM expanded-format PKCS8 private key via its raw secret key. Returns nullptr
-// (without setting an error) when |der| is not an expanded-format ML-KEM PKCS8. der2EvpPrivateKey
-// calls this as a fallover after d2i_PrivateKey fails. Defined below, next to parseMLKEMPublicKey.
+// Parses an ML-KEM expanded-format PKCS8 private key via its raw secret key. Returns nullptr for
+// inputs it does not handle; EVP_PKEY_kem_new_raw_secret_key may queue an OpenSSL error when it
+// rejects a well-formed but wrong-length key. der2EvpPrivateKey calls this as a fallover after
+// d2i_PrivateKey fails. Defined below, next to parseMLKEMPublicKey.
 static EVP_PKEY* parseMLKEMPrivateKey(const unsigned char* der, const int derLen);
 
 EVP_PKEY* der2EvpPrivateKey(const unsigned char* der,
@@ -26,6 +27,11 @@ EVP_PKEY* der2EvpPrivateKey(const unsigned char* der,
 {
     const unsigned char* der_mutable_ptr = der; // openssl modifies the input pointer
 
+    // Scope away the errors a failed d2i_PrivateKey queues. Its failure is expected for ML-KEM in
+    // regular FIPS (see the fallover below), and when nothing can parse |der| the errors are still
+    // in the queue for throw_openssl to report before this guard unwinds.
+    ErrorQueueMark error_mark;
+
     // Try the standard decoder first so non-ML-KEM keys (and, in non-FIPS builds, ML-KEM keys) incur
     // no ML-KEM parsing overhead.
     EVP_PKEY* result = d2i_PrivateKey(evpType, NULL, &der_mutable_ptr, derLen);
@@ -35,10 +41,9 @@ EVP_PKEY* der2EvpPrivateKey(const unsigned char* der,
     // we hand-roll the parse via the raw secret key. This matches the non-FIPS d2i expanded-decode
     // path exactly: both reconstruct the key by setting only the raw secret key
     // (KEM_KEY_set_raw_secret_key), leaving the public key unpopulated. parseMLKEMPrivateKey returns
-    // nullptr for inputs it cannot handle. Clear the error queue the failed d2i_PrivateKey left behind.
+    // nullptr for inputs it cannot handle.
     // TODO [AWS-LC-FIPS 4.x]: drop this raw-key decode path once the FIPS module supports d2i_PrivateKey for ML-KEM.
     if (result == nullptr && evpType == EVP_PKEY_KEM) {
-        ERR_clear_error();
         EVP_PKEY* mlkem = parseMLKEMPrivateKey(der, derLen);
         if (mlkem != nullptr) {
             if (shouldCheckPrivate && !checkKey(mlkem)) {
@@ -137,6 +142,9 @@ EVP_PKEY* der2EvpPrivateKey(const unsigned char* der,
 // i2d_PUBKEY produces in non-FIPS builds.
 // TODO [AWS-LC-FIPS 4.x]: drop this hand-rolled SPKI path once the FIPS module implements i2d/d2i_PUBKEY for ML-KEM.
 
+// True when |nid| identifies one of the three ML-KEM parameter sets.
+static bool isMLKEMNid(int nid) { return nid == NID_MLKEM512 || nid == NID_MLKEM768 || nid == NID_MLKEM1024; }
+
 // Maps an ML-KEM raw public-key length (FIPS 203, Table 3) to its NID, or NID_undef.
 //
 // NOTE: this mapping is only unambiguous for ML-KEM keys. AWS-LC registers legacy Kyber-R3 under the
@@ -190,20 +198,24 @@ size_t encodeMLKEMPublicKey(const EVP_PKEY* key, uint8_t** out)
         !CBB_add_asn1(&spki, &pub, CBS_ASN1_BITSTRING) ||
         !CBB_add_u8(&pub, 0) /* unused bits */ ||
         !CBB_add_bytes(&pub, raw_pub, raw_len)) {
+        CBB_cleanup(&cbb);
         throw_java_ex(EX_RUNTIME_CRYPTO, "Error serializing ML-KEM public key");
     }
     // spotless:on
     size_t out_len;
+    // A failed CBB_finish leaves the CBB owning its buffer and does not write |*out|, so clean the CBB
+    // up and leave |*out| alone. A successful CBB_finish transfers the buffer to |*out| and cleans up.
     if (!CBB_finish(&cbb, out, &out_len)) {
-        OPENSSL_free(*out);
+        CBB_cleanup(&cbb);
         throw_java_ex(EX_RUNTIME_CRYPTO, "Error finalizing ML-KEM public key");
     }
     return out_len;
 }
 
 // Parses an ML-KEM X.509 SubjectPublicKeyInfo into an EVP_PKEY via its raw public key. Returns
-// nullptr (without setting an error) when |der| is not an ML-KEM SPKI. der2EvpPublicKey calls this
-// as a fallover after d2i_PUBKEY fails.
+// nullptr when |der| is not an ML-KEM SPKI, or when the raw public key is the wrong length for the
+// OID's parameter set (in which case EVP_PKEY_kem_new_raw_public_key queues an error).
+// der2EvpPublicKey calls this as a fallover after d2i_PUBKEY fails.
 static EVP_PKEY* parseMLKEMPublicKey(const unsigned char* der, const int derLen)
 {
     CBS cbs, spki, algorithm, oid, bit_string;
@@ -216,7 +228,7 @@ static EVP_PKEY* parseMLKEMPublicKey(const unsigned char* der, const int derLen)
     }
     // spotless:on
     int nid = OBJ_cbs2nid(&oid);
-    if (nid != NID_MLKEM512 && nid != NID_MLKEM768 && nid != NID_MLKEM1024) {
+    if (!isMLKEMNid(nid)) {
         return nullptr;
     }
     // The ML-KEM AlgorithmIdentifier has no parameters; the subjectPublicKey BIT STRING follows.
@@ -275,7 +287,7 @@ static EVP_PKEY* parseMLKEMPrivateKey(const unsigned char* der, const int derLen
     }
     // spotless:on
     int nid = OBJ_cbs2nid(&oid);
-    if (nid != NID_MLKEM512 && nid != NID_MLKEM768 && nid != NID_MLKEM1024) {
+    if (!isMLKEMNid(nid)) {
         return nullptr;
     }
     // The ML-KEM AlgorithmIdentifier has no parameters. The PrivateKey OCTET STRING wraps the
@@ -315,6 +327,11 @@ static EVP_PKEY* parseMLKEMPrivateKey(const unsigned char* der, const int derLen
 
 EVP_PKEY* der2EvpPublicKey(const unsigned char* der, const int derLen, const char* javaExceptionClass)
 {
+    // Scope away the errors a failed d2i_PUBKEY queues. Its failure is expected for ML-KEM in regular
+    // FIPS (see the fallover below), and when nothing can parse |der| the errors are still in the queue
+    // for throw_openssl to report before this guard unwinds.
+    ErrorQueueMark error_mark;
+
     // Try the standard decoder first so non-ML-KEM keys (and, in non-FIPS builds, ML-KEM keys) incur
     // no ML-KEM parsing overhead.
     const unsigned char* der_mutable_ptr = der; // openssl modifies the input pointer
@@ -334,9 +351,8 @@ EVP_PKEY* der2EvpPublicKey(const unsigned char* der, const int derLen, const cha
     // d2i_PUBKEY could not parse |der|. In regular FIPS, AWS-LC-FIPS 3.1.0 has no pub_decode for
     // ML-KEM, so d2i_PUBKEY raises UNSUPPORTED_ALGORITHM on ML-KEM SPKI; fall over to the hand-rolled
     // parser. parseMLKEMPublicKey returns nullptr for non-ML-KEM inputs, so a genuinely unparseable
-    // key still throws below. Clear the error queue d2i_PUBKEY left behind so the fallover starts clean.
+    // key still throws below.
     // TODO [AWS-LC-FIPS 4.x]: drop this ML-KEM SPKI fallover once the FIPS module supports d2i_PUBKEY for ML-KEM.
-    ERR_clear_error();
     EVP_PKEY* mlkem = parseMLKEMPublicKey(der, derLen);
     if (mlkem == nullptr) {
         throw_openssl(javaExceptionClass, "Unable to parse key");

--- a/csrc/keyutils.cpp
+++ b/csrc/keyutils.cpp
@@ -13,6 +13,11 @@
 
 namespace AmazonCorrettoCryptoProvider {
 
+// Parses an ML-KEM expanded-format PKCS8 private key via its raw secret key. Returns nullptr
+// (without setting an error) when |der| is not an expanded-format ML-KEM PKCS8. der2EvpPrivateKey
+// calls this as a fallover after d2i_PrivateKey fails. Defined below, next to parseMLKEMPublicKey.
+static EVP_PKEY* parseMLKEMPrivateKey(const unsigned char* der, const int derLen);
+
 EVP_PKEY* der2EvpPrivateKey(const unsigned char* der,
     const int derLen,
     const int evpType,
@@ -21,7 +26,28 @@ EVP_PKEY* der2EvpPrivateKey(const unsigned char* der,
 {
     const unsigned char* der_mutable_ptr = der; // openssl modifies the input pointer
 
+    // Try the standard decoder first so non-ML-KEM keys (and, in non-FIPS builds, ML-KEM keys) incur
+    // no ML-KEM parsing overhead.
     EVP_PKEY* result = d2i_PrivateKey(evpType, NULL, &der_mutable_ptr, derLen);
+
+    // Regular-FIPS fallover: AWS-LC-FIPS 3.1.0 has no priv_decode for ML-KEM, so d2i_PrivateKey fails
+    // on ML-KEM PKCS8. Only when the caller asked for a KEM key and d2i_PrivateKey produced nothing do
+    // we hand-roll the parse via the raw secret key. This matches the non-FIPS d2i expanded-decode
+    // path exactly: both reconstruct the key by setting only the raw secret key
+    // (KEM_KEY_set_raw_secret_key), leaving the public key unpopulated. parseMLKEMPrivateKey returns
+    // nullptr for inputs it cannot handle. Clear the error queue the failed d2i_PrivateKey left behind.
+    // TODO [AWS-LC-FIPS 4.x]: drop this raw-key decode path once the FIPS module supports d2i_PrivateKey for ML-KEM.
+    if (result == nullptr && evpType == EVP_PKEY_KEM) {
+        ERR_clear_error();
+        EVP_PKEY* mlkem = parseMLKEMPrivateKey(der, derLen);
+        if (mlkem != nullptr) {
+            if (shouldCheckPrivate && !checkKey(mlkem)) {
+                EVP_PKEY_free(mlkem);
+                throw_openssl(javaExceptionClass, "Key fails check");
+            }
+            return mlkem;
+        }
+    }
 
     if (!result) {
         throw_openssl(javaExceptionClass, "Unable to convert PKCS8_PRIV_KEY_INFO to EVP_PKEY");
@@ -98,27 +124,173 @@ EVP_PKEY* der2EvpPrivateKey(const unsigned char* der,
     return result;
 }
 
+// ML-KEM public-key SubjectPublicKeyInfo (SPKI) encode/decode.
+//
+// AWS-LC-FIPS 3.1.0 does not implement i2d_PUBKEY / d2i_PUBKEY for ML-KEM (the ML-KEM
+// EVP_PKEY_ASN1_METHOD has no pub_encode/pub_decode in the FIPS module), so those calls raise
+// UNSUPPORTED_ALGORITHM. We hand-roll the X.509 SubjectPublicKeyInfo from the raw public key so
+// ML-KEM key serialization works in regular FIPS. The SubjectPublicKeyInfo format is specified in
+// RFC 9935 Section 4 (Subject Public Key Fields), with the formal ASN.1 module in Appendix A:
+// https://datatracker.ietf.org/doc/html/rfc9935#section-4
+// https://datatracker.ietf.org/doc/html/rfc9935#appendix-A
+// ML-KEM SPKI is fully determined by (OID, rawPublicKey), so this is byte-identical to what
+// i2d_PUBKEY produces in non-FIPS builds.
+// TODO [AWS-LC-FIPS 4.x]: drop this hand-rolled SPKI path once the FIPS module implements i2d/d2i_PUBKEY for ML-KEM.
+
+// Maps an ML-KEM raw public-key length (FIPS 203, Table 3) to its NID, or NID_undef.
+static int mlkemNidForPublicKeyLen(size_t raw_len)
+{
+    switch (raw_len) {
+    case 800:
+        return NID_MLKEM512;
+    case 1184:
+        return NID_MLKEM768;
+    case 1568:
+        return NID_MLKEM1024;
+    default:
+        return NID_undef;
+    }
+}
+
+size_t encodeMLKEMPublicKey(const EVP_PKEY* key, uint8_t** out)
+{
+    CHECK_OPENSSL(key);
+    CHECK_OPENSSL(EVP_PKEY_id(key) == EVP_PKEY_KEM);
+    CHECK_OPENSSL(out);
+    size_t raw_len = 0;
+    CHECK_OPENSSL(EVP_PKEY_get_raw_public_key(key, nullptr, &raw_len));
+    int nid = mlkemNidForPublicKeyLen(raw_len);
+    if (nid == NID_undef) {
+        throw_java_ex(EX_ILLEGAL_ARGUMENT, "Invalid ML-KEM public key size");
+    }
+    OPENSSL_buffer_auto raw_pub(raw_len);
+    CHECK_OPENSSL(EVP_PKEY_get_raw_public_key(key, raw_pub, &raw_len));
+    // SubjectPublicKeyInfo ::= SEQUENCE { algorithm SEQUENCE { OID }, subjectPublicKey BIT STRING }.
+    // The ML-KEM AlgorithmIdentifier carries no parameters; the BIT STRING is the raw public key.
+    // See RFC 9935 Section 4 (Subject Public Key Fields):
+    // https://datatracker.ietf.org/doc/html/rfc9935#section-4
+    CBB cbb, spki, algorithm, pub;
+    CBB_init(&cbb, 0);
+    // spotless:off
+    if (!CBB_add_asn1(&cbb, &spki, CBS_ASN1_SEQUENCE) ||
+        !CBB_add_asn1(&spki, &algorithm, CBS_ASN1_SEQUENCE) ||
+        !OBJ_nid2cbb(&algorithm, nid) ||
+        !CBB_add_asn1(&spki, &pub, CBS_ASN1_BITSTRING) ||
+        !CBB_add_u8(&pub, 0) /* unused bits */ ||
+        !CBB_add_bytes(&pub, raw_pub, raw_len)) {
+        throw_java_ex(EX_RUNTIME_CRYPTO, "Error serializing ML-KEM public key");
+    }
+    // spotless:on
+    size_t out_len;
+    if (!CBB_finish(&cbb, out, &out_len)) {
+        OPENSSL_free(*out);
+        throw_java_ex(EX_RUNTIME_CRYPTO, "Error finalizing ML-KEM public key");
+    }
+    return out_len;
+}
+
+// Parses an ML-KEM X.509 SubjectPublicKeyInfo into an EVP_PKEY via its raw public key. Returns
+// nullptr (without setting an error) when |der| is not an ML-KEM SPKI. der2EvpPublicKey calls this
+// as a fallover after d2i_PUBKEY fails.
+static EVP_PKEY* parseMLKEMPublicKey(const unsigned char* der, const int derLen)
+{
+    CBS cbs, spki, algorithm, oid, bit_string;
+    CBS_init(&cbs, der, derLen);
+    // spotless:off
+    if (!CBS_get_asn1(&cbs, &spki, CBS_ASN1_SEQUENCE) || CBS_len(&cbs) != 0 ||
+        !CBS_get_asn1(&spki, &algorithm, CBS_ASN1_SEQUENCE) ||
+        !CBS_get_asn1(&algorithm, &oid, CBS_ASN1_OBJECT)) {
+        return nullptr;
+    }
+    // spotless:on
+    int nid = OBJ_cbs2nid(&oid);
+    if (nid != NID_MLKEM512 && nid != NID_MLKEM768 && nid != NID_MLKEM1024) {
+        return nullptr;
+    }
+    // The ML-KEM AlgorithmIdentifier has no parameters; the subjectPublicKey BIT STRING follows.
+    uint8_t unused_bits = 0;
+    // spotless:off
+    if (CBS_len(&algorithm) != 0 ||
+        !CBS_get_asn1(&spki, &bit_string, CBS_ASN1_BITSTRING) || CBS_len(&spki) != 0 ||
+        !CBS_get_u8(&bit_string, &unused_bits) || unused_bits != 0) {
+        return nullptr;
+    }
+    // spotless:on
+    return EVP_PKEY_kem_new_raw_public_key(nid, CBS_data(&bit_string), CBS_len(&bit_string));
+}
+
+// See forward declaration above der2EvpPrivateKey. Parses an expanded-format ML-KEM PKCS8 private
+// key via EVP_PKEY_kem_new_raw_secret_key. The expandedKey CHOICE is specified in RFC 9935
+// Section 6 (Private Key Format), with the formal ASN.1 module in Appendix A:
+// https://datatracker.ietf.org/doc/html/rfc9935#section-6
+// https://datatracker.ietf.org/doc/html/rfc9935#appendix-A
+// Returns nullptr for seed-format or non-ML-KEM inputs; der2EvpPrivateKey calls this as a fallover
+// after d2i_PrivateKey fails.
+static EVP_PKEY* parseMLKEMPrivateKey(const unsigned char* der, const int derLen)
+{
+    CBS cbs, pkcs8, algorithm, oid, priv, expanded;
+    uint64_t version = 0;
+    CBS_init(&cbs, der, derLen);
+    // spotless:off
+    if (!CBS_get_asn1(&cbs, &pkcs8, CBS_ASN1_SEQUENCE) || CBS_len(&cbs) != 0 ||
+        !CBS_get_asn1_uint64(&pkcs8, &version) || version != 0 ||
+        !CBS_get_asn1(&pkcs8, &algorithm, CBS_ASN1_SEQUENCE) ||
+        !CBS_get_asn1(&algorithm, &oid, CBS_ASN1_OBJECT)) {
+        return nullptr;
+    }
+    // spotless:on
+    int nid = OBJ_cbs2nid(&oid);
+    if (nid != NID_MLKEM512 && nid != NID_MLKEM768 && nid != NID_MLKEM1024) {
+        return nullptr;
+    }
+    // The ML-KEM AlgorithmIdentifier has no parameters. The PrivateKey OCTET STRING wraps the
+    // expanded-key OCTET STRING. Seed-format keys instead wrap a context-specific [0] tag, which
+    // fails the inner OCTET STRING parse below, so this returns nullptr for them.
+    // spotless:off
+    if (CBS_len(&algorithm) != 0 ||
+        !CBS_get_asn1(&pkcs8, &priv, CBS_ASN1_OCTETSTRING) || CBS_len(&pkcs8) != 0 ||
+        !CBS_get_asn1(&priv, &expanded, CBS_ASN1_OCTETSTRING) || CBS_len(&priv) != 0) {
+        return nullptr;
+    }
+    // spotless:on
+    // EVP_PKEY_kem_new_raw_secret_key validates that the length matches the parameter set's
+    // secret_key_len and returns NULL otherwise (surfaced by der2EvpPrivateKey as a decode failure).
+    return EVP_PKEY_kem_new_raw_secret_key(nid, CBS_data(&expanded), CBS_len(&expanded));
+}
+
 EVP_PKEY* der2EvpPublicKey(const unsigned char* der, const int derLen, const char* javaExceptionClass)
 {
+    // Try the standard decoder first so non-ML-KEM keys (and, in non-FIPS builds, ML-KEM keys) incur
+    // no ML-KEM parsing overhead.
     const unsigned char* der_mutable_ptr = der; // openssl modifies the input pointer
-
     EVP_PKEY* result = d2i_PUBKEY(NULL, &der_mutable_ptr, derLen);
-    if (!result) {
+    if (result != nullptr) {
+        if (der + derLen != der_mutable_ptr) {
+            EVP_PKEY_free(result);
+            throw_openssl(javaExceptionClass, "Extra key information");
+        }
+        if (!checkKey(result)) {
+            EVP_PKEY_free(result);
+            throw_openssl(javaExceptionClass, "Key fails check");
+        }
+        return result;
+    }
+
+    // d2i_PUBKEY could not parse |der|. In regular FIPS, AWS-LC-FIPS 3.1.0 has no pub_decode for
+    // ML-KEM, so d2i_PUBKEY raises UNSUPPORTED_ALGORITHM on ML-KEM SPKI; fall over to the hand-rolled
+    // parser. parseMLKEMPublicKey returns nullptr for non-ML-KEM inputs, so a genuinely unparseable
+    // key still throws below. Clear the error queue d2i_PUBKEY left behind so the fallover starts clean.
+    // TODO [AWS-LC-FIPS 4.x]: drop this ML-KEM SPKI fallover once the FIPS module supports d2i_PUBKEY for ML-KEM.
+    ERR_clear_error();
+    EVP_PKEY* mlkem = parseMLKEMPublicKey(der, derLen);
+    if (mlkem == nullptr) {
         throw_openssl(javaExceptionClass, "Unable to parse key");
     }
-
-    // Only meaningful once a key came back: d2i_PUBKEY leaves |der_mutable_ptr| untouched when it
-    // fails, so checking it first reported every decode failure as "Extra key information".
-    if (der + derLen != der_mutable_ptr) {
-        EVP_PKEY_free(result);
-        throw_openssl(javaExceptionClass, "Extra key information");
-    }
-
-    if (!checkKey(result)) {
-        EVP_PKEY_free(result);
+    if (!checkKey(mlkem)) {
+        EVP_PKEY_free(mlkem);
         throw_openssl(javaExceptionClass, "Key fails check");
     }
-    return result;
+    return mlkem;
 }
 
 bool checkKey(const EVP_PKEY* key)
@@ -238,7 +410,13 @@ size_t encodeExpandedMLDSAPrivateKey(const EVP_PKEY* key, uint8_t** out)
     }
     return out_len;
 }
+#endif // !defined(FIPS_BUILD) || defined(EXPERIMENTAL_FIPS_BUILD)
 
+// ML-KEM expanded-format private-key PKCS8 encode. Unguarded (unlike the ML-DSA variant above):
+// regular FIPS relies on this because AWS-LC-FIPS 3.1.0 cannot marshal ML-KEM private keys (the
+// ML-KEM EVP_PKEY_ASN1_METHOD has no priv_encode in the FIPS module) and lacks seed support. The
+// raw-key APIs it uses (EVP_PKEY_get_raw_private_key, OBJ_nid2cbb) are available in the FIPS module.
+// TODO [AWS-LC-FIPS 4.x]: drop this hand-rolled encode once the FIPS module supports priv_encode for ML-KEM.
 size_t encodeExpandedMLKEMPrivateKey(const EVP_PKEY* key, uint8_t** out)
 {
     CHECK_OPENSSL(key);
@@ -267,8 +445,10 @@ size_t encodeExpandedMLKEMPrivateKey(const EVP_PKEY* key, uint8_t** out)
     CHECK_OPENSSL(EVP_PKEY_get_raw_private_key(key, raw_expanded, &raw_len));
     CBB cbb, pkcs8, algorithm, priv, expanded;
     CHECK_OPENSSL(CBB_init(&cbb, 0));
-    // Encoding below is based on expandedKey CHOICE member of PrivateKey ASN.1 structures in:
-    // https://datatracker.ietf.org/doc/rfc9935/ section 6
+    // Encoding below is based on the expandedKey CHOICE member of the PrivateKey structure in
+    // RFC 9935 Section 6 (Private Key Format), with the formal ASN.1 module in Appendix A:
+    // https://datatracker.ietf.org/doc/html/rfc9935#section-6
+    // https://datatracker.ietf.org/doc/html/rfc9935#appendix-A
     // spotless:off
     if (!CBB_add_asn1(&cbb, &pkcs8, CBS_ASN1_SEQUENCE) ||
         !CBB_add_asn1_uint64(&pkcs8, 0) ||
@@ -290,7 +470,6 @@ size_t encodeExpandedMLKEMPrivateKey(const EVP_PKEY* key, uint8_t** out)
     }
     return out_len;
 }
-#endif // !defined(FIPS_BUILD) || defined(EXPERIMENTAL_FIPS_BUILD)
 
 size_t encodeRfc5915EcPrivateKey(const EVP_PKEY* key, uint8_t** out)
 {

--- a/csrc/keyutils.cpp
+++ b/csrc/keyutils.cpp
@@ -23,15 +23,15 @@ EVP_PKEY* der2EvpPrivateKey(const unsigned char* der,
 
     EVP_PKEY* result = d2i_PrivateKey(evpType, NULL, &der_mutable_ptr, derLen);
 
-    if (der + derLen != der_mutable_ptr) {
-        if (result) {
-            EVP_PKEY_free(result);
-        }
-        throw_openssl(javaExceptionClass, "Extra key information");
-    }
-
     if (!result) {
         throw_openssl(javaExceptionClass, "Unable to convert PKCS8_PRIV_KEY_INFO to EVP_PKEY");
+    }
+
+    // Only meaningful once a key came back: d2i_PrivateKey leaves |der_mutable_ptr| untouched when it
+    // fails, so checking it first reported every decode failure as "Extra key information".
+    if (der + derLen != der_mutable_ptr) {
+        EVP_PKEY_free(result);
+        throw_openssl(javaExceptionClass, "Extra key information");
     }
 
     if (isRsaKeyType(EVP_PKEY_base_id(result))) {
@@ -103,14 +103,15 @@ EVP_PKEY* der2EvpPublicKey(const unsigned char* der, const int derLen, const cha
     const unsigned char* der_mutable_ptr = der; // openssl modifies the input pointer
 
     EVP_PKEY* result = d2i_PUBKEY(NULL, &der_mutable_ptr, derLen);
-    if (der + derLen != der_mutable_ptr) {
-        if (result) {
-            EVP_PKEY_free(result);
-        }
-        throw_openssl(javaExceptionClass, "Extra key information");
-    }
     if (!result) {
         throw_openssl(javaExceptionClass, "Unable to parse key");
+    }
+
+    // Only meaningful once a key came back: d2i_PUBKEY leaves |der_mutable_ptr| untouched when it
+    // fails, so checking it first reported every decode failure as "Extra key information".
+    if (der + derLen != der_mutable_ptr) {
+        EVP_PKEY_free(result);
+        throw_openssl(javaExceptionClass, "Extra key information");
     }
 
     if (!checkKey(result)) {
@@ -209,9 +210,11 @@ size_t encodeExpandedMLDSAPrivateKey(const EVP_PKEY* key, uint8_t** out)
         throw_java_ex(EX_ILLEGAL_ARGUMENT, "Invalid ML-DSA signature size");
     }
     OPENSSL_buffer_auto raw_expanded(raw_len);
+    // OPENSSL_buffer_auto does not check its own allocation, and the next call memcpy's into it.
+    CHECK_OPENSSL(raw_expanded.buf != nullptr);
     CHECK_OPENSSL(EVP_PKEY_get_raw_private_key(key, raw_expanded, &raw_len));
     CBB cbb, pkcs8, algorithm, priv, expanded;
-    CBB_init(&cbb, 0);
+    CHECK_OPENSSL(CBB_init(&cbb, 0));
     // Encoding below is based on expandedKey CHOICE member of PrivateKey ASN.1 structures in:
     // https://github.com/lamps-wg/dilithium-certificates/blob/main/X509-ML-DSA-2025.asn
     // spotless:off
@@ -222,12 +225,15 @@ size_t encodeExpandedMLDSAPrivateKey(const EVP_PKEY* key, uint8_t** out)
         !CBB_add_asn1(&pkcs8, &priv, CBS_ASN1_OCTETSTRING) ||
         !CBB_add_asn1(&priv, &expanded, CBS_ASN1_OCTETSTRING) ||
         !CBB_add_bytes(&expanded, raw_expanded, raw_len)) {
+        CBB_cleanup(&cbb);
         throw_java_ex(EX_RUNTIME_CRYPTO, "Error serializing expanded ML-DSA key");
     }
     // spotless:on
     size_t out_len;
+    // A failed CBB_finish leaves the CBB owning its buffer and does not write |*out|, so clean the CBB
+    // up and leave |*out| alone. A successful CBB_finish transfers the buffer to |*out| and cleans up.
     if (!CBB_finish(&cbb, out, &out_len)) {
-        OPENSSL_free(*out);
+        CBB_cleanup(&cbb);
         throw_java_ex(EX_RUNTIME_CRYPTO, "Error finalizing expanded ML-DSA key");
     }
     return out_len;
@@ -256,9 +262,11 @@ size_t encodeExpandedMLKEMPrivateKey(const EVP_PKEY* key, uint8_t** out)
         throw_java_ex(EX_ILLEGAL_ARGUMENT, "Invalid ML-KEM secret key size");
     }
     OPENSSL_buffer_auto raw_expanded(raw_len);
+    // OPENSSL_buffer_auto does not check its own allocation, and the next call memcpy's into it.
+    CHECK_OPENSSL(raw_expanded.buf != nullptr);
     CHECK_OPENSSL(EVP_PKEY_get_raw_private_key(key, raw_expanded, &raw_len));
     CBB cbb, pkcs8, algorithm, priv, expanded;
-    CBB_init(&cbb, 0);
+    CHECK_OPENSSL(CBB_init(&cbb, 0));
     // Encoding below is based on expandedKey CHOICE member of PrivateKey ASN.1 structures in:
     // https://datatracker.ietf.org/doc/rfc9935/ section 6
     // spotless:off
@@ -269,12 +277,15 @@ size_t encodeExpandedMLKEMPrivateKey(const EVP_PKEY* key, uint8_t** out)
         !CBB_add_asn1(&pkcs8, &priv, CBS_ASN1_OCTETSTRING) ||
         !CBB_add_asn1(&priv, &expanded, CBS_ASN1_OCTETSTRING) ||
         !CBB_add_bytes(&expanded, raw_expanded, raw_len)) {
+        CBB_cleanup(&cbb);
         throw_java_ex(EX_RUNTIME_CRYPTO, "Error serializing expanded ML-KEM key");
     }
     // spotless:on
     size_t out_len;
+    // A failed CBB_finish leaves the CBB owning its buffer and does not write |*out|, so clean the CBB
+    // up and leave |*out| alone. A successful CBB_finish transfers the buffer to |*out| and cleans up.
     if (!CBB_finish(&cbb, out, &out_len)) {
-        OPENSSL_free(*out);
+        CBB_cleanup(&cbb);
         throw_java_ex(EX_RUNTIME_CRYPTO, "Error finalizing expanded ML-KEM key");
     }
     return out_len;
@@ -301,7 +312,7 @@ size_t encodeRfc5915EcPrivateKey(const EVP_PKEY* key, uint8_t** out)
     int oid_data_len = OBJ_length(oid_obj);
     const EC_KEY* ec_key = EVP_PKEY_get0_EC_KEY(key);
     CBB cbb, pkcs8, algorithm, oid, priv;
-    CBB_init(&cbb, 0);
+    CHECK_OPENSSL(CBB_init(&cbb, 0));
     // spotless:off
     if (!CBB_add_asn1(&cbb, &pkcs8, CBS_ASN1_SEQUENCE) ||
         !CBB_add_asn1_uint64(&pkcs8, 0 /* version */) ||
@@ -319,9 +330,10 @@ size_t encodeRfc5915EcPrivateKey(const EVP_PKEY* key, uint8_t** out)
     }
     // spotless:on
     size_t out_len;
+    // A failed CBB_finish leaves the CBB owning its buffer and does not write |*out|, so clean the CBB
+    // up and leave |*out| alone. A successful CBB_finish transfers the buffer to |*out| and cleans up.
     if (!CBB_finish(&cbb, out, &out_len)) {
         CBB_cleanup(&cbb);
-        OPENSSL_free(*out);
         throw_java_ex(EX_RUNTIME_CRYPTO, "Error finalizing expanded EC key");
     }
     return out_len;

--- a/csrc/keyutils.cpp
+++ b/csrc/keyutils.cpp
@@ -174,13 +174,15 @@ size_t encodeMLKEMPublicKey(const EVP_PKEY* key, uint8_t** out)
         throw_java_ex(EX_ILLEGAL_ARGUMENT, "Invalid ML-KEM public key size");
     }
     OPENSSL_buffer_auto raw_pub(raw_len);
+    // OPENSSL_buffer_auto does not check its own allocation, and the next call memcpy's into it.
+    CHECK_OPENSSL(raw_pub.buf != nullptr);
     CHECK_OPENSSL(EVP_PKEY_get_raw_public_key(key, raw_pub, &raw_len));
     // SubjectPublicKeyInfo ::= SEQUENCE { algorithm SEQUENCE { OID }, subjectPublicKey BIT STRING }.
     // The ML-KEM AlgorithmIdentifier carries no parameters; the BIT STRING is the raw public key.
     // See RFC 9935 Section 4 (Subject Public Key Fields):
     // https://datatracker.ietf.org/doc/html/rfc9935#section-4
     CBB cbb, spki, algorithm, pub;
-    CBB_init(&cbb, 0);
+    CHECK_OPENSSL(CBB_init(&cbb, 0));
     // spotless:off
     if (!CBB_add_asn1(&cbb, &spki, CBS_ASN1_SEQUENCE) ||
         !CBB_add_asn1(&spki, &algorithm, CBS_ASN1_SEQUENCE) ||
@@ -229,6 +231,24 @@ static EVP_PKEY* parseMLKEMPublicKey(const unsigned char* der, const int derLen)
     return EVP_PKEY_kem_new_raw_public_key(nid, CBS_data(&bit_string), CBS_len(&bit_string));
 }
 
+// Skips an optional context-specific field numbered |tag_number| from |cbs|, accepting both the
+// constructed and the primitive encoding of the tag. Returns false only when a matching tag is
+// present but its element is malformed; a missing field is not an error.
+static bool skipOptionalContextSpecificField(CBS* cbs, unsigned tag_number)
+{
+    const unsigned constructed = CBS_ASN1_CONTEXT_SPECIFIC | CBS_ASN1_CONSTRUCTED | tag_number;
+    if (CBS_peek_asn1_tag(cbs, constructed)) {
+        return CBS_get_asn1(cbs, nullptr, constructed) == 1;
+    }
+    // AWS-LC's EVP_parse_private_key looks for the primitive form of these tags, so accept it too
+    // rather than rejecting keys the non-FIPS d2i_PrivateKey path would have accepted.
+    const unsigned primitive = CBS_ASN1_CONTEXT_SPECIFIC | tag_number;
+    if (CBS_peek_asn1_tag(cbs, primitive)) {
+        return CBS_get_asn1(cbs, nullptr, primitive) == 1;
+    }
+    return true;
+}
+
 // See forward declaration above der2EvpPrivateKey. Parses an expanded-format ML-KEM PKCS8 private
 // key via EVP_PKEY_kem_new_raw_secret_key. The expandedKey CHOICE is specified in RFC 9935
 // Section 6 (Private Key Format), with the formal ASN.1 module in Appendix A:
@@ -241,9 +261,14 @@ static EVP_PKEY* parseMLKEMPrivateKey(const unsigned char* der, const int derLen
     CBS cbs, pkcs8, algorithm, oid, priv, expanded;
     uint64_t version = 0;
     CBS_init(&cbs, der, derLen);
+    // The outer structure is a PrivateKeyInfo (RFC 5208, version 0) or a OneAsymmetricKey (RFC 5958,
+    // version 1). Accept both versions, matching EVP_parse_private_key, so this regular-FIPS fallover
+    // parses everything the non-FIPS d2i_PrivateKey path parses. Rejecting version 1 here would make
+    // ACCP refuse OneAsymmetricKey encodings that other providers (and ACCP's own non-FIPS builds)
+    // emit and accept.
     // spotless:off
     if (!CBS_get_asn1(&cbs, &pkcs8, CBS_ASN1_SEQUENCE) || CBS_len(&cbs) != 0 ||
-        !CBS_get_asn1_uint64(&pkcs8, &version) || version != 0 ||
+        !CBS_get_asn1_uint64(&pkcs8, &version) || version > 1 ||
         !CBS_get_asn1(&pkcs8, &algorithm, CBS_ASN1_SEQUENCE) ||
         !CBS_get_asn1(&algorithm, &oid, CBS_ASN1_OBJECT)) {
         return nullptr;
@@ -258,8 +283,28 @@ static EVP_PKEY* parseMLKEMPrivateKey(const unsigned char* der, const int derLen
     // fails the inner OCTET STRING parse below, so this returns nullptr for them.
     // spotless:off
     if (CBS_len(&algorithm) != 0 ||
-        !CBS_get_asn1(&pkcs8, &priv, CBS_ASN1_OCTETSTRING) || CBS_len(&pkcs8) != 0 ||
-        !CBS_get_asn1(&priv, &expanded, CBS_ASN1_OCTETSTRING) || CBS_len(&priv) != 0) {
+        !CBS_get_asn1(&pkcs8, &priv, CBS_ASN1_OCTETSTRING)) {
+        return nullptr;
+    }
+    // spotless:on
+    // attributes [0] Attributes OPTIONAL. Ignored, exactly as EVP_parse_private_key ignores it.
+    if (!skipOptionalContextSpecificField(&pkcs8, 0)) {
+        return nullptr;
+    }
+    // publicKey [1] BIT STRING OPTIONAL, permitted only in a version-1 OneAsymmetricKey. Ignored: the
+    // non-FIPS d2i expanded path also reconstructs ML-KEM keys from the secret key alone, so honoring
+    // the public key here would make the two paths disagree.
+    const bool has_public_key = CBS_peek_asn1_tag(&pkcs8, CBS_ASN1_CONTEXT_SPECIFIC | CBS_ASN1_CONSTRUCTED | 1)
+        || CBS_peek_asn1_tag(&pkcs8, CBS_ASN1_CONTEXT_SPECIFIC | 1);
+    if (has_public_key && (version != 1 || !skipOptionalContextSpecificField(&pkcs8, 1))) {
+        return nullptr;
+    }
+    // Anything left over is not part of the grammar, so fail obviously rather than ignore it.
+    if (CBS_len(&pkcs8) != 0) {
+        return nullptr;
+    }
+    // spotless:off
+    if (!CBS_get_asn1(&priv, &expanded, CBS_ASN1_OCTETSTRING) || CBS_len(&priv) != 0) {
         return nullptr;
     }
     // spotless:on

--- a/csrc/keyutils.cpp
+++ b/csrc/keyutils.cpp
@@ -138,6 +138,16 @@ EVP_PKEY* der2EvpPrivateKey(const unsigned char* der,
 // TODO [AWS-LC-FIPS 4.x]: drop this hand-rolled SPKI path once the FIPS module implements i2d/d2i_PUBKEY for ML-KEM.
 
 // Maps an ML-KEM raw public-key length (FIPS 203, Table 3) to its NID, or NID_undef.
+//
+// NOTE: this mapping is only unambiguous for ML-KEM keys. AWS-LC registers legacy Kyber-R3 under the
+// same EVP_PKEY_KEM type (see KEM_find_kem_by_nid), and Kyber-512/768/1024-R3 have byte-for-byte the
+// same public- and secret-key lengths as ML-KEM-512/768/1024, so a length alone cannot tell the two
+// families apart. Callers must therefore only reach this helper for keys the library itself could not
+// encode: Java_..._EvpKey_encodePublicKey tries i2d_PUBKEY first, and encodeExpandedMLKEMPrivateKey is
+// only reached after EVP_marshal_private_key fails. Both of those only fail for EVP_PKEY_KEM in
+// regular FIPS, where AWS-LC-FIPS 3.1.0 supplies no pub_encode/pub_decode/priv_encode/priv_decode at
+// all -- so the only ML-KEM codecs in play are the ones in this file, which key off the OID and reject
+// every non-ML-KEM OID, and ACCP itself never generates anything but ML-KEM.
 static int mlkemNidForPublicKeyLen(size_t raw_len)
 {
     switch (raw_len) {
@@ -425,7 +435,10 @@ size_t encodeExpandedMLKEMPrivateKey(const EVP_PKEY* key, uint8_t** out)
     size_t raw_len = 0;
     CHECK_OPENSSL(EVP_PKEY_get_raw_private_key(key, nullptr, &raw_len));
     int nid = NID_undef;
-    // See FIPS 203, Table 3: secret_key_len per parameter set
+    // See FIPS 203, Table 3: secret_key_len per parameter set. As with mlkemNidForPublicKeyLen above,
+    // these lengths are shared with legacy Kyber-R3, so this switch is only sound because the caller
+    // reaches it exclusively after EVP_marshal_private_key has failed -- which for EVP_PKEY_KEM only
+    // happens in regular FIPS, where no non-ML-KEM KEM key can exist.
     switch (raw_len) {
     case 1632:
         nid = NID_MLKEM512;

--- a/csrc/keyutils.h
+++ b/csrc/keyutils.h
@@ -105,6 +105,10 @@ EVP_PKEY* der2EvpPrivateKey(const unsigned char* der,
     const char* javaExceptionClass);
 EVP_PKEY* der2EvpPublicKey(const unsigned char* der, const int derLen, const char* javaExceptionClass);
 bool checkKey(const EVP_PKEY* key);
+// Encodes an ML-KEM public key as an X.509 SubjectPublicKeyInfo DER blob. Used instead of
+// i2d_PUBKEY for ML-KEM, which AWS-LC-FIPS 3.1.0 does not support.
+// TODO [AWS-LC-FIPS 4.x]: remove once the FIPS module supports i2d_PUBKEY for ML-KEM.
+size_t encodeMLKEMPublicKey(const EVP_PKEY* key, uint8_t** out);
 static bool inline BN_null_or_zero(const BIGNUM* bn) { return nullptr == bn || BN_is_zero(bn); }
 
 // Returns true if keyType is EVP_PKEY_RSA or EVP_PKEY_RSA_PSS. RSASSA-PSS keys
@@ -175,12 +179,14 @@ RSA* new_private_RSA_key_with_no_e(BIGNUM const* n, BIGNUM const* d);
 // |*out|, and returns the size of |*out| on success and throws an unchecked exception on failure. The caller takes
 // ownership of |*out|.
 size_t encodeExpandedMLDSAPrivateKey(const EVP_PKEY* key, uint8_t** out);
+#endif
 
 // Expands ML-KEM |key|, allocates appropriately sized buffer to |*out|, writes the PKCS8-encoded expanded key to
 // |*out|, and returns the size of |*out| on success and throws an unchecked exception on failure. The caller takes
-// ownership of |*out|.
+// ownership of |*out|. Available in all builds: regular FIPS uses this because AWS-LC-FIPS 3.1.0 cannot marshal
+// ML-KEM private keys (no priv_encode) and lacks seed support.
+// TODO [AWS-LC-FIPS 4.x]: regular FIPS can drop this once the FIPS module supports priv_encode for ML-KEM.
 size_t encodeExpandedMLKEMPrivateKey(const EVP_PKEY* key, uint8_t** out);
-#endif
 
 // Formats an EC private key with redundant curve identifier confromant to RFC
 // 5915, similar to BouncyCastle's encoding format. Allocates appropriately

--- a/csrc/keyutils.h
+++ b/csrc/keyutils.h
@@ -7,6 +7,7 @@
 #include "env.h"
 #include "util.h"
 #include <openssl/bn.h>
+#include <openssl/err.h>
 #include <openssl/evp.h>
 #include <openssl/x509.h>
 
@@ -14,6 +15,24 @@
 // Unlike util.h, this is intended to capture high-level logic with more internal dependencies.
 
 namespace AmazonCorrettoCryptoProvider {
+
+// Scope guard for discarding errors queued by an operation whose failure is expected and handled,
+// such as a marshaler that a fallover encoder retries. Prefer this over a bare ERR_clear_error():
+// it only discards what was queued inside the guarded scope (leaving anything queued earlier for
+// the caller to see), and it runs even when the guarded scope exits by throwing.
+//
+// Errors queued inside the scope remain visible until the guard goes out of scope, so throw_openssl
+// still reports them. Note that ERR_set_mark is a no-op on an empty queue, in which case
+// ERR_pop_to_mark clears the whole queue -- which is the desired behavior there anyway.
+class ErrorQueueMark {
+public:
+    ErrorQueueMark() { ERR_set_mark(); }
+    ~ErrorQueueMark() { ERR_pop_to_mark(); }
+
+private:
+    ErrorQueueMark(const ErrorQueueMark&) DELETE_IMPLICIT;
+    ErrorQueueMark& operator=(const ErrorQueueMark&) DELETE_IMPLICIT;
+};
 
 // This class should generally not be used for new development
 // as it has been replaced by the *_auto classes in auto_free.h

--- a/csrc/keyutils.h
+++ b/csrc/keyutils.h
@@ -17,7 +17,7 @@
 namespace AmazonCorrettoCryptoProvider {
 
 // Scope guard for discarding errors queued by an operation whose failure is expected and handled,
-// such as a marshaler that a fallover encoder retries. Prefer this over a bare ERR_clear_error():
+// such as a d2i_* call that a fallover decoder retries. Prefer this over a bare ERR_clear_error():
 // it only discards what was queued inside the guarded scope (leaving anything queued earlier for
 // the caller to see), and it runs even when the guarded scope exits by throwing.
 //

--- a/src/com/amazon/corretto/crypto/provider/EvpKemPrivateKey.java
+++ b/src/com/amazon/corretto/crypto/provider/EvpKemPrivateKey.java
@@ -7,6 +7,8 @@ import java.security.PrivateKey;
 class EvpKemPrivateKey extends EvpKemKey implements PrivateKey {
   private static final long serialVersionUID = 1;
 
+  private static native byte[] encodeMlKemPrivateKey(long ptr);
+
   EvpKemPrivateKey(final long ptr) {
     this(new InternalKey(ptr));
   }
@@ -20,6 +22,25 @@ class EvpKemPrivateKey extends EvpKemKey implements PrivateKey {
     this.sharedKey = true;
     final EvpKemPublicKey result = new EvpKemPublicKey(internalKey);
     result.sharedKey = true;
+    return result;
+  }
+
+  @Override
+  protected byte[] internalGetEncoded() {
+    // ML-KEM private keys prefer seed format, but AWS-LC-FIPS 3.1.0 cannot marshal ML-KEM private
+    // keys and lacks seed support, so the native encoder falls back to expanded format in regular
+    // FIPS. (Mirrors EvpMlDsaPrivateKey's seed/expanded handling.)
+    assertNotDestroyed();
+    byte[] result = encoded;
+    if (result == null) {
+      synchronized (this) {
+        result = encoded;
+        if (result == null) {
+          result = use(EvpKemPrivateKey::encodeMlKemPrivateKey);
+          encoded = result;
+        }
+      }
+    }
     return result;
   }
 }

--- a/tst/com/amazon/corretto/crypto/provider/test/EvpKeyFactoryTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/EvpKeyFactoryTest.java
@@ -83,16 +83,6 @@ public class EvpKeyFactoryTest {
     for (Provider.Service service : NATIVE_PROVIDER.getServices()) {
       if ("KeyFactory".equals(service.getType())) {
         final String algorithm = service.getAlgorithm();
-        // AWS-LC-FIPS 3.1.0 cannot marshal/parse ML-KEM keys (no i2d_PUBKEY / d2i_PUBKEY for
-        // ML-KEM), so ML-KEM KeyFactory X509/PKCS8 round-trips fail in pure-FIPS builds. Skip
-        // ML-KEM here in pure FIPS; it is still exercised in non-FIPS and experimental-FIPS.
-        // TODO(#568): remove once ACCP hand-rolls ML-KEM SubjectPublicKeyInfo encode/decode for
-        // FIPS.
-        if (algorithm.toUpperCase().startsWith("ML-KEM")
-            && NATIVE_PROVIDER.isFips()
-            && !NATIVE_PROVIDER.isExperimentalFips()) {
-          continue;
-        }
         ALGORITHMS.add(algorithm);
       }
     }

--- a/tst/com/amazon/corretto/crypto/provider/test/EvpKeyFactoryTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/EvpKeyFactoryTest.java
@@ -332,9 +332,23 @@ public class EvpKeyFactoryTest {
 
     final PKCS8EncodedKeySpec nativeSpec =
         nativeFactory.getKeySpec(privKey, PKCS8EncodedKeySpec.class);
-    final PKCS8EncodedKeySpec jceSpec = jceFactory.getKeySpec(privKey, PKCS8EncodedKeySpec.class);
 
-    assertArrayEquals(jceSpec.getEncoded(), nativeSpec.getEncoded(), "PKCS #8 encodings match");
+    if (isMlKemWithExpandedOnlyEncoding(algorithm)) {
+      // In regular FIPS builds ACCP always emits the RFC 9935 expandedKey form for ML-KEM private
+      // keys, because AWS-LC-FIPS 3.1.0 retains no keygen seed. Other providers may emit the seed
+      // form for the same key, so the two encodings need not be byte-identical. Assert that ACCP's
+      // own encoding round-trips unchanged instead of comparing against another provider's bytes.
+      // TODO: compare against the alternate provider once AWS-LC-FIPS supports seed-format ML-KEM
+      // private keys.
+      final PrivateKey reparsed = nativeFactory.generatePrivate(nativeSpec);
+      assertArrayEquals(
+          nativeSpec.getEncoded(),
+          nativeFactory.getKeySpec(reparsed, PKCS8EncodedKeySpec.class).getEncoded(),
+          "ACCP PKCS #8 encoding round-trips unchanged");
+    } else {
+      final PKCS8EncodedKeySpec jceSpec = jceFactory.getKeySpec(privKey, PKCS8EncodedKeySpec.class);
+      assertArrayEquals(jceSpec.getEncoded(), nativeSpec.getEncoded(), "PKCS #8 encodings match");
+    }
 
     // Get a spec with extra data
     final byte[] validSpec = nativeSpec.getEncoded();
@@ -741,6 +755,15 @@ public class EvpKeyFactoryTest {
       this.nativeSample = nativeSample;
       this.jceSample = jceSample;
     }
+  }
+
+  // True when |algorithm| is ML-KEM and this is a regular (non-experimental) FIPS build, where ACCP
+  // can only emit the expanded-key PKCS#8 encoding. Other providers may emit the seed encoding for
+  // the same key, so cross-provider PKCS#8 byte comparisons are not meaningful in that combination.
+  private static boolean isMlKemWithExpandedOnlyEncoding(final String algorithm) {
+    return algorithm.toUpperCase().startsWith("ML-KEM")
+        && NATIVE_PROVIDER.isFips()
+        && !NATIVE_PROVIDER.isExperimentalFips();
   }
 
   // This method is used to determine whether tests should use an alternate provider for a given

--- a/tst/com/amazon/corretto/crypto/provider/test/jdk17plus/BouncyCastleJsseMlKemIntegrationTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/jdk17plus/BouncyCastleJsseMlKemIntegrationTest.java
@@ -250,17 +250,6 @@ public class BouncyCastleJsseMlKemIntegrationTest {
    * ACCP itself has ML-KEM (its shipped Maven artifacts do not). Missing any one of these skips.
    */
   private static void assumeMlKemDelegationReachable() {
-    // ACCP can generate ML-KEM keypairs in pure FIPS, but AWS-LC-FIPS 3.1.0 cannot marshal ML-KEM
-    // keys (getEncoded -> i2d_PUBKEY raises UNSUPPORTED_ALGORITHM), so BCJSSE cannot encode the
-    // ephemeral ML-KEM public key into the TLS key_share. The KEM-over-TLS path is therefore
-    // unusable in pure FIPS; it works in non-FIPS and experimental-FIPS builds (non-FIPS AWS-LC).
-    // TODO(#568): remove once ACCP hand-rolls ML-KEM SubjectPublicKeyInfo encode/decode for FIPS.
-    assumeTrue(
-        !AmazonCorrettoCryptoProvider.INSTANCE.isFips()
-            || AmazonCorrettoCryptoProvider.INSTANCE.isExperimentalFips(),
-        "ML-KEM key encoding is unavailable in pure-FIPS AWS-LC; BCJSSE cannot source ML-KEM TLS"
-            + " from ACCP there");
-
     assumeTrue(
         classPresent("javax.crypto.KEMSpi"),
         "javax.crypto.KEMSpi absent -- need JDK 21+ or KEM-backported JDK 17");

--- a/tst/com/amazon/corretto/crypto/provider/test/jdk17plus/MlKemTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/jdk17plus/MlKemTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import com.amazon.corretto.crypto.provider.AmazonCorrettoCryptoProvider;
@@ -21,17 +22,21 @@ import java.security.Provider;
 import java.security.PublicKey;
 import java.security.SecureRandom;
 import java.security.spec.AlgorithmParameterSpec;
+import java.security.spec.InvalidKeySpecException;
 import java.security.spec.NamedParameterSpec;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.security.spec.X509EncodedKeySpec;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import javax.crypto.KEM;
 import javax.crypto.SecretKey;
 import org.bouncycastle.asn1.ASN1Encodable;
 import org.bouncycastle.asn1.ASN1Integer;
+import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 import org.bouncycastle.asn1.ASN1Sequence;
 import org.bouncycastle.asn1.DERBitString;
+import org.bouncycastle.asn1.DEROctetString;
 import org.bouncycastle.asn1.DERSequence;
 import org.bouncycastle.asn1.DERSet;
 import org.bouncycastle.asn1.DERTaggedObject;
@@ -55,6 +60,8 @@ public class MlKemTest {
       AmazonCorrettoCryptoProvider.INSTANCE;
   private static final int SHARED_SECRET_SIZE = 32;
   private static final String[] ML_KEM_PARAM_SETS = {"ML-KEM-512", "ML-KEM-768", "ML-KEM-1024"};
+  // An OID under an unassigned private-enterprise arc, so no provider maps it to an algorithm.
+  private static final String UNASSIGNED_OID = "1.3.6.1.4.1.99999.1";
 
   private static String[] mlKemParamSets() {
     return ML_KEM_PARAM_SETS;
@@ -330,6 +337,158 @@ public class MlKemTest {
           encapsulated.key().getEncoded(),
           kem.newDecapsulator(parsed, paramSpec).decapsulate(ciphertext).getEncoded(),
           paramSet + " OneAsymmetricKey variant must decapsulate to the same shared secret");
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("mlKemParamSets")
+  public void testMalformedPkcs8PrivateKeysRejected(String paramSet) throws Exception {
+    // Negative counterpart to testPkcs8OneAsymmetricKeyFieldsAccepted. Every variant below is
+    // outside
+    // the PKCS#8 grammar for ML-KEM and must be rejected both by AWS-LC's EVP_parse_private_key
+    // (the
+    // non-FIPS decoder) and by ACCP's hand-rolled regular-FIPS fallover parser.
+    ASN1Sequence pkcs8 =
+        ASN1Sequence.getInstance(
+            KeyPairGenerator.getInstance(paramSet, NATIVE_PROVIDER)
+                .generateKeyPair()
+                .getPrivate()
+                .getEncoded());
+    ASN1Encodable algorithm = pkcs8.getObjectAt(1);
+    ASN1Encodable privateKey = pkcs8.getObjectAt(2);
+    KeyFactory keyFactory = KeyFactory.getInstance(paramSet, NATIVE_PROVIDER);
+
+    assertPrivateKeyRejected(
+        keyFactory,
+        paramSet + " unrecognized algorithm OID",
+        new DERSequence(
+                new ASN1Encodable[] {
+                  new ASN1Integer(0),
+                  new DERSequence(new ASN1ObjectIdentifier(UNASSIGNED_OID)),
+                  privateKey
+                })
+            .getEncoded("DER"));
+
+    // version 2 is outside both RFC 5208 (version 0) and RFC 5958 (version 1).
+    assertPrivateKeyRejected(
+        keyFactory,
+        paramSet + " version 2",
+        new DERSequence(new ASN1Encodable[] {new ASN1Integer(2), algorithm, privateKey})
+            .getEncoded("DER"));
+
+    // An expandedKey CHOICE whose length matches no ML-KEM parameter set. Written explicitly rather
+    // than derived from the key above, because ACCP emits the seed CHOICE in non-FIPS builds.
+    assertPrivateKeyRejected(
+        keyFactory,
+        paramSet + " expandedKey of invalid length",
+        new DERSequence(
+                new ASN1Encodable[] {
+                  new ASN1Integer(0),
+                  algorithm,
+                  new DEROctetString(new DEROctetString(new byte[1631]).getEncoded("DER"))
+                })
+            .getEncoded("DER"));
+
+    // Trailing garbage after the PrivateKeyInfo SEQUENCE.
+    byte[] valid =
+        new DERSequence(new ASN1Encodable[] {new ASN1Integer(0), algorithm, privateKey})
+            .getEncoded("DER");
+    assertPrivateKeyRejected(
+        keyFactory, paramSet + " trailing byte", Arrays.copyOf(valid, valid.length + 1));
+  }
+
+  @ParameterizedTest
+  @MethodSource("mlKemParamSets")
+  public void testMalformedSpkiPublicKeysRejected(String paramSet) throws Exception {
+    // Every variant below is outside the X.509 SubjectPublicKeyInfo grammar for ML-KEM (RFC 9935
+    // Section 4) and must be rejected both by AWS-LC's EVP_parse_public_key (the non-FIPS decoder)
+    // and by ACCP's hand-rolled regular-FIPS fallover parser.
+    KeyPair keyPair = KeyPairGenerator.getInstance(paramSet, NATIVE_PROVIDER).generateKeyPair();
+    byte[] validSpki = keyPair.getPublic().getEncoded();
+    ASN1Encodable algorithm = ASN1Sequence.getInstance(validSpki).getObjectAt(0);
+    byte[] rawPublicKey = SubjectPublicKeyInfo.getInstance(validSpki).getPublicKeyData().getBytes();
+    KeyFactory keyFactory = KeyFactory.getInstance(paramSet, NATIVE_PROVIDER);
+
+    assertPublicKeyRejected(
+        keyFactory,
+        paramSet + " unrecognized algorithm OID",
+        new DERSequence(
+                new ASN1Encodable[] {
+                  new DERSequence(new ASN1ObjectIdentifier(UNASSIGNED_OID)),
+                  new DERBitString(rawPublicKey)
+                })
+            .getEncoded("DER"));
+
+    // An ML-KEM public key is a whole number of octets, so the unused-bit count must be zero. Clear
+    // the bit that padBits=1 declares unused so the BIT STRING itself stays well-formed DER.
+    byte[] maskedPublicKey = rawPublicKey.clone();
+    maskedPublicKey[maskedPublicKey.length - 1] &= (byte) 0xFE;
+    assertPublicKeyRejected(
+        keyFactory,
+        paramSet + " non-zero unused bit count",
+        new DERSequence(new ASN1Encodable[] {algorithm, new DERBitString(maskedPublicKey, 1)})
+            .getEncoded("DER"));
+
+    assertPublicKeyRejected(
+        keyFactory,
+        paramSet + " empty subjectPublicKey",
+        new DERSequence(new ASN1Encodable[] {algorithm, new DERBitString(new byte[0])})
+            .getEncoded("DER"));
+
+    assertPublicKeyRejected(
+        keyFactory,
+        paramSet + " truncated subjectPublicKey",
+        new DERSequence(
+                new ASN1Encodable[] {
+                  algorithm, new DERBitString(Arrays.copyOf(rawPublicKey, rawPublicKey.length - 1))
+                })
+            .getEncoded("DER"));
+
+    assertPublicKeyRejected(
+        keyFactory, paramSet + " trailing byte", Arrays.copyOf(validSpki, validSpki.length + 1));
+  }
+
+  @ParameterizedTest
+  @MethodSource("mlKemParamSets")
+  public void testPublicKeyEncodingMatchesBouncyCastle(String paramSet) throws Exception {
+    // ML-KEM SPKI is fully determined by (OID, rawPublicKey), so unlike the private-key encoding it
+    // has one canonical form in every build. That makes it a byte-for-byte check on ACCP's
+    // hand-rolled regular-FIPS SPKI encoder, which is why this test carries no FIPS guard.
+    KeyPair keyPair = KeyPairGenerator.getInstance(paramSet, NATIVE_PROVIDER).generateKeyPair();
+    byte[] accpSpki = keyPair.getPublic().getEncoded();
+
+    PublicKey bcPublicKey =
+        KeyFactory.getInstance("ML-KEM", TestUtil.BC_PROVIDER)
+            .generatePublic(new X509EncodedKeySpec(accpSpki));
+    assertArrayEquals(
+        accpSpki,
+        bcPublicKey.getEncoded(),
+        paramSet + " SPKI must round-trip byte-identically through BouncyCastle");
+
+    PublicKey reparsed =
+        KeyFactory.getInstance(paramSet, NATIVE_PROVIDER)
+            .generatePublic(new X509EncodedKeySpec(accpSpki));
+    assertArrayEquals(
+        accpSpki, reparsed.getEncoded(), paramSet + " SPKI must round-trip unchanged through ACCP");
+  }
+
+  private static void assertPrivateKeyRejected(KeyFactory keyFactory, String label, byte[] der)
+      throws Exception {
+    try {
+      keyFactory.generatePrivate(new PKCS8EncodedKeySpec(der));
+      fail("Expected InvalidKeySpecException for " + label);
+    } catch (InvalidKeySpecException expected) {
+      // Expected: the encoding is outside the grammar ACCP accepts.
+    }
+  }
+
+  private static void assertPublicKeyRejected(KeyFactory keyFactory, String label, byte[] der)
+      throws Exception {
+    try {
+      keyFactory.generatePublic(new X509EncodedKeySpec(der));
+      fail("Expected InvalidKeySpecException for " + label);
+    } catch (InvalidKeySpecException expected) {
+      // Expected: the encoding is outside the grammar ACCP accepts.
     }
   }
 

--- a/tst/com/amazon/corretto/crypto/provider/test/jdk17plus/MlKemTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/jdk17plus/MlKemTest.java
@@ -28,6 +28,14 @@ import java.util.ArrayList;
 import java.util.List;
 import javax.crypto.KEM;
 import javax.crypto.SecretKey;
+import org.bouncycastle.asn1.ASN1Encodable;
+import org.bouncycastle.asn1.ASN1Integer;
+import org.bouncycastle.asn1.ASN1Sequence;
+import org.bouncycastle.asn1.DERBitString;
+import org.bouncycastle.asn1.DERSequence;
+import org.bouncycastle.asn1.DERSet;
+import org.bouncycastle.asn1.DERTaggedObject;
+import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
 import org.bouncycastle.jcajce.interfaces.MLKEMPrivateKey;
 import org.bouncycastle.jcajce.spec.KTSParameterSpec;
 import org.junit.jupiter.api.Test;
@@ -261,6 +269,68 @@ public class MlKemTest {
     byte[] privateKeyEncoded = originalKeyPair.getPrivate().getEncoded();
     PrivateKey privateKey = keyFactory.generatePrivate(new PKCS8EncodedKeySpec(privateKeyEncoded));
     assertArrayEquals(privateKeyEncoded, privateKey.getEncoded());
+  }
+
+  @ParameterizedTest
+  @MethodSource("mlKemParamSets")
+  public void testPkcs8OneAsymmetricKeyFieldsAccepted(String paramSet) throws Exception {
+    // A PKCS#8 ML-KEM private key may arrive as an RFC 5208 PrivateKeyInfo (version 0) or an
+    // RFC 5958 OneAsymmetricKey (version 1, which also permits a [1] publicKey); both versions
+    // permit an optional [0] attributes field. AWS-LC's EVP_parse_private_key accepts all of these,
+    // and in regular FIPS builds ACCP's hand-rolled fallover parser is what has to accept them
+    // instead, so exercise each shape. The assertion is encoding-independent: every variant carries
+    // the same key material, so each must decapsulate to the same shared secret.
+    KeyPairGenerator keyGen = KeyPairGenerator.getInstance(paramSet, NATIVE_PROVIDER);
+    KeyPair keyPair = keyGen.generateKeyPair();
+    KeyFactory keyFactory = KeyFactory.getInstance(paramSet, NATIVE_PROVIDER);
+
+    ASN1Sequence pkcs8 = ASN1Sequence.getInstance(keyPair.getPrivate().getEncoded());
+    ASN1Encodable algorithm = pkcs8.getObjectAt(1);
+    ASN1Encodable privateKey = pkcs8.getObjectAt(2);
+    byte[] rawPublicKey =
+        SubjectPublicKeyInfo.getInstance(keyPair.getPublic().getEncoded())
+            .getPublicKeyData()
+            .getBytes();
+
+    List<byte[]> variants = new ArrayList<>();
+    // version 1 (OneAsymmetricKey) with no optional fields.
+    variants.add(
+        new DERSequence(new ASN1Encodable[] {new ASN1Integer(1), algorithm, privateKey})
+            .getEncoded("DER"));
+    // version 0 with an (empty) [0] attributes SET, which is encoded constructed.
+    variants.add(
+        new DERSequence(
+                new ASN1Encodable[] {
+                  new ASN1Integer(0),
+                  algorithm,
+                  privateKey,
+                  new DERTaggedObject(false, 0, new DERSet())
+                })
+            .getEncoded("DER"));
+    // version 1 with a [1] publicKey BIT STRING, which is encoded primitive.
+    variants.add(
+        new DERSequence(
+                new ASN1Encodable[] {
+                  new ASN1Integer(1),
+                  algorithm,
+                  privateKey,
+                  new DERTaggedObject(false, 1, new DERBitString(rawPublicKey))
+                })
+            .getEncoded("DER"));
+
+    KEM kem = KEM.getInstance(paramSet, NATIVE_PROVIDER);
+    NamedParameterSpec paramSpec = new NamedParameterSpec(paramSet);
+    KEM.Encapsulated encapsulated =
+        kem.newEncapsulator(keyPair.getPublic(), paramSpec, null).encapsulate();
+    byte[] ciphertext = encapsulated.encapsulation();
+
+    for (byte[] variant : variants) {
+      PrivateKey parsed = keyFactory.generatePrivate(new PKCS8EncodedKeySpec(variant));
+      assertArrayEquals(
+          encapsulated.key().getEncoded(),
+          kem.newDecapsulator(parsed, paramSpec).decapsulate(ciphertext).getEncoded(),
+          paramSet + " OneAsymmetricKey variant must decapsulate to the same shared secret");
+    }
   }
 
   @ParameterizedTest


### PR DESCRIPTION
Follow-up to #564, and a **precursor to #569**, which adds ML-KEM seed-format *parsing* in regular FIPS. Makes ML-KEM key serialization work in **regular FIPS** so ML-KEM-over-TLS (BCJSSE) and `EvpKeyFactoryTest` no longer have to be skipped.

## Problem
AWS-LC-FIPS-3.1.0's ML-KEM `EVP_PKEY_ASN1_METHOD` implements no `pub_encode`/`pub_decode` or `priv_encode`/`priv_decode`, so `i2d_PUBKEY`/`d2i_PUBKEY` and `EVP_PKEY2PKCS8`/`d2i_PrivateKey` return `UNSUPPORTED_ALGORITHM` for ML-KEM. ML-KEM *KEM ops* work in FIPS, but `getEncoded()`/`KeyFactory` on ML-KEM keys fail -- blocking ML-KEM-over-TLS in regular FIPS (BCJSSE cannot encode the ephemeral public key into the TLS `key_share`) and failing `EvpKeyFactoryTest`'s ML-KEM cases. #564 skipped those in regular FIPS as an interim.

## Change

Hand-roll ML-KEM key encode/decode in ACCP's native layer using the raw-key APIs AWS-LC-FIPS-3.1.0 *does* provide (all in the FIPS module), bypassing the unsupported ASN.1 marshalers. See source comments with links to RFC for format details. Non-FIPS behavior is unchanged: the hand-rolled encoders are only reached when the library marshaler (`i2d_PUBKEY` for public keys, `EVP_marshal_private_key` for private keys) fails.

## #564 skips lifted
- BCJSSE ML-KEM integration test (regular FIPS)
- `EvpKeyFactoryTest` ML-KEM cases (regular FIPS)

## Review fixes
- **Library encoders take precedence.** `encodePublicKey` now tries `i2d_PUBKEY` first and hand-rolls only on failure, matching the private-key path; previously the hand-rolled encoder ran first for ML-KEM in *every* build, so non-FIPS output came from ACCP rather than AWS-LC. The ordering is also what makes the length-based OID inference in the fallback sound, since `KEM_find_kem_by_nid` resolves the legacy Kyber-R3 NIDs under the same `EVP_PKEY_KEM` type at identical key lengths.
- **Full `OneAsymmetricKey` grammar accepted.** The regular-FIPS PKCS#8 fallover parser took only version 0 and required the SEQUENCE to end right after `privateKey`. It now accepts version 0 or 1, an optional `[0] attributes`, and (version 1 only) an optional `[1] publicKey`, in both the constructed and the primitive tag encodings that `EVP_parse_private_key` accepts. Keys in those shapes decoded in non-FIPS but were rejected in regular FIPS. Trailing content is still rejected.
- **Encoder cleanup and error scoping.** A failed `CBB_finish` does not write `*out` and leaves the CBB owning its buffer, so the old `OPENSSL_free(*out)` freed an uninitialized pointer and leaked; the failure paths now `CBB_cleanup` instead. Added the missing `OPENSSL_malloc` and `CBB_init` return checks, and replaced the bare `ERR_clear_error()` calls with a scoped `ErrorQueueMark` guard so an expected fallover failure no longer discards errors queued by the caller, and a genuinely failed fallover reports the underlying error instead of nothing.
- **Misleading decode errors fixed.** `d2i_PrivateKey` leaves its input pointer untouched on failure, so the trailing-data check running before the null check reported every decode failure as `Extra key information`.
- **Tests.** `OneAsymmetricKey` shapes accepted; malformed PKCS#8 and SPKI encodings rejected (unassigned algorithm OID, bad version, wrong-length `expandedKey`, non-zero BIT STRING padding, empty/truncated public key, trailing bytes); ACCP's SPKI output cross-checked against BouncyCastle in all build modes.

## Still to come (follow-up PR)
This PR does **not** parse seed-format ML-KEM private keys in regular FIPS; #569 adds that (via `EVP_PKEY_keygen_deterministic`) and lifts `testKeyFactorySelfConversion`. Seed-format *encoding* (emitting the compact 86-byte seed) remains impossible in regular FIPS -- AWS-LC-FIPS-3.1.0 stores no keygen seed -- and awaits the AWS-LC-FIPS v5.0.0 bump. The seed-format tests stay skipped in this PR.
