### PR TITLE
Parse seed-format ML-KEM private keys in regular FIPS (follow-up to #568)

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ ACCP did not track a FIPS branch/release version of AWS-LC until ACCP v2.3.0. Be
 | 2.4.0               | 1.30.1         | 2.0.13              |
 | 2.4.1               | 1.30.1         | 2.0.13              |
 | 2.5.0               | 1.47.0         | 3.0.0               |
-| 2.6.0               | 1.72.0         | 3.1.0               |
+| 2.6.0               | 5.0.0          | 3.1.0               |
 
 Notable differences between ACCP and ACCP-FIPS:
 * ACCP uses [the latest release of AWS-LC](https://github.com/aws/aws-lc/releases), whereas, ACCP-FIPS uses [a timestamped FIPS branch of AWS-LC](https://github.com/aws/aws-lc/branches).

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ ACCP did not track a FIPS branch/release version of AWS-LC until ACCP v2.3.0. Be
 | 2.4.0               | 1.30.1         | 2.0.13              |
 | 2.4.1               | 1.30.1         | 2.0.13              |
 | 2.5.0               | 1.47.0         | 3.0.0               |
-| 2.6.0               | 5.0.0          | 3.1.0               |
+| 2.6.0               | 1.72.0         | 3.1.0               |
 
 Notable differences between ACCP and ACCP-FIPS:
 * ACCP uses [the latest release of AWS-LC](https://github.com/aws/aws-lc/releases), whereas, ACCP-FIPS uses [a timestamped FIPS branch of AWS-LC](https://github.com/aws/aws-lc/branches).
@@ -187,6 +187,7 @@ Notable differences between ACCP and ACCP-FIPS:
 * In FIPS-mode, RSA keys are limited to 2048, 3072, or 4096 bits in size with public exponent F4.
 * Due to the fact that an older branch of AWS-LC is used in FIPS-mode, there will be performance differences between ACCP and ACCP-FIPS. We highly recommend performing detailed performance testing of your application if you choose to experiment with ACCP-FIPS.
 * Between versions 2.1.0 and 2.3.3 (inclusive), ACCP-FIPS does not register SecureRandom by default due to the performance of AWS-LC’s entropy source in FIPS-mode, with older versions of AWS-LC. Since version 2.4.0, ACCP-FIPS behaves as ACCP: it registers SecureRandom from AWS-LC by default. [A system property](https://github.com/corretto/amazon-corretto-crypto-provider#other-system-properties) is available to change the default behavior.
+* ACCP-FIPS cannot *serialize* an ML-KEM private key in the seed format of [RFC 9935](https://datatracker.ietf.org/doc/html/rfc9935#section-6): the `KEM_KEY` of AWS-LC-FIPS 3.1.0 has no field in which to retain the keygen seed, so `PrivateKey.getEncoded()` emits the `expandedKey` CHOICE where ACCP emits `seed`. Both CHOICEs are still *parsed* in every build, so a seed-format key imported through `KeyFactory` works everywhere; it simply re-encodes to the expanded form under FIPS. For well-formed keys this is the only intended behavioral difference in ML-KEM key handling between the FIPS and non-FIPS builds, and it goes away when ACCP-FIPS moves to an AWS-LC-FIPS branch whose `KEM_KEY` retains the seed. Builds configured with `-DEXPERIMENTAL_FIPS=1` track the non-FIPS AWS-LC branch and so are unaffected.
 
 ACCP-FIPS is only supported on the following platforms:
 

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ plugins {
 
 group = 'software.amazon.cryptools'
 version = '2.6.0'
-ext.awsLcMainTag = 'v1.72.0'
+ext.awsLcMainTag = 'v5.0.0'
 ext.awsLcFipsTag = 'AWS-LC-FIPS-3.1.0'
 ext.isExperimentalFips = Boolean.getBoolean('EXPERIMENTAL_FIPS')
 ext.isFips = ext.isExperimentalFips || Boolean.getBoolean('FIPS')

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ plugins {
 
 group = 'software.amazon.cryptools'
 version = '2.6.0'
-ext.awsLcMainTag = 'v5.0.0'
+ext.awsLcMainTag = 'v1.72.0'
 ext.awsLcFipsTag = 'AWS-LC-FIPS-3.1.0'
 ext.isExperimentalFips = Boolean.getBoolean('EXPERIMENTAL_FIPS')
 ext.isFips = ext.isExperimentalFips || Boolean.getBoolean('FIPS')

--- a/csrc/java_evp_keys.cpp
+++ b/csrc/java_evp_keys.cpp
@@ -779,11 +779,7 @@ JNIEXPORT jbyteArray JNICALL Java_com_amazon_corretto_crypto_provider_EvpKemPriv
         // Prefer the standard PKCS8 marshal, which yields the compact seed format in non-FIPS and
         // experimental-FIPS builds. AWS-LC-FIPS 3.1.0 cannot marshal ML-KEM private keys (no
         // priv_encode) and lacks seed support, so on failure fall back to hand-rolled expanded-format
-        // PKCS8. Regular FIPS therefore always emits the expanded form: emitting the compact seed
-        // format needs the FIPS module to retain the keygen seed, which awaits AWS-LC-FIPS 5.0.
-        // Preferring the library encoder also keeps every non-ML-KEM EVP_PKEY_KEM key off
-        // encodeExpandedMLKEMPrivateKey's length-based OID inference; see the equivalent note in
-        // encodePublicKey above. Mirrors encodeMlDsaPrivateKey above.
+        // PKCS8. Regular FIPS therefore always emits the expanded form. Mirrors encodeMlDsaPrivateKey.
         // TODO [AWS-LC-FIPS 4.x]: drop the encodeExpandedMLKEMPrivateKey fallback once the FIPS module has priv_encode.
         // TODO [AWS-LC-FIPS 5.0]: emit seed-format PKCS8 in regular FIPS once the module retains the keygen seed.
         //

--- a/csrc/java_evp_keys.cpp
+++ b/csrc/java_evp_keys.cpp
@@ -779,10 +779,13 @@ JNIEXPORT jbyteArray JNICALL Java_com_amazon_corretto_crypto_provider_EvpKemPriv
         // Prefer the standard PKCS8 marshal, which yields the compact seed format in non-FIPS and
         // experimental-FIPS builds. AWS-LC-FIPS 3.1.0 cannot marshal ML-KEM private keys (no
         // priv_encode) and lacks seed support, so on failure fall back to hand-rolled expanded-format
-        // PKCS8. Preferring the library encoder also keeps every non-ML-KEM EVP_PKEY_KEM key off
+        // PKCS8. Regular FIPS therefore always emits the expanded form: emitting the compact seed
+        // format needs the FIPS module to retain the keygen seed, which awaits AWS-LC-FIPS 5.0.
+        // Preferring the library encoder also keeps every non-ML-KEM EVP_PKEY_KEM key off
         // encodeExpandedMLKEMPrivateKey's length-based OID inference; see the equivalent note in
         // encodePublicKey above. Mirrors encodeMlDsaPrivateKey above.
         // TODO [AWS-LC-FIPS 4.x]: drop the encodeExpandedMLKEMPrivateKey fallback once the FIPS module has priv_encode.
+        // TODO [AWS-LC-FIPS 5.0]: emit seed-format PKCS8 in regular FIPS once the module retains the keygen seed.
         //
         // Scope away the errors the expected marshal failure queues; the guard has to be set before the
         // call, since ERR_set_mark marks the newest error rather than deleting it.

--- a/csrc/keyutils.cpp
+++ b/csrc/keyutils.cpp
@@ -7,15 +7,15 @@
 #include <openssl/ec.h>
 #include <openssl/err.h>
 #include <openssl/evp.h>
+// EVP_PKEY_keygen_deterministic (seed -> ML-KEM key) lives in this experimental header. Every AWS-LC
+// flavor ACCP builds against declares it with the same signature, so the seed decode below is compiled
+// unconditionally rather than only for regular FIPS: one parser for all flavors cannot drift per build,
+// and the grammar it accepts stays a single thing to reason about.
+// TODO [AWS-LC-FIPS 4.x]: drop this experimental include once the FIPS module can d2i seed-format ML-KEM keys.
+#include <openssl/experimental/kem_deterministic_api.h>
 #include <openssl/obj.h>
 #include <openssl/pkcs8.h>
 #include <openssl/rsa.h>
-#if defined(FIPS_BUILD) && !defined(EXPERIMENTAL_FIPS_BUILD)
-// EVP_PKEY_keygen_deterministic (seed -> ML-KEM key) lives in this experimental header. Only regular
-// FIPS needs it: AWS-LC-FIPS 3.1.0's ASN.1 method cannot decode seed-format ML-KEM private keys.
-// TODO [AWS-LC-FIPS 4.x]: drop this experimental include once the FIPS module can d2i seed-format ML-KEM keys.
-#include <openssl/experimental/kem_deterministic_api.h>
-#endif
 
 namespace AmazonCorrettoCryptoProvider {
 
@@ -43,12 +43,15 @@ EVP_PKEY* der2EvpPrivateKey(const unsigned char* der,
     // no ML-KEM parsing overhead.
     EVP_PKEY* result = d2i_PrivateKey(evpType, NULL, &der_mutable_ptr, derLen);
 
-    // Regular-FIPS fallover: AWS-LC-FIPS 3.1.0 has no priv_decode for ML-KEM, so d2i_PrivateKey fails
-    // on ML-KEM PKCS8. Only when the caller asked for a KEM key and d2i_PrivateKey produced nothing do
-    // we hand-roll the parse via the raw secret key. This matches the non-FIPS d2i expanded-decode
-    // path exactly: both reconstruct the key by setting only the raw secret key
-    // (KEM_KEY_set_raw_secret_key), leaving the public key unpopulated. parseMLKEMPrivateKey returns
-    // nullptr for inputs it cannot handle.
+    // Fallover for ML-KEM PKCS8: AWS-LC-FIPS 3.1.0 has no priv_decode for ML-KEM, so d2i_PrivateKey
+    // fails on every ML-KEM private key there. Only when the caller asked for a KEM key and
+    // d2i_PrivateKey produced nothing do we hand-roll the parse via the raw APIs. Each CHOICE
+    // reconstructs the key exactly the way mainline AWS-LC's decoder does, so the two agree per CHOICE:
+    //   - expandedKey sets only the raw secret key (KEM_KEY_set_raw_secret_key), leaving the public key
+    //     unpopulated, so getPublicKey().getEncoded() fails for such a key in every build;
+    //   - seed derives the whole key pair from the seed, public key included.
+    // parseMLKEMPrivateKey returns nullptr for inputs it cannot handle, which in a non-FIPS build is
+    // everything: it accepts nothing d2i_PrivateKey has not already accepted there.
     // TODO [AWS-LC-FIPS 4.x]: drop this raw-key decode path once the FIPS module supports d2i_PrivateKey for ML-KEM.
     if (result == nullptr && evpType == EVP_PKEY_KEM) {
         EVP_PKEY* mlkem = parseMLKEMPrivateKey(der, derLen);
@@ -250,13 +253,23 @@ static EVP_PKEY* parseMLKEMPublicKey(const unsigned char* der, const int derLen)
     return EVP_PKEY_kem_new_raw_public_key(nid, CBS_data(&bit_string), CBS_len(&bit_string));
 }
 
-#if defined(FIPS_BUILD) && !defined(EXPERIMENTAL_FIPS_BUILD)
-// Expands a raw ML-KEM keygen seed (d || z) into a full EVP_PKEY via deterministic keygen. Used only
-// in regular FIPS, where AWS-LC-FIPS 3.1.0's ASN.1 method cannot decode seed-format ML-KEM private
-// keys. Returns nullptr on failure so parseMLKEMPrivateKey falls through to d2i_PrivateKey.
+// Every ML-KEM parameter set uses the same 64-byte keygen seed, d || z (FIPS 203, Algorithm 16).
+static const size_t MLKEM_SEED_LEN = 64;
+
+// Expands a raw ML-KEM keygen seed (d || z) into a full EVP_PKEY (public key included) via
+// deterministic keygen, the same way AWS-LC's KEM_KEY_set_raw_keypair_from_seed does. Returns nullptr
+// on failure, which makes the caller's parse fail and surfaces out of der2EvpPrivateKey as a decode
+// failure. Only regular FIPS reaches this, because AWS-LC-FIPS 3.1.0's ASN.1 method cannot decode a
+// seed-format key and every other flavor decodes it inside d2i_PrivateKey.
 // TODO [AWS-LC-FIPS 4.x]: drop this seed-expansion helper once the FIPS module can d2i seed-format ML-KEM keys.
 static EVP_PKEY* mlkemKeyFromSeed(int nid, const uint8_t* seed, size_t seed_len)
 {
+    // AWS-LC's kem_priv_decode length-checks the seed against the parameter set's keygen_seed_len
+    // before expanding it, so check it here too rather than relying on the experimental keygen API's
+    // internal validation.
+    if (seed_len != MLKEM_SEED_LEN) {
+        return nullptr;
+    }
     EVP_PKEY_CTX_auto ctx = EVP_PKEY_CTX_auto::from(EVP_PKEY_CTX_new_id(EVP_PKEY_KEM, nullptr));
     if (!ctx.isInitialized() || EVP_PKEY_CTX_kem_set_params(ctx, nid) != 1 || EVP_PKEY_keygen_init(ctx) != 1) {
         return nullptr;
@@ -268,35 +281,50 @@ static EVP_PKEY* mlkemKeyFromSeed(int nid, const uint8_t* seed, size_t seed_len)
     }
     return pkey;
 }
-#endif // defined(FIPS_BUILD) && !defined(EXPERIMENTAL_FIPS_BUILD)
 
-// Skips an optional context-specific field numbered |tag_number| from |cbs|, accepting both the
-// constructed and the primitive encoding of the tag. Returns false only when a matching tag is
+// Tags of the two optional PrivateKeyInfo / OneAsymmetricKey trailing fields, spelled exactly as
+// mainline AWS-LC's EVP_parse_private_key spells them (kAttributesTag and kPublicKeyTag in
+// evp_asn1.c): attributes is recognized only in its constructed form and publicKey only in its
+// primitive form. Deliberately not lenient about the other form of either tag -- see
+// parseMLKEMPrivateKey.
+static const unsigned MLKEM_PKCS8_ATTRIBUTES_TAG = CBS_ASN1_CONTEXT_SPECIFIC | CBS_ASN1_CONSTRUCTED | 0;
+static const unsigned MLKEM_PKCS8_PUBLIC_KEY_TAG = CBS_ASN1_CONTEXT_SPECIFIC | 1;
+
+// Skips the optional field tagged |tag| from |cbs| if present. Returns false only when the tag is
 // present but its element is malformed; a missing field is not an error.
-static bool skipOptionalContextSpecificField(CBS* cbs, unsigned tag_number)
+static bool skipOptionalField(CBS* cbs, unsigned tag)
 {
-    const unsigned constructed = CBS_ASN1_CONTEXT_SPECIFIC | CBS_ASN1_CONSTRUCTED | tag_number;
-    if (CBS_peek_asn1_tag(cbs, constructed)) {
-        return CBS_get_asn1(cbs, nullptr, constructed) == 1;
+    if (!CBS_peek_asn1_tag(cbs, tag)) {
+        return true;
     }
-    // AWS-LC's EVP_parse_private_key looks for the primitive form of these tags, so accept it too
-    // rather than rejecting keys the non-FIPS d2i_PrivateKey path would have accepted.
-    const unsigned primitive = CBS_ASN1_CONTEXT_SPECIFIC | tag_number;
-    if (CBS_peek_asn1_tag(cbs, primitive)) {
-        return CBS_get_asn1(cbs, nullptr, primitive) == 1;
-    }
-    return true;
+    return CBS_get_asn1(cbs, nullptr, tag) == 1;
 }
 
 // See forward declaration above der2EvpPrivateKey. Parses a PKCS8 ML-KEM private key via the raw
-// APIs, bypassing the ASN.1 method that AWS-LC-FIPS 3.1.0 lacks. Handles the expanded-key CHOICE
-// (all builds) and, in regular FIPS only, the seed CHOICE. Both CHOICEs are specified in RFC 9935
-// Section 6 (Private Key Format), with the formal ASN.1 module in Appendix A:
+// APIs, bypassing the ASN.1 method that AWS-LC-FIPS 3.1.0 lacks. The private-key CHOICEs are
+// specified in RFC 9935 Section 6 (Private Key Format), with the formal ASN.1 module in Appendix A:
 // https://datatracker.ietf.org/doc/html/rfc9935#section-6
 // https://datatracker.ietf.org/doc/html/rfc9935#appendix-A
-// Returns nullptr for non-ML-KEM inputs, and (in non-FIPS / experimental-FIPS builds) for
-// seed-format keys, which the standard d2i_PrivateKey handles natively there. der2EvpPrivateKey
-// calls this as a fallover after d2i_PrivateKey fails.
+//
+// This is a stand-in for mainline AWS-LC's decoder, not an improvement on it: it deliberately mirrors
+// EVP_parse_private_key (crypto/evp_extra/evp_asn1.c) plus kem_priv_decode
+// (crypto/evp_extra/p_kem_asn1.c) accept-for-accept and reject-for-reject, so that deleting this
+// function once AWS-LC-FIPS decodes ML-KEM natively is a behavioral no-op. Two consequences worth
+// spelling out, both matching AWS-LC:
+//   - the "both" CHOICE (SEQUENCE { seed, expandedKey }) is rejected, even though it is well-formed
+//     RFC 9935 and is what BouncyCastle's ML-KEM getEncoded() emits by default. AWS-LC has not
+//     implemented it in any flavor, mainline included ("Case 3 ... not implemented yet"), so
+//     accepting it here would make ACCP quietly lose the ability on the FIPS bump;
+//   - trailing bytes after the CHOICE inside the privateKey OCTET STRING are ignored rather than
+//     rejected, because kem_priv_decode does not check CBS_len(key) after extracting the CHOICE.
+// "Mainline" means AWS-LC main, the version whose decoder this is destined to be replaced by. Older
+// AWS-LC releases are laxer about the two optional trailing fields: the non-FIPS build's v1.72.0
+// spells kAttributesTag without CBS_ASN1_CONSTRUCTED and has no trailing-data check inside the
+// PrivateKeyInfo SEQUENCE, so it accepts a few encodings this parser rejects. Following main rather
+// than the pinned release is the point; do not relax these checks to match v1.72.0.
+// Returns nullptr for non-ML-KEM inputs. der2EvpPrivateKey calls this as a fallover after
+// d2i_PrivateKey fails, so in non-FIPS / experimental-FIPS builds only inputs AWS-LC itself rejected
+// reach it, and it rejects those too.
 static EVP_PKEY* parseMLKEMPrivateKey(const unsigned char* der, const int derLen)
 {
     CBS cbs, pkcs8, algorithm, oid, priv;
@@ -319,8 +347,8 @@ static EVP_PKEY* parseMLKEMPrivateKey(const unsigned char* der, const int derLen
     if (!isMLKEMNid(nid)) {
         return nullptr;
     }
-    // The ML-KEM AlgorithmIdentifier has no parameters. The PrivateKey OCTET STRING wraps either the
-    // expanded key (OCTET STRING) or, in seed format, a [0] IMPLICIT OCTET STRING seed.
+    // The ML-KEM AlgorithmIdentifier has no parameters. The PrivateKey OCTET STRING wraps one of the
+    // CHOICE alternatives, dispatched on its tag below.
     // spotless:off
     if (CBS_len(&algorithm) != 0 ||
         !CBS_get_asn1(&pkcs8, &priv, CBS_ASN1_OCTETSTRING)) {
@@ -328,45 +356,43 @@ static EVP_PKEY* parseMLKEMPrivateKey(const unsigned char* der, const int derLen
     }
     // spotless:on
     // attributes [0] Attributes OPTIONAL. Ignored, exactly as EVP_parse_private_key ignores it.
-    if (!skipOptionalContextSpecificField(&pkcs8, 0)) {
+    if (!skipOptionalField(&pkcs8, MLKEM_PKCS8_ATTRIBUTES_TAG)) {
         return nullptr;
     }
     // publicKey [1] BIT STRING OPTIONAL, permitted only in a version-1 OneAsymmetricKey. Ignored: the
-    // non-FIPS d2i expanded path also reconstructs ML-KEM keys from the secret key alone, so honoring
-    // the public key here would make the two paths disagree.
-    const bool has_public_key = CBS_peek_asn1_tag(&pkcs8, CBS_ASN1_CONTEXT_SPECIFIC | CBS_ASN1_CONSTRUCTED | 1)
-        || CBS_peek_asn1_tag(&pkcs8, CBS_ASN1_CONTEXT_SPECIFIC | 1);
-    if (has_public_key && (version != 1 || !skipOptionalContextSpecificField(&pkcs8, 1))) {
+    // expanded CHOICE reconstructs ML-KEM keys from the secret key alone in AWS-LC too, so honoring the
+    // public key here would make the two disagree.
+    if (CBS_peek_asn1_tag(&pkcs8, MLKEM_PKCS8_PUBLIC_KEY_TAG)
+        && (version != 1 || !skipOptionalField(&pkcs8, MLKEM_PKCS8_PUBLIC_KEY_TAG))) {
         return nullptr;
     }
-    // Anything left over is not part of the grammar, so fail obviously rather than ignore it.
+    // Trailing data within the SEQUENCE, rejected as mainline EVP_parse_private_key rejects it.
     if (CBS_len(&pkcs8) != 0) {
         return nullptr;
     }
-    if (CBS_peek_asn1_tag(&priv, CBS_ASN1_OCTETSTRING)) {
-        // Expanded format. EVP_PKEY_kem_new_raw_secret_key validates the length against the parameter
-        // set's secret_key_len and returns NULL otherwise (surfaced by der2EvpPrivateKey as a decode
-        // failure).
-        CBS expanded;
-        if (!CBS_get_asn1(&priv, &expanded, CBS_ASN1_OCTETSTRING) || CBS_len(&priv) != 0) {
-            return nullptr;
-        }
-        return EVP_PKEY_kem_new_raw_secret_key(nid, CBS_data(&expanded), CBS_len(&expanded));
-    }
-#if defined(FIPS_BUILD) && !defined(EXPERIMENTAL_FIPS_BUILD)
-    // Seed format ([0] IMPLICIT OCTET STRING, the raw d || z keygen seed). AWS-LC-FIPS 3.1.0 cannot
-    // d2i a seed-format ML-KEM key, so expand the seed into a full key. (Serializing back to seed is
-    // still impossible in regular FIPS -- getEncoded() emits the expanded form.)
-    // See RFC 9935 Section 6 (Private Key Format): https://datatracker.ietf.org/doc/html/rfc9935#section-6
-    // TODO [AWS-LC-FIPS 4.x]: drop this seed branch once the FIPS module can d2i seed-format ML-KEM keys.
     if (CBS_peek_asn1_tag(&priv, CBS_ASN1_CONTEXT_SPECIFIC | 0)) {
+        // seed CHOICE ([0] IMPLICIT OCTET STRING, the raw d || z keygen seed). AWS-LC-FIPS 3.1.0 cannot
+        // d2i a seed-format ML-KEM key, so expand the seed into a full key. (Serializing back to seed is
+        // still impossible in regular FIPS -- getEncoded() emits the expanded form.)
+        // TODO [AWS-LC-FIPS 4.x]: drop this seed branch once the FIPS module can d2i seed-format ML-KEM keys.
         CBS seed;
-        if (!CBS_get_asn1(&priv, &seed, CBS_ASN1_CONTEXT_SPECIFIC | 0) || CBS_len(&priv) != 0) {
+        if (!CBS_get_asn1(&priv, &seed, CBS_ASN1_CONTEXT_SPECIFIC | 0)) {
             return nullptr;
         }
         return mlkemKeyFromSeed(nid, CBS_data(&seed), CBS_len(&seed));
     }
-#endif // defined(FIPS_BUILD) && !defined(EXPERIMENTAL_FIPS_BUILD)
+    if (CBS_peek_asn1_tag(&priv, CBS_ASN1_OCTETSTRING)) {
+        // expandedKey CHOICE. EVP_PKEY_kem_new_raw_secret_key validates the length against the parameter
+        // set's secret_key_len and returns NULL otherwise (surfaced by der2EvpPrivateKey as a decode
+        // failure), which is the same check kem_priv_decode makes before KEM_KEY_set_raw_secret_key.
+        CBS expanded;
+        if (!CBS_get_asn1(&priv, &expanded, CBS_ASN1_OCTETSTRING)) {
+            return nullptr;
+        }
+        return EVP_PKEY_kem_new_raw_secret_key(nid, CBS_data(&expanded), CBS_len(&expanded));
+    }
+    // Any other tag, the "both" CHOICE included. See the note above about staying reject-for-reject
+    // with kem_priv_decode.
     return nullptr;
 }
 

--- a/csrc/keyutils.cpp
+++ b/csrc/keyutils.cpp
@@ -152,14 +152,8 @@ EVP_PKEY* der2EvpPrivateKey(const unsigned char* der,
 // True when |nid| identifies one of the three ML-KEM parameter sets.
 static bool isMLKEMNid(int nid) { return nid == NID_MLKEM512 || nid == NID_MLKEM768 || nid == NID_MLKEM1024; }
 
-// Maps an ML-KEM raw public-key length (FIPS 203, Table 3) to its NID, or NID_undef.
-//
-// NOTE: this mapping is only unambiguous for ML-KEM keys. AWS-LC registers legacy Kyber-R3 under the
-// same EVP_PKEY_KEM type with byte-for-byte identical key lengths, so a length alone cannot tell the
-// two families apart. Java_..._EvpKey_encodePublicKey tries i2d_PUBKEY first and only falls back to
-// encodeMLKEMPublicKey when the library cannot encode the key at all, which for EVP_PKEY_KEM only
-// happens in regular FIPS, where no non-ML-KEM KEM codec exists. encodeExpandedMLKEMPrivateKey has no
-// such caller-side guarantee and cross-checks against mlkemNidForSecretKeyLen instead.
+// Maps an ML-KEM raw public-key length (FIPS 203, Table 3) to its NID, or NID_undef. Kyber keys
+// share the same key lengths, but are not considered as Kyber is fully deprecated.
 static int mlkemNidForPublicKeyLen(size_t raw_len)
 {
     switch (raw_len) {
@@ -587,12 +581,6 @@ size_t encodeExpandedMLKEMPrivateKey(const EVP_PKEY* key, uint8_t** out)
     CHECK_OPENSSL(out);
     size_t raw_len = 0;
     CHECK_OPENSSL(EVP_PKEY_get_raw_private_key(key, nullptr, &raw_len));
-    // Neither length identifies an ML-KEM parameter set on its own (see mlkemNidForPublicKeyLen), and
-    // unlike encodeMLKEMPublicKey this has no caller-side guarantee that the key is ML-KEM at all:
-    // MlKemUtils.expandPrivateKey reaches it in every build. Requiring both lengths to name the same
-    // parameter set refuses a KEM key of another family rather than relabeling it with an ML-KEM OID.
-    // Querying the public-key length is safe even for keys holding no public key, since
-    // kem_get_pub_raw reports the parameter set's length before it looks at the key's own public key.
     size_t pub_len = 0;
     CHECK_OPENSSL(EVP_PKEY_get_raw_public_key(key, nullptr, &pub_len));
     int nid = mlkemNidForSecretKeyLen(raw_len);

--- a/csrc/keyutils.cpp
+++ b/csrc/keyutils.cpp
@@ -7,12 +7,12 @@
 #include <openssl/ec.h>
 #include <openssl/err.h>
 #include <openssl/evp.h>
-// EVP_PKEY_keygen_deterministic (seed -> ML-KEM key) lives in this experimental header. Every AWS-LC
-// flavor ACCP builds against declares it with the same signature, so the seed decode below is compiled
-// unconditionally rather than only for regular FIPS: one parser for all flavors cannot drift per build,
-// and the grammar it accepts stays a single thing to reason about.
+#if defined(FIPS_BUILD) && !defined(EXPERIMENTAL_FIPS_BUILD)
+// EVP_PKEY_keygen_deterministic lives in this experimental header, which carries no API-stability
+// guarantee. Only regular FIPS needs it, so keep it out of the builds that cannot reach it.
 // TODO [AWS-LC-FIPS 4.x]: drop this experimental include once the FIPS module can d2i seed-format ML-KEM keys.
 #include <openssl/experimental/kem_deterministic_api.h>
+#endif
 #include <openssl/obj.h>
 #include <openssl/pkcs8.h>
 #include <openssl/rsa.h>
@@ -45,15 +45,10 @@ EVP_PKEY* der2EvpPrivateKey(const unsigned char* der,
     EVP_PKEY* result = d2i_PrivateKey(evpType, NULL, &der_mutable_ptr, derLen);
 
     // Fallover for ML-KEM PKCS8: AWS-LC-FIPS 3.1.0 has no priv_decode for ML-KEM, so d2i_PrivateKey
-    // fails on every ML-KEM private key there. Only when the caller asked for a KEM key and
-    // d2i_PrivateKey produced nothing do we hand-roll the parse via the raw APIs. Each CHOICE
-    // reconstructs the key exactly the way AWS-LC's decoder does (identically in v1.72.0 and v5.0.0),
-    // so the two agree per CHOICE:
-    //   - expandedKey sets only the raw secret key (KEM_KEY_set_raw_secret_key), leaving the public key
-    //     unpopulated, so getPublicKey().getEncoded() fails for such a key in every build;
-    //   - seed derives the whole key pair from the seed, public key included.
-    // parseMLKEMPrivateKey returns nullptr for inputs it cannot handle, which in a non-FIPS build is
-    // everything: it accepts nothing d2i_PrivateKey has not already accepted there.
+    // fails on every ML-KEM private key there. Each CHOICE reconstructs the key the way AWS-LC's own
+    // decoder does: expandedKey sets only the raw secret key and leaves the public key unpopulated,
+    // while seed derives the whole key pair. parseMLKEMPrivateKey returns nullptr for anything it
+    // cannot handle.
     // TODO [AWS-LC-FIPS 4.x]: drop this raw-key decode path once the FIPS module supports d2i_PrivateKey for ML-KEM.
     if (result == nullptr && evpType == EVP_PKEY_KEM) {
         EVP_PKEY* mlkem = parseMLKEMPrivateKey(der, derLen);
@@ -160,14 +155,11 @@ static bool isMLKEMNid(int nid) { return nid == NID_MLKEM512 || nid == NID_MLKEM
 // Maps an ML-KEM raw public-key length (FIPS 203, Table 3) to its NID, or NID_undef.
 //
 // NOTE: this mapping is only unambiguous for ML-KEM keys. AWS-LC registers legacy Kyber-R3 under the
-// same EVP_PKEY_KEM type (see KEM_find_kem_by_nid), and Kyber-512/768/1024-R3 have byte-for-byte the
-// same public- and secret-key lengths as ML-KEM-512/768/1024, so a length alone cannot tell the two
-// families apart. Callers must therefore only reach this helper for keys the library itself could not
-// encode: Java_..._EvpKey_encodePublicKey tries i2d_PUBKEY first, and encodeExpandedMLKEMPrivateKey is
-// only reached after EVP_marshal_private_key fails. Both of those only fail for EVP_PKEY_KEM in
-// regular FIPS, where AWS-LC-FIPS 3.1.0 supplies no pub_encode/pub_decode/priv_encode/priv_decode at
-// all -- so the only ML-KEM codecs in play are the ones in this file, which key off the OID and reject
-// every non-ML-KEM OID, and ACCP itself never generates anything but ML-KEM.
+// same EVP_PKEY_KEM type with byte-for-byte identical key lengths, so a length alone cannot tell the
+// two families apart. Java_..._EvpKey_encodePublicKey tries i2d_PUBKEY first and only falls back to
+// encodeMLKEMPublicKey when the library cannot encode the key at all, which for EVP_PKEY_KEM only
+// happens in regular FIPS, where no non-ML-KEM KEM codec exists. encodeExpandedMLKEMPrivateKey has no
+// such caller-side guarantee and cross-checks against mlkemNidForSecretKeyLen instead.
 static int mlkemNidForPublicKeyLen(size_t raw_len)
 {
     switch (raw_len) {
@@ -176,6 +168,22 @@ static int mlkemNidForPublicKeyLen(size_t raw_len)
     case 1184:
         return NID_MLKEM768;
     case 1568:
+        return NID_MLKEM1024;
+    default:
+        return NID_undef;
+    }
+}
+
+// Maps an ML-KEM raw secret-key length (FIPS 203, Table 3) to its NID, or NID_undef. Same ambiguity
+// caveat as mlkemNidForPublicKeyLen above; the two are only conclusive together.
+static int mlkemNidForSecretKeyLen(size_t raw_len)
+{
+    switch (raw_len) {
+    case 1632:
+        return NID_MLKEM512;
+    case 2400:
+        return NID_MLKEM768;
+    case 3168:
         return NID_MLKEM1024;
     default:
         return NID_undef;
@@ -255,20 +263,20 @@ static EVP_PKEY* parseMLKEMPublicKey(const unsigned char* der, const int derLen)
     return EVP_PKEY_kem_new_raw_public_key(nid, CBS_data(&bit_string), CBS_len(&bit_string));
 }
 
+// Expands a raw ML-KEM keygen seed (d || z) into a full EVP_PKEY, public key included, the same way
+// AWS-LC's KEM_KEY_set_raw_keypair_from_seed does. Returns nullptr on failure, which surfaces out of
+// der2EvpPrivateKey as a decode failure.
+//
+// Only regular FIPS has any use for this; every other flavor decodes the seed CHOICE inside
+// d2i_PrivateKey and never consults the fallover for a seed, so those builds get the stub below.
+// TODO [AWS-LC-FIPS 4.x]: drop this seed-expansion helper once the FIPS module can d2i seed-format ML-KEM keys.
+#if defined(FIPS_BUILD) && !defined(EXPERIMENTAL_FIPS_BUILD)
 // Every ML-KEM parameter set uses the same 64-byte keygen seed, d || z (FIPS 203, Algorithm 16).
 static const size_t MLKEM_SEED_LEN = 64;
 
-// Expands a raw ML-KEM keygen seed (d || z) into a full EVP_PKEY (public key included) via
-// deterministic keygen, the same way AWS-LC's KEM_KEY_set_raw_keypair_from_seed does. Returns nullptr
-// on failure, which makes the caller's parse fail and surfaces out of der2EvpPrivateKey as a decode
-// failure. Only regular FIPS reaches this, because AWS-LC-FIPS 3.1.0's ASN.1 method cannot decode a
-// seed-format key and every other flavor decodes it inside d2i_PrivateKey.
-// TODO [AWS-LC-FIPS 4.x]: drop this seed-expansion helper once the FIPS module can d2i seed-format ML-KEM keys.
 static EVP_PKEY* mlkemKeyFromSeed(int nid, const uint8_t* seed, size_t seed_len)
 {
-    // AWS-LC's kem_priv_decode length-checks the seed against the parameter set's keygen_seed_len
-    // before expanding it, so check it here too rather than relying on the experimental keygen API's
-    // internal validation.
+    // Length-check the seed here rather than relying on the experimental keygen API to do it.
     if (seed_len != MLKEM_SEED_LEN) {
         return nullptr;
     }
@@ -283,19 +291,22 @@ static EVP_PKEY* mlkemKeyFromSeed(int nid, const uint8_t* seed, size_t seed_len)
     }
     return pkey;
 }
+#else
+// Unreachable here: d2i_PrivateKey decodes the seed CHOICE itself in this build, so the fallover only
+// ever sees inputs AWS-LC already rejected.
+static EVP_PKEY* mlkemKeyFromSeed(int, const uint8_t*, size_t) { return nullptr; }
+#endif
 
 // Hand-rolled PKCS8 private-key path for ML-KEM. The tag constants and skipOptionalField below exist
 // only to serve parseMLKEMPrivateKey, so all three are deleted together, along with the seed branch
 // and mlkemKeyFromSeed above it.
 // TODO [AWS-LC-FIPS 4.x]: drop this hand-rolled PKCS8 path once the FIPS module implements priv_decode for ML-KEM.
 
-// Tags of the two optional PrivateKeyInfo / OneAsymmetricKey trailing fields, spelled exactly as
-// AWS-LC v5.0.0's EVP_parse_private_key spells them (kAttributesTag and kPublicKeyTag in
-// evp_asn1.c): attributes is recognized only in its constructed form and publicKey only in its
-// primitive form. That asymmetry is what DER requires of each, not an inconsistency: attributes is
-// a SET, which is always constructed, while publicKey is an IMPLICIT-tagged BIT STRING, which is
-// primitive. Deliberately not lenient about the other form of either tag -- see
-// parseMLKEMPrivateKey.
+// Tags of the two optional PrivateKeyInfo / OneAsymmetricKey trailing fields, spelled as AWS-LC
+// v5.0.0's EVP_parse_private_key spells them (kAttributesTag and kPublicKeyTag in evp_asn1.c).
+// attributes is recognized only constructed and publicKey only primitive, which is what DER requires
+// of a SET and of an IMPLICIT-tagged BIT STRING respectively; the other form of either tag is
+// deliberately not tolerated.
 static const unsigned MLKEM_PKCS8_ATTRIBUTES_TAG = CBS_ASN1_CONTEXT_SPECIFIC | CBS_ASN1_CONSTRUCTED | 0;
 static const unsigned MLKEM_PKCS8_PUBLIC_KEY_TAG = CBS_ASN1_CONTEXT_SPECIFIC | 1;
 
@@ -315,48 +326,33 @@ static bool skipOptionalField(CBS* cbs, unsigned tag)
 // https://datatracker.ietf.org/doc/html/rfc9935#section-6
 // https://datatracker.ietf.org/doc/html/rfc9935#appendix-A
 //
-// This is a stand-in for AWS-LC's decoder, not an improvement on it: it deliberately mirrors
-// EVP_parse_private_key (crypto/evp_extra/evp_asn1.c) plus kem_priv_decode
-// (crypto/evp_extra/p_kem_asn1.c) accept-for-accept and reject-for-reject, so that deleting this
-// function once AWS-LC-FIPS decodes ML-KEM natively is a behavioral no-op. Two consequences worth
-// spelling out, both matching AWS-LC:
-//   - the "both" CHOICE (SEQUENCE { seed, expandedKey }) is rejected, even though it is well-formed
-//     RFC 9935 and is what BouncyCastle's ML-KEM getEncoded() emits by default. AWS-LC has not
-//     implemented it in any flavor ("Case 3 ... not implemented yet"), so accepting it here would
-//     make ACCP quietly lose the ability on the FIPS bump;
-//   - trailing bytes after the CHOICE inside the privateKey OCTET STRING are ignored rather than
-//     rejected, because kem_priv_decode does not check CBS_len(key) after extracting the CHOICE.
+// A stand-in for AWS-LC's decoder, tracking EVP_parse_private_key (crypto/evp_extra/evp_asn1.c) and
+// kem_priv_decode (crypto/evp_extra/p_kem_asn1.c) closely so that deleting this function once
+// AWS-LC-FIPS decodes ML-KEM natively is as close to a no-op as possible. The version tracked is
+// AWS-LC v5.0.0, the decoder this is destined to be replaced by, NOT the v1.72.0 that build.gradle
+// pins for non-FIPS and experimental-FIPS builds, which spells the optional-field tags differently.
+// Do not relax these checks to match v1.72.0.
 //
-// The version mirrored is AWS-LC v5.0.0, the decoder this function is destined to be replaced by,
-// and NOT the v1.72.0 that build.gradle pins for non-FIPS and experimental-FIPS builds. v1.72.0's
-// EVP_parse_private_key is laxer about the two optional trailing fields: it spells kAttributesTag
-// without CBS_ASN1_CONSTRUCTED, consumes the attributes field from the wrong CBS, and never checks
-// for trailing data inside the PrivateKeyInfo SEQUENCE, so it silently ignores encodings this parser
-// rejects (a constructed [1] where a primitive [1] publicKey belongs, for instance). Mirroring where
-// ACCP is going rather than where it is pinned is the point; do not relax these checks to match
-// v1.72.0.
+// Two deliberate departures from AWS-LC: the "both" CHOICE is rejected, since AWS-LC has not
+// implemented it in any flavor and accepting it here would mean quietly withdrawing support on the
+// FIPS bump; and trailing bytes after the CHOICE inside the privateKey OCTET STRING are rejected,
+// where kem_priv_decode ignores them. Ignoring them would let caller-controlled data ride along
+// inside an encoding the provider calls well-formed, and would stop getEncoded() round-tripping.
 //
-// The resulting divergence is bounded and one-directional: everything this function accepts,
-// v1.72.0 accepts too, so it is strictly the stricter of the two and the fallover can never widen
-// what a non-FIPS build accepts. It only ever shows up as regular FIPS rejecting a malformed
-// encoding that the other builds ignore, and it disappears once the pinned mainline tag reaches
-// v5.x. The one intended behavioral difference between the builds is serialization, not parsing:
-// see the seed CHOICE below.
-//
-// AWS-LC-FIPS 3.1.0 has no ML-KEM ASN.1 method at all, so in regular FIPS this function is the
-// entire decoder. Returns nullptr for non-ML-KEM inputs. der2EvpPrivateKey calls this as a fallover
-// after d2i_PrivateKey fails, so in non-FIPS / experimental-FIPS builds only inputs AWS-LC itself
-// rejected reach it, and it rejects those too.
+// Neither this grammar nor v1.72.0's contains the other, so the flavors are not strictly ordered.
+// That is safe because of the fallover structure in der2EvpPrivateKey: outside regular FIPS a key is
+// accepted if either decoder accepts it, so this can only widen what those builds accept, while in
+// regular FIPS it is the only decoder. The divergence disappears once the pinned mainline tag reaches
+// v5.x. The one intended behavioral difference between builds is serialization, not parsing: see the
+// seed CHOICE below.
 static EVP_PKEY* parseMLKEMPrivateKey(const unsigned char* der, const int derLen)
 {
     CBS cbs, pkcs8, algorithm, oid, priv;
     uint64_t version = 0;
     CBS_init(&cbs, der, derLen);
     // The outer structure is a PrivateKeyInfo (RFC 5208, version 0) or a OneAsymmetricKey (RFC 5958,
-    // version 1). Accept both versions, matching EVP_parse_private_key, so this regular-FIPS fallover
-    // parses everything the non-FIPS d2i_PrivateKey path parses. Rejecting version 1 here would make
-    // ACCP refuse OneAsymmetricKey encodings that other providers (and ACCP's own non-FIPS builds)
-    // emit and accept.
+    // version 1). Both are accepted, matching EVP_parse_private_key, so this regular-FIPS fallover
+    // parses everything the d2i_PrivateKey path parses elsewhere.
     // spotless:off
     if (!CBS_get_asn1(&cbs, &pkcs8, CBS_ASN1_SEQUENCE) || CBS_len(&cbs) != 0 ||
         !CBS_get_asn1_uint64(&pkcs8, &version) || version > 1 ||
@@ -393,17 +389,15 @@ static EVP_PKEY* parseMLKEMPrivateKey(const unsigned char* der, const int derLen
         return nullptr;
     }
     if (CBS_peek_asn1_tag(&priv, CBS_ASN1_CONTEXT_SPECIFIC | 0)) {
-        // seed CHOICE ([0] IMPLICIT OCTET STRING, the raw d || z keygen seed). AWS-LC-FIPS 3.1.0 cannot
-        // d2i a seed-format ML-KEM key, so expand the seed into a full key. The seed itself is then
-        // dropped, and this is the one intended FIPS-vs-non-FIPS behavioral difference in ML-KEM key
-        // handling: mainline AWS-LC's KEM_KEY carries a seed field (v1.72.0 included) and re-emits the
-        // seed CHOICE from it, while AWS-LC-FIPS 3.1.0's KEM_KEY has no such field, so nothing can hold
-        // the seed and getEncoded() emits the expanded CHOICE in regular FIPS. Parsing is unaffected --
-        // both CHOICEs are accepted in every build. Documented in README.md under "Notable differences
-        // between ACCP and ACCP-FIPS".
+        // seed CHOICE ([0] IMPLICIT OCTET STRING, the raw d || z keygen seed), expanded into a full key.
+        // The seed itself is dropped: AWS-LC-FIPS 3.1.0's KEM_KEY has no field to retain it, so regular
+        // FIPS re-emits such a key in the expandedKey form. That is the one intended FIPS-vs-non-FIPS
+        // behavioral difference in ML-KEM key handling, and it affects serialization only -- both CHOICEs
+        // parse in every build. See README.md, "Notable differences between ACCP and ACCP-FIPS".
         // TODO [AWS-LC-FIPS 4.x]: drop this seed branch once the FIPS module can d2i seed-format ML-KEM keys.
         CBS seed;
-        if (!CBS_get_asn1(&priv, &seed, CBS_ASN1_CONTEXT_SPECIFIC | 0)) {
+        // The CHOICE has to be the entire content of the privateKey OCTET STRING.
+        if (!CBS_get_asn1(&priv, &seed, CBS_ASN1_CONTEXT_SPECIFIC | 0) || CBS_len(&priv) != 0) {
             return nullptr;
         }
         return mlkemKeyFromSeed(nid, CBS_data(&seed), CBS_len(&seed));
@@ -413,13 +407,13 @@ static EVP_PKEY* parseMLKEMPrivateKey(const unsigned char* der, const int derLen
         // set's secret_key_len and returns NULL otherwise (surfaced by der2EvpPrivateKey as a decode
         // failure), which is the same check kem_priv_decode makes before KEM_KEY_set_raw_secret_key.
         CBS expanded;
-        if (!CBS_get_asn1(&priv, &expanded, CBS_ASN1_OCTETSTRING)) {
+        // As above, nothing may follow the CHOICE inside the privateKey OCTET STRING.
+        if (!CBS_get_asn1(&priv, &expanded, CBS_ASN1_OCTETSTRING) || CBS_len(&priv) != 0) {
             return nullptr;
         }
         return EVP_PKEY_kem_new_raw_secret_key(nid, CBS_data(&expanded), CBS_len(&expanded));
     }
-    // Any other tag, the "both" CHOICE included. See the note above about staying reject-for-reject
-    // with kem_priv_decode.
+    // Any other tag, the "both" CHOICE included; see the note above the function.
     return nullptr;
 }
 
@@ -593,23 +587,17 @@ size_t encodeExpandedMLKEMPrivateKey(const EVP_PKEY* key, uint8_t** out)
     CHECK_OPENSSL(out);
     size_t raw_len = 0;
     CHECK_OPENSSL(EVP_PKEY_get_raw_private_key(key, nullptr, &raw_len));
-    int nid = NID_undef;
-    // See FIPS 203, Table 3: secret_key_len per parameter set. As with mlkemNidForPublicKeyLen above,
-    // these lengths are shared with legacy Kyber-R3, so this switch is only sound because the caller
-    // reaches it exclusively after EVP_marshal_private_key has failed -- which for EVP_PKEY_KEM only
-    // happens in regular FIPS, where no non-ML-KEM KEM key can exist.
-    switch (raw_len) {
-    case 1632:
-        nid = NID_MLKEM512;
-        break;
-    case 2400:
-        nid = NID_MLKEM768;
-        break;
-    case 3168:
-        nid = NID_MLKEM1024;
-        break;
-    default:
-        throw_java_ex(EX_ILLEGAL_ARGUMENT, "Invalid ML-KEM secret key size");
+    // Neither length identifies an ML-KEM parameter set on its own (see mlkemNidForPublicKeyLen), and
+    // unlike encodeMLKEMPublicKey this has no caller-side guarantee that the key is ML-KEM at all:
+    // MlKemUtils.expandPrivateKey reaches it in every build. Requiring both lengths to name the same
+    // parameter set refuses a KEM key of another family rather than relabeling it with an ML-KEM OID.
+    // Querying the public-key length is safe even for keys holding no public key, since
+    // kem_get_pub_raw reports the parameter set's length before it looks at the key's own public key.
+    size_t pub_len = 0;
+    CHECK_OPENSSL(EVP_PKEY_get_raw_public_key(key, nullptr, &pub_len));
+    int nid = mlkemNidForSecretKeyLen(raw_len);
+    if (nid == NID_undef || nid != mlkemNidForPublicKeyLen(pub_len)) {
+        throw_java_ex(EX_ILLEGAL_ARGUMENT, "Not an ML-KEM private key");
     }
     OPENSSL_buffer_auto raw_expanded(raw_len);
     // OPENSSL_buffer_auto does not check its own allocation, and the next call memcpy's into it.

--- a/csrc/keyutils.cpp
+++ b/csrc/keyutils.cpp
@@ -46,7 +46,8 @@ EVP_PKEY* der2EvpPrivateKey(const unsigned char* der,
     // Fallover for ML-KEM PKCS8: AWS-LC-FIPS 3.1.0 has no priv_decode for ML-KEM, so d2i_PrivateKey
     // fails on every ML-KEM private key there. Only when the caller asked for a KEM key and
     // d2i_PrivateKey produced nothing do we hand-roll the parse via the raw APIs. Each CHOICE
-    // reconstructs the key exactly the way mainline AWS-LC's decoder does, so the two agree per CHOICE:
+    // reconstructs the key exactly the way AWS-LC's decoder does (identically in v1.72.0 and v5.0.0),
+    // so the two agree per CHOICE:
     //   - expandedKey sets only the raw secret key (KEM_KEY_set_raw_secret_key), leaving the public key
     //     unpopulated, so getPublicKey().getEncoded() fails for such a key in every build;
     //   - seed derives the whole key pair from the seed, public key included.
@@ -283,9 +284,11 @@ static EVP_PKEY* mlkemKeyFromSeed(int nid, const uint8_t* seed, size_t seed_len)
 }
 
 // Tags of the two optional PrivateKeyInfo / OneAsymmetricKey trailing fields, spelled exactly as
-// mainline AWS-LC's EVP_parse_private_key spells them (kAttributesTag and kPublicKeyTag in
+// AWS-LC v5.0.0's EVP_parse_private_key spells them (kAttributesTag and kPublicKeyTag in
 // evp_asn1.c): attributes is recognized only in its constructed form and publicKey only in its
-// primitive form. Deliberately not lenient about the other form of either tag -- see
+// primitive form. That asymmetry is what DER requires of each, not an inconsistency: attributes is
+// a SET, which is always constructed, while publicKey is an IMPLICIT-tagged BIT STRING, which is
+// primitive. Deliberately not lenient about the other form of either tag -- see
 // parseMLKEMPrivateKey.
 static const unsigned MLKEM_PKCS8_ATTRIBUTES_TAG = CBS_ASN1_CONTEXT_SPECIFIC | CBS_ASN1_CONSTRUCTED | 0;
 static const unsigned MLKEM_PKCS8_PUBLIC_KEY_TAG = CBS_ASN1_CONTEXT_SPECIFIC | 1;
@@ -306,23 +309,38 @@ static bool skipOptionalField(CBS* cbs, unsigned tag)
 // https://datatracker.ietf.org/doc/html/rfc9935#section-6
 // https://datatracker.ietf.org/doc/html/rfc9935#appendix-A
 //
-// This is a stand-in for mainline AWS-LC's decoder, not an improvement on it: it deliberately mirrors
+// This is a stand-in for AWS-LC's decoder, not an improvement on it: it deliberately mirrors
 // EVP_parse_private_key (crypto/evp_extra/evp_asn1.c) plus kem_priv_decode
 // (crypto/evp_extra/p_kem_asn1.c) accept-for-accept and reject-for-reject, so that deleting this
 // function once AWS-LC-FIPS decodes ML-KEM natively is a behavioral no-op. Two consequences worth
 // spelling out, both matching AWS-LC:
 //   - the "both" CHOICE (SEQUENCE { seed, expandedKey }) is rejected, even though it is well-formed
 //     RFC 9935 and is what BouncyCastle's ML-KEM getEncoded() emits by default. AWS-LC has not
-//     implemented it in any flavor, mainline included ("Case 3 ... not implemented yet"), so
-//     accepting it here would make ACCP quietly lose the ability on the FIPS bump;
+//     implemented it in any flavor ("Case 3 ... not implemented yet"), so accepting it here would
+//     make ACCP quietly lose the ability on the FIPS bump;
 //   - trailing bytes after the CHOICE inside the privateKey OCTET STRING are ignored rather than
 //     rejected, because kem_priv_decode does not check CBS_len(key) after extracting the CHOICE.
-// The reference is the AWS-LC that non-FIPS and experimental-FIPS builds link, v5.0.0, whose
-// EVP_parse_private_key and kem_priv_decode are the two functions cited above. AWS-LC-FIPS 3.1.0 has
-// no ML-KEM ASN.1 method at all, so in regular FIPS this function is the entire decoder.
-// Returns nullptr for non-ML-KEM inputs. der2EvpPrivateKey calls this as a fallover after
-// d2i_PrivateKey fails, so in non-FIPS / experimental-FIPS builds only inputs AWS-LC itself rejected
-// reach it, and it rejects those too.
+//
+// The version mirrored is AWS-LC v5.0.0, the decoder this function is destined to be replaced by,
+// and NOT the v1.72.0 that build.gradle pins for non-FIPS and experimental-FIPS builds. v1.72.0's
+// EVP_parse_private_key is laxer about the two optional trailing fields: it spells kAttributesTag
+// without CBS_ASN1_CONSTRUCTED, consumes the attributes field from the wrong CBS, and never checks
+// for trailing data inside the PrivateKeyInfo SEQUENCE, so it silently ignores encodings this parser
+// rejects (a constructed [1] where a primitive [1] publicKey belongs, for instance). Mirroring where
+// ACCP is going rather than where it is pinned is the point; do not relax these checks to match
+// v1.72.0.
+//
+// The resulting divergence is bounded and one-directional: everything this function accepts,
+// v1.72.0 accepts too, so it is strictly the stricter of the two and the fallover can never widen
+// what a non-FIPS build accepts. It only ever shows up as regular FIPS rejecting a malformed
+// encoding that the other builds ignore, and it disappears once the pinned mainline tag reaches
+// v5.x. The one intended behavioral difference between the builds is serialization, not parsing:
+// see the seed CHOICE below.
+//
+// AWS-LC-FIPS 3.1.0 has no ML-KEM ASN.1 method at all, so in regular FIPS this function is the
+// entire decoder. Returns nullptr for non-ML-KEM inputs. der2EvpPrivateKey calls this as a fallover
+// after d2i_PrivateKey fails, so in non-FIPS / experimental-FIPS builds only inputs AWS-LC itself
+// rejected reach it, and it rejects those too.
 static EVP_PKEY* parseMLKEMPrivateKey(const unsigned char* der, const int derLen)
 {
     CBS cbs, pkcs8, algorithm, oid, priv;
@@ -370,9 +388,13 @@ static EVP_PKEY* parseMLKEMPrivateKey(const unsigned char* der, const int derLen
     }
     if (CBS_peek_asn1_tag(&priv, CBS_ASN1_CONTEXT_SPECIFIC | 0)) {
         // seed CHOICE ([0] IMPLICIT OCTET STRING, the raw d || z keygen seed). AWS-LC-FIPS 3.1.0 cannot
-        // d2i a seed-format ML-KEM key, so expand the seed into a full key. The seed itself is dropped:
-        // AWS-LC-FIPS 3.1.0's KEM_KEY has no seed field (v5.0.0 added one), so nothing can hold it and
-        // getEncoded() emits the expanded CHOICE in regular FIPS.
+        // d2i a seed-format ML-KEM key, so expand the seed into a full key. The seed itself is then
+        // dropped, and this is the one intended FIPS-vs-non-FIPS behavioral difference in ML-KEM key
+        // handling: mainline AWS-LC's KEM_KEY carries a seed field (v1.72.0 included) and re-emits the
+        // seed CHOICE from it, while AWS-LC-FIPS 3.1.0's KEM_KEY has no such field, so nothing can hold
+        // the seed and getEncoded() emits the expanded CHOICE in regular FIPS. Parsing is unaffected --
+        // both CHOICEs are accepted in every build. Documented in README.md under "Notable differences
+        // between ACCP and ACCP-FIPS".
         // TODO [AWS-LC-FIPS 4.x]: drop this seed branch once the FIPS module can d2i seed-format ML-KEM keys.
         CBS seed;
         if (!CBS_get_asn1(&priv, &seed, CBS_ASN1_CONTEXT_SPECIFIC | 0)) {

--- a/csrc/keyutils.cpp
+++ b/csrc/keyutils.cpp
@@ -24,6 +24,7 @@ namespace AmazonCorrettoCryptoProvider {
 // delegates to may queue an OpenSSL error when they reject a well-formed but invalid key.
 // der2EvpPrivateKey calls this as a fallover after d2i_PrivateKey fails. Defined below, next to
 // parseMLKEMPublicKey.
+// TODO [AWS-LC-FIPS 4.x]: drop this fallover parser once the FIPS module implements priv_decode for ML-KEM.
 static EVP_PKEY* parseMLKEMPrivateKey(const unsigned char* der, const int derLen);
 
 EVP_PKEY* der2EvpPrivateKey(const unsigned char* der,
@@ -282,6 +283,11 @@ static EVP_PKEY* mlkemKeyFromSeed(int nid, const uint8_t* seed, size_t seed_len)
     }
     return pkey;
 }
+
+// Hand-rolled PKCS8 private-key path for ML-KEM. The tag constants and skipOptionalField below exist
+// only to serve parseMLKEMPrivateKey, so all three are deleted together, along with the seed branch
+// and mlkemKeyFromSeed above it.
+// TODO [AWS-LC-FIPS 4.x]: drop this hand-rolled PKCS8 path once the FIPS module implements priv_decode for ML-KEM.
 
 // Tags of the two optional PrivateKeyInfo / OneAsymmetricKey trailing fields, spelled exactly as
 // AWS-LC v5.0.0's EVP_parse_private_key spells them (kAttributesTag and kPublicKeyTag in

--- a/csrc/keyutils.cpp
+++ b/csrc/keyutils.cpp
@@ -10,13 +10,20 @@
 #include <openssl/obj.h>
 #include <openssl/pkcs8.h>
 #include <openssl/rsa.h>
+#if defined(FIPS_BUILD) && !defined(EXPERIMENTAL_FIPS_BUILD)
+// EVP_PKEY_keygen_deterministic (seed -> ML-KEM key) lives in this experimental header. Only regular
+// FIPS needs it: AWS-LC-FIPS 3.1.0's ASN.1 method cannot decode seed-format ML-KEM private keys.
+// TODO [AWS-LC-FIPS 4.x]: drop this experimental include once the FIPS module can d2i seed-format ML-KEM keys.
+#include <openssl/experimental/kem_deterministic_api.h>
+#endif
 
 namespace AmazonCorrettoCryptoProvider {
 
-// Parses an ML-KEM expanded-format PKCS8 private key via its raw secret key. Returns nullptr for
-// inputs it does not handle; EVP_PKEY_kem_new_raw_secret_key may queue an OpenSSL error when it
-// rejects a well-formed but wrong-length key. der2EvpPrivateKey calls this as a fallover after
-// d2i_PrivateKey fails. Defined below, next to parseMLKEMPublicKey.
+// Parses a PKCS8 ML-KEM private key via the raw APIs (bypassing the ASN.1 method absent from
+// AWS-LC-FIPS 3.1.0). Returns nullptr for inputs it does not handle; the key-construction helpers it
+// delegates to may queue an OpenSSL error when they reject a well-formed but invalid key.
+// der2EvpPrivateKey calls this as a fallover after d2i_PrivateKey fails. Defined below, next to
+// parseMLKEMPublicKey.
 static EVP_PKEY* parseMLKEMPrivateKey(const unsigned char* der, const int derLen);
 
 EVP_PKEY* der2EvpPrivateKey(const unsigned char* der,
@@ -243,6 +250,26 @@ static EVP_PKEY* parseMLKEMPublicKey(const unsigned char* der, const int derLen)
     return EVP_PKEY_kem_new_raw_public_key(nid, CBS_data(&bit_string), CBS_len(&bit_string));
 }
 
+#if defined(FIPS_BUILD) && !defined(EXPERIMENTAL_FIPS_BUILD)
+// Expands a raw ML-KEM keygen seed (d || z) into a full EVP_PKEY via deterministic keygen. Used only
+// in regular FIPS, where AWS-LC-FIPS 3.1.0's ASN.1 method cannot decode seed-format ML-KEM private
+// keys. Returns nullptr on failure so parseMLKEMPrivateKey falls through to d2i_PrivateKey.
+// TODO [AWS-LC-FIPS 4.x]: drop this seed-expansion helper once the FIPS module can d2i seed-format ML-KEM keys.
+static EVP_PKEY* mlkemKeyFromSeed(int nid, const uint8_t* seed, size_t seed_len)
+{
+    EVP_PKEY_CTX_auto ctx = EVP_PKEY_CTX_auto::from(EVP_PKEY_CTX_new_id(EVP_PKEY_KEM, nullptr));
+    if (!ctx.isInitialized() || EVP_PKEY_CTX_kem_set_params(ctx, nid) != 1 || EVP_PKEY_keygen_init(ctx) != 1) {
+        return nullptr;
+    }
+    EVP_PKEY* pkey = nullptr;
+    size_t len = seed_len;
+    if (!EVP_PKEY_keygen_deterministic(ctx, &pkey, seed, &len)) {
+        return nullptr;
+    }
+    return pkey;
+}
+#endif // defined(FIPS_BUILD) && !defined(EXPERIMENTAL_FIPS_BUILD)
+
 // Skips an optional context-specific field numbered |tag_number| from |cbs|, accepting both the
 // constructed and the primitive encoding of the tag. Returns false only when a matching tag is
 // present but its element is malformed; a missing field is not an error.
@@ -261,16 +288,18 @@ static bool skipOptionalContextSpecificField(CBS* cbs, unsigned tag_number)
     return true;
 }
 
-// See forward declaration above der2EvpPrivateKey. Parses an expanded-format ML-KEM PKCS8 private
-// key via EVP_PKEY_kem_new_raw_secret_key. The expandedKey CHOICE is specified in RFC 9935
+// See forward declaration above der2EvpPrivateKey. Parses a PKCS8 ML-KEM private key via the raw
+// APIs, bypassing the ASN.1 method that AWS-LC-FIPS 3.1.0 lacks. Handles the expanded-key CHOICE
+// (all builds) and, in regular FIPS only, the seed CHOICE. Both CHOICEs are specified in RFC 9935
 // Section 6 (Private Key Format), with the formal ASN.1 module in Appendix A:
 // https://datatracker.ietf.org/doc/html/rfc9935#section-6
 // https://datatracker.ietf.org/doc/html/rfc9935#appendix-A
-// Returns nullptr for seed-format or non-ML-KEM inputs; der2EvpPrivateKey calls this as a fallover
-// after d2i_PrivateKey fails.
+// Returns nullptr for non-ML-KEM inputs, and (in non-FIPS / experimental-FIPS builds) for
+// seed-format keys, which the standard d2i_PrivateKey handles natively there. der2EvpPrivateKey
+// calls this as a fallover after d2i_PrivateKey fails.
 static EVP_PKEY* parseMLKEMPrivateKey(const unsigned char* der, const int derLen)
 {
-    CBS cbs, pkcs8, algorithm, oid, priv, expanded;
+    CBS cbs, pkcs8, algorithm, oid, priv;
     uint64_t version = 0;
     CBS_init(&cbs, der, derLen);
     // The outer structure is a PrivateKeyInfo (RFC 5208, version 0) or a OneAsymmetricKey (RFC 5958,
@@ -290,9 +319,8 @@ static EVP_PKEY* parseMLKEMPrivateKey(const unsigned char* der, const int derLen
     if (!isMLKEMNid(nid)) {
         return nullptr;
     }
-    // The ML-KEM AlgorithmIdentifier has no parameters. The PrivateKey OCTET STRING wraps the
-    // expanded-key OCTET STRING. Seed-format keys instead wrap a context-specific [0] tag, which
-    // fails the inner OCTET STRING parse below, so this returns nullptr for them.
+    // The ML-KEM AlgorithmIdentifier has no parameters. The PrivateKey OCTET STRING wraps either the
+    // expanded key (OCTET STRING) or, in seed format, a [0] IMPLICIT OCTET STRING seed.
     // spotless:off
     if (CBS_len(&algorithm) != 0 ||
         !CBS_get_asn1(&pkcs8, &priv, CBS_ASN1_OCTETSTRING)) {
@@ -315,14 +343,31 @@ static EVP_PKEY* parseMLKEMPrivateKey(const unsigned char* der, const int derLen
     if (CBS_len(&pkcs8) != 0) {
         return nullptr;
     }
-    // spotless:off
-    if (!CBS_get_asn1(&priv, &expanded, CBS_ASN1_OCTETSTRING) || CBS_len(&priv) != 0) {
-        return nullptr;
+    if (CBS_peek_asn1_tag(&priv, CBS_ASN1_OCTETSTRING)) {
+        // Expanded format. EVP_PKEY_kem_new_raw_secret_key validates the length against the parameter
+        // set's secret_key_len and returns NULL otherwise (surfaced by der2EvpPrivateKey as a decode
+        // failure).
+        CBS expanded;
+        if (!CBS_get_asn1(&priv, &expanded, CBS_ASN1_OCTETSTRING) || CBS_len(&priv) != 0) {
+            return nullptr;
+        }
+        return EVP_PKEY_kem_new_raw_secret_key(nid, CBS_data(&expanded), CBS_len(&expanded));
     }
-    // spotless:on
-    // EVP_PKEY_kem_new_raw_secret_key validates that the length matches the parameter set's
-    // secret_key_len and returns NULL otherwise (surfaced by der2EvpPrivateKey as a decode failure).
-    return EVP_PKEY_kem_new_raw_secret_key(nid, CBS_data(&expanded), CBS_len(&expanded));
+#if defined(FIPS_BUILD) && !defined(EXPERIMENTAL_FIPS_BUILD)
+    // Seed format ([0] IMPLICIT OCTET STRING, the raw d || z keygen seed). AWS-LC-FIPS 3.1.0 cannot
+    // d2i a seed-format ML-KEM key, so expand the seed into a full key. (Serializing back to seed is
+    // still impossible in regular FIPS -- getEncoded() emits the expanded form.)
+    // See RFC 9935 Section 6 (Private Key Format): https://datatracker.ietf.org/doc/html/rfc9935#section-6
+    // TODO [AWS-LC-FIPS 4.x]: drop this seed branch once the FIPS module can d2i seed-format ML-KEM keys.
+    if (CBS_peek_asn1_tag(&priv, CBS_ASN1_CONTEXT_SPECIFIC | 0)) {
+        CBS seed;
+        if (!CBS_get_asn1(&priv, &seed, CBS_ASN1_CONTEXT_SPECIFIC | 0) || CBS_len(&priv) != 0) {
+            return nullptr;
+        }
+        return mlkemKeyFromSeed(nid, CBS_data(&seed), CBS_len(&seed));
+    }
+#endif // defined(FIPS_BUILD) && !defined(EXPERIMENTAL_FIPS_BUILD)
+    return nullptr;
 }
 
 EVP_PKEY* der2EvpPublicKey(const unsigned char* der, const int derLen, const char* javaExceptionClass)

--- a/csrc/keyutils.cpp
+++ b/csrc/keyutils.cpp
@@ -317,11 +317,9 @@ static bool skipOptionalField(CBS* cbs, unsigned tag)
 //     accepting it here would make ACCP quietly lose the ability on the FIPS bump;
 //   - trailing bytes after the CHOICE inside the privateKey OCTET STRING are ignored rather than
 //     rejected, because kem_priv_decode does not check CBS_len(key) after extracting the CHOICE.
-// "Mainline" means AWS-LC main, the version whose decoder this is destined to be replaced by. Older
-// AWS-LC releases are laxer about the two optional trailing fields: the non-FIPS build's v1.72.0
-// spells kAttributesTag without CBS_ASN1_CONSTRUCTED and has no trailing-data check inside the
-// PrivateKeyInfo SEQUENCE, so it accepts a few encodings this parser rejects. Following main rather
-// than the pinned release is the point; do not relax these checks to match v1.72.0.
+// The reference is the AWS-LC that non-FIPS and experimental-FIPS builds link, v5.0.0, whose
+// EVP_parse_private_key and kem_priv_decode are the two functions cited above. AWS-LC-FIPS 3.1.0 has
+// no ML-KEM ASN.1 method at all, so in regular FIPS this function is the entire decoder.
 // Returns nullptr for non-ML-KEM inputs. der2EvpPrivateKey calls this as a fallover after
 // d2i_PrivateKey fails, so in non-FIPS / experimental-FIPS builds only inputs AWS-LC itself rejected
 // reach it, and it rejects those too.
@@ -372,8 +370,9 @@ static EVP_PKEY* parseMLKEMPrivateKey(const unsigned char* der, const int derLen
     }
     if (CBS_peek_asn1_tag(&priv, CBS_ASN1_CONTEXT_SPECIFIC | 0)) {
         // seed CHOICE ([0] IMPLICIT OCTET STRING, the raw d || z keygen seed). AWS-LC-FIPS 3.1.0 cannot
-        // d2i a seed-format ML-KEM key, so expand the seed into a full key. (Serializing back to seed is
-        // still impossible in regular FIPS -- getEncoded() emits the expanded form.)
+        // d2i a seed-format ML-KEM key, so expand the seed into a full key. The seed itself is dropped:
+        // AWS-LC-FIPS 3.1.0's KEM_KEY has no seed field (v5.0.0 added one), so nothing can hold it and
+        // getEncoded() emits the expanded CHOICE in regular FIPS.
         // TODO [AWS-LC-FIPS 4.x]: drop this seed branch once the FIPS module can d2i seed-format ML-KEM keys.
         CBS seed;
         if (!CBS_get_asn1(&priv, &seed, CBS_ASN1_CONTEXT_SPECIFIC | 0)) {

--- a/csrc/util_class.cpp
+++ b/csrc/util_class.cpp
@@ -136,7 +136,58 @@ Java_com_amazon_corretto_crypto_utils_MlDsaUtils_expandPrivateKeyInternal(JNIEnv
     }
     return result;
 }
+#endif // !defined(FIPS_BUILD) || defined(EXPERIMENTAL_FIPS_BUILD)
 
+/*
+ * Class:     com_amazon_corretto_crypto_utils_MlKemUtils
+ * Method:    expandPrivateKeyInternal
+ * Signature: ([B)[B
+ *
+ * Deliberately outside the guard that brackets the ML-DSA helpers on either side of it:
+ * der2EvpPrivateKey accepts the seed and expandedKey CHOICEs of RFC 9935 Section 6 in every build
+ * -- in regular FIPS through the hand-rolled fallover parser in keyutils.cpp -- and
+ * encodeExpandedMLKEMPrivateKey is likewise available everywhere. Re-encoding a key that was
+ * already expanded reproduces its DER byte for byte, so this is idempotent rather than
+ * special-cased on the input length.
+ */
+JNIEXPORT jbyteArray JNICALL Java_com_amazon_corretto_crypto_utils_MlKemUtils_expandPrivateKeyInternal(
+    JNIEnv* pEnv, jclass, jbyteArray keyBytes)
+{
+    jbyteArray result = NULL;
+    try {
+        raii_env env(pEnv);
+        jsize key_der_len = env->GetArrayLength(keyBytes);
+        uint8_t* key_der = (uint8_t*)env->GetByteArrayElements(keyBytes, nullptr);
+        CHECK_OPENSSL(key_der);
+
+        EVP_PKEY_auto key;
+        try {
+            key.set(der2EvpPrivateKey(
+                key_der, key_der_len, EVP_PKEY_KEM, /*shouldCheckPrivate*/ false, EX_INVALID_KEY_SPEC));
+        } catch (...) {
+            env->ReleaseByteArrayElements(keyBytes, (jbyte*)key_der, JNI_ABORT);
+            throw;
+        }
+        env->ReleaseByteArrayElements(keyBytes, (jbyte*)key_der, JNI_ABORT);
+        CHECK_OPENSSL(key.isInitialized());
+
+        // Encode as expanded-format PKCS8
+        OPENSSL_buffer_auto new_der;
+        int new_der_len = encodeExpandedMLKEMPrivateKey(key, &new_der);
+        CHECK_OPENSSL(new_der_len > 0);
+
+        if (!(result = env->NewByteArray(new_der_len))) {
+            throw_java_ex(EX_OOM, "Unable to allocate DER array");
+        }
+        env->SetByteArrayRegion(result, 0, new_der_len, (const jbyte*)new_der);
+    } catch (java_ex& ex) {
+        ex.throw_to_java(pEnv);
+        return 0;
+    }
+    return result;
+}
+
+#if !defined(FIPS_BUILD) || defined(EXPERIMENTAL_FIPS_BUILD)
 /*
  * Class:     com_amazon_corretto_crypto_utils_MlDsaUtils
  * Method:    computeMuInternal
@@ -203,54 +254,6 @@ JNIEXPORT jbyteArray JNICALL Java_com_amazon_corretto_crypto_utils_MlDsaUtils_co
     }
 }
 #endif // !defined(FIPS_BUILD) || defined(EXPERIMENTAL_FIPS_BUILD)
-
-/*
- * Class:     com_amazon_corretto_crypto_utils_MlKemUtils
- * Method:    expandPrivateKeyInternal
- * Signature: ([B)[B
- *
- * Unguarded (unlike the ML-DSA helpers above): der2EvpPrivateKey accepts the seed and expandedKey
- * CHOICEs of RFC 9935 Section 6 in every build -- in regular FIPS through the hand-rolled fallover
- * parser in keyutils.cpp -- and encodeExpandedMLKEMPrivateKey is likewise available everywhere.
- * Re-encoding a key that was already expanded reproduces its DER byte for byte, so this is
- * idempotent rather than special-cased on the input length.
- */
-JNIEXPORT jbyteArray JNICALL Java_com_amazon_corretto_crypto_utils_MlKemUtils_expandPrivateKeyInternal(
-    JNIEnv* pEnv, jclass, jbyteArray keyBytes)
-{
-    jbyteArray result = NULL;
-    try {
-        raii_env env(pEnv);
-        jsize key_der_len = env->GetArrayLength(keyBytes);
-        uint8_t* key_der = (uint8_t*)env->GetByteArrayElements(keyBytes, nullptr);
-        CHECK_OPENSSL(key_der);
-
-        EVP_PKEY_auto key;
-        try {
-            key.set(der2EvpPrivateKey(
-                key_der, key_der_len, EVP_PKEY_KEM, /*shouldCheckPrivate*/ false, EX_INVALID_KEY_SPEC));
-        } catch (...) {
-            env->ReleaseByteArrayElements(keyBytes, (jbyte*)key_der, JNI_ABORT);
-            throw;
-        }
-        env->ReleaseByteArrayElements(keyBytes, (jbyte*)key_der, JNI_ABORT);
-        CHECK_OPENSSL(key.isInitialized());
-
-        // Encode as expanded-format PKCS8
-        OPENSSL_buffer_auto new_der;
-        int new_der_len = encodeExpandedMLKEMPrivateKey(key, &new_der);
-        CHECK_OPENSSL(new_der_len > 0);
-
-        if (!(result = env->NewByteArray(new_der_len))) {
-            throw_java_ex(EX_OOM, "Unable to allocate DER array");
-        }
-        env->SetByteArrayRegion(result, 0, new_der_len, (const jbyte*)new_der);
-    } catch (java_ex& ex) {
-        ex.throw_to_java(pEnv);
-        return 0;
-    }
-    return result;
-}
 
 /*
  * Class:     com_amazon_corretto_crypto_utils_DigestUtils

--- a/csrc/util_class.cpp
+++ b/csrc/util_class.cpp
@@ -145,10 +145,16 @@ Java_com_amazon_corretto_crypto_utils_MlDsaUtils_expandPrivateKeyInternal(JNIEnv
  *
  * Deliberately outside the guard that brackets the ML-DSA helpers on either side of it:
  * der2EvpPrivateKey accepts the seed and expandedKey CHOICEs of RFC 9935 Section 6 in every build
- * -- in regular FIPS through the hand-rolled fallover parser in keyutils.cpp -- and
- * encodeExpandedMLKEMPrivateKey is likewise available everywhere. Re-encoding a key that was
- * already expanded reproduces its DER byte for byte, so this is idempotent rather than
- * special-cased on the input length.
+ * -- in regular FIPS through the fallover parser in keyutils.cpp -- and encodeExpandedMLKEMPrivateKey
+ * is likewise available everywhere.
+ *
+ * Every input is parsed and re-encoded, rather than short-circuiting on the input length the way the
+ * ML-DSA helper above still does. So the output is always the canonical minimal expandedKey PKCS8
+ * (version 0, no attributes, no publicKey), making this idempotent on that form rather than
+ * byte-preserving in general, and an input der2EvpPrivateKey will not accept is rejected instead of
+ * handed back unchanged. EX_RUNTIME_CRYPTO is passed down rather than the EX_INVALID_KEY_SPEC the
+ * KeyFactory callers use: InvalidKeySpecException is checked, and MlKemUtils.expandPrivateKey does
+ * not declare it.
  */
 JNIEXPORT jbyteArray JNICALL Java_com_amazon_corretto_crypto_utils_MlKemUtils_expandPrivateKeyInternal(
     JNIEnv* pEnv, jclass, jbyteArray keyBytes)
@@ -163,13 +169,13 @@ JNIEXPORT jbyteArray JNICALL Java_com_amazon_corretto_crypto_utils_MlKemUtils_ex
         EVP_PKEY_auto key;
         try {
             key.set(der2EvpPrivateKey(
-                key_der, key_der_len, EVP_PKEY_KEM, /*shouldCheckPrivate*/ false, EX_INVALID_KEY_SPEC));
+                key_der, key_der_len, EVP_PKEY_KEM, /*shouldCheckPrivate*/ false, EX_RUNTIME_CRYPTO));
         } catch (...) {
             env->ReleaseByteArrayElements(keyBytes, (jbyte*)key_der, JNI_ABORT);
             throw;
         }
         env->ReleaseByteArrayElements(keyBytes, (jbyte*)key_der, JNI_ABORT);
-        CHECK_OPENSSL(key.isInitialized());
+        // No null check: der2EvpPrivateKey either returns a key or throws.
 
         // Encode as expanded-format PKCS8
         OPENSSL_buffer_auto new_der;

--- a/csrc/util_class.cpp
+++ b/csrc/util_class.cpp
@@ -138,58 +138,6 @@ Java_com_amazon_corretto_crypto_utils_MlDsaUtils_expandPrivateKeyInternal(JNIEnv
 }
 
 /*
- * Class:     com_amazon_corretto_crypto_utils_MlKemUtils
- * Method:    expandPrivateKeyInternal
- * Signature: ([B)[B
- *
- * AWS-LC's kem_priv_decode automatically expands seed-format keys
- * via KEM_KEY_set_raw_keypair_from_seed. We then use encodeExpandedMLKEMPrivateKey
- * to manually build expanded-format PKCS8.
- */
-JNIEXPORT jbyteArray JNICALL
-Java_com_amazon_corretto_crypto_utils_MlKemUtils_expandPrivateKeyInternal(JNIEnv* pEnv, jclass, jbyteArray keyBytes)
-{
-    jbyteArray result = NULL;
-    try {
-        raii_env env(pEnv);
-        jsize key_der_len = env->GetArrayLength(keyBytes);
-
-        // ML-KEM seed-format PKCS8 is 86 bytes for all parameter sets (64-byte seed + ASN.1 overhead).
-        // If the key is already expanded, return it as-is.
-        if (key_der_len > 86) {
-            return keyBytes;
-        }
-        CHECK_OPENSSL(key_der_len == 86); // seed-only keys are always 86 bytes when PKCS8-encoded
-        uint8_t* key_der = (uint8_t*)env->GetByteArrayElements(keyBytes, nullptr);
-        CHECK_OPENSSL(key_der);
-
-        // Parse the seed key — AWS-LC expands it during parsing
-        BIO* key_bio = BIO_new_mem_buf(key_der, key_der_len);
-        CHECK_OPENSSL(key_bio);
-        PKCS8_PRIV_KEY_INFO_auto pkcs8 = PKCS8_PRIV_KEY_INFO_auto::from(d2i_PKCS8_PRIV_KEY_INFO_bio(key_bio, nullptr));
-        BIO_free(key_bio);
-        env->ReleaseByteArrayElements(keyBytes, (jbyte*)key_der, JNI_ABORT);
-        CHECK_OPENSSL(pkcs8.isInitialized());
-        EVP_PKEY_auto key = EVP_PKEY_auto::from(EVP_PKCS82PKEY(pkcs8));
-        CHECK_OPENSSL(key.isInitialized());
-
-        // Encode as expanded-format PKCS8
-        OPENSSL_buffer_auto new_der;
-        int new_der_len = encodeExpandedMLKEMPrivateKey(key, &new_der);
-        CHECK_OPENSSL(new_der_len > 0);
-
-        if (!(result = env->NewByteArray(new_der_len))) {
-            throw_java_ex(EX_OOM, "Unable to allocate DER array");
-        }
-        env->SetByteArrayRegion(result, 0, new_der_len, (const jbyte*)new_der);
-    } catch (java_ex& ex) {
-        ex.throw_to_java(pEnv);
-        return 0;
-    }
-    return result;
-}
-
-/*
  * Class:     com_amazon_corretto_crypto_utils_MlDsaUtils
  * Method:    computeMuInternal
  * Signature: ([B[B)[B
@@ -255,6 +203,54 @@ JNIEXPORT jbyteArray JNICALL Java_com_amazon_corretto_crypto_utils_MlDsaUtils_co
     }
 }
 #endif // !defined(FIPS_BUILD) || defined(EXPERIMENTAL_FIPS_BUILD)
+
+/*
+ * Class:     com_amazon_corretto_crypto_utils_MlKemUtils
+ * Method:    expandPrivateKeyInternal
+ * Signature: ([B)[B
+ *
+ * Unguarded (unlike the ML-DSA helpers above): der2EvpPrivateKey accepts the seed and expandedKey
+ * CHOICEs of RFC 9935 Section 6 in every build -- in regular FIPS through the hand-rolled fallover
+ * parser in keyutils.cpp -- and encodeExpandedMLKEMPrivateKey is likewise available everywhere.
+ * Re-encoding a key that was already expanded reproduces its DER byte for byte, so this is
+ * idempotent rather than special-cased on the input length.
+ */
+JNIEXPORT jbyteArray JNICALL Java_com_amazon_corretto_crypto_utils_MlKemUtils_expandPrivateKeyInternal(
+    JNIEnv* pEnv, jclass, jbyteArray keyBytes)
+{
+    jbyteArray result = NULL;
+    try {
+        raii_env env(pEnv);
+        jsize key_der_len = env->GetArrayLength(keyBytes);
+        uint8_t* key_der = (uint8_t*)env->GetByteArrayElements(keyBytes, nullptr);
+        CHECK_OPENSSL(key_der);
+
+        EVP_PKEY_auto key;
+        try {
+            key.set(der2EvpPrivateKey(
+                key_der, key_der_len, EVP_PKEY_KEM, /*shouldCheckPrivate*/ false, EX_INVALID_KEY_SPEC));
+        } catch (...) {
+            env->ReleaseByteArrayElements(keyBytes, (jbyte*)key_der, JNI_ABORT);
+            throw;
+        }
+        env->ReleaseByteArrayElements(keyBytes, (jbyte*)key_der, JNI_ABORT);
+        CHECK_OPENSSL(key.isInitialized());
+
+        // Encode as expanded-format PKCS8
+        OPENSSL_buffer_auto new_der;
+        int new_der_len = encodeExpandedMLKEMPrivateKey(key, &new_der);
+        CHECK_OPENSSL(new_der_len > 0);
+
+        if (!(result = env->NewByteArray(new_der_len))) {
+            throw_java_ex(EX_OOM, "Unable to allocate DER array");
+        }
+        env->SetByteArrayRegion(result, 0, new_der_len, (const jbyte*)new_der);
+    } catch (java_ex& ex) {
+        ex.throw_to_java(pEnv);
+        return 0;
+    }
+    return result;
+}
 
 /*
  * Class:     com_amazon_corretto_crypto_utils_DigestUtils

--- a/src/com/amazon/corretto/crypto/utils/MlKemUtils.java
+++ b/src/com/amazon/corretto/crypto/utils/MlKemUtils.java
@@ -30,7 +30,8 @@ public final class MlKemUtils {
    *
    * @param key an ML-KEM private key
    * @return a byte[] containing the PKCS8-encoded expanded private key
-   * @throws IllegalArgumentException if {@code key} is null or is not an ML-KEM key
+   * @throws IllegalArgumentException if {@code key} is null, is not an ML-KEM key, or returns null
+   *     from {@code getEncoded()} because it does not support encoding
    * @throws com.amazon.corretto.crypto.provider.RuntimeCryptoException if {@code key.getEncoded()}
    *     is not a PKCS8 ML-KEM private key ACCP can parse
    */
@@ -38,6 +39,12 @@ public final class MlKemUtils {
     if (key == null || !key.getAlgorithm().startsWith("ML-KEM")) {
       throw new IllegalArgumentException();
     }
-    return expandPrivateKeyInternal(key.getEncoded());
+    // Key.getEncoded() is specified to return null for a key that does not support encoding, so it
+    // has to be checked here rather than in JNI, where it would reach GetArrayLength(nullptr).
+    final byte[] encoded = key.getEncoded();
+    if (encoded == null) {
+      throw new IllegalArgumentException();
+    }
+    return expandPrivateKeyInternal(encoded);
   }
 }

--- a/src/com/amazon/corretto/crypto/utils/MlKemUtils.java
+++ b/src/com/amazon/corretto/crypto/utils/MlKemUtils.java
@@ -21,8 +21,18 @@ public final class MlKemUtils {
    *
    * <p>See <a href="https://datatracker.ietf.org/doc/rfc9935/">RFC 9935</a>
    *
+   * <p>The returned encoding is always the canonical minimal form: a version 0 {@code
+   * PrivateKeyInfo} wrapping the {@code expandedKey} CHOICE, with no {@code attributes} and no
+   * {@code publicKey}. Those optional {@code OneAsymmetricKey} fields are accepted on input but are
+   * not carried over, so this method is idempotent on its own output rather than byte-preserving on
+   * arbitrary input. Only the {@code seed} and {@code expandedKey} CHOICEs of RFC 9935 Section 6
+   * are accepted; the {@code both} CHOICE is rejected.
+   *
    * @param key an ML-KEM private key
    * @return a byte[] containing the PKCS8-encoded expanded private key
+   * @throws IllegalArgumentException if {@code key} is null or is not an ML-KEM key
+   * @throws com.amazon.corretto.crypto.provider.RuntimeCryptoException if {@code key.getEncoded()}
+   *     is not a PKCS8 ML-KEM private key ACCP can parse
    */
   public static byte[] expandPrivateKey(PrivateKey key) {
     if (key == null || !key.getAlgorithm().startsWith("ML-KEM")) {

--- a/tst/com/amazon/corretto/crypto/provider/test/MlKemUtilsTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/MlKemUtilsTest.java
@@ -80,15 +80,13 @@ public class MlKemUtilsTest {
   @ValueSource(strings = {"ML-KEM-512", "ML-KEM-768", "ML-KEM-1024"})
   @DisabledIf("mlKemDisabled")
   public void testExpandSeedKey(String algorithm) throws Exception {
-    // ML-KEM seed expansion (RFC 9935) requires seed support in the underlying
-    // AWS-LC, present only in non-FIPS / experimental-FIPS builds (matches the
-    // native #if !defined(FIPS_BUILD) || defined(EXPERIMENTAL_FIPS_BUILD) guard).
-    // TODO: remove this guard once AWS-LC-FIPS is bumped to v5.0.0, which provides
-    // FIPS-validated ML-KEM private-key (seed-format) parsing.
+    // MlKemUtils.expandPrivateKey's native method (expandPrivateKeyInternal) is compiled only in
+    // non-FIPS / experimental-FIPS builds. Seed PARSING via KeyFactory is supported in regular FIPS
+    // (see MlKemTest#testSeedFormatPrivateKeyParses).
     assumeTrue(
         !AmazonCorrettoCryptoProvider.INSTANCE.isFips()
             || AmazonCorrettoCryptoProvider.INSTANCE.isExperimentalFips(),
-        "ML-KEM seed-format keys are unavailable in FIPS builds");
+        "MlKemUtils.expandPrivateKey is unavailable in regular FIPS");
     KeyFactory kf = KeyFactory.getInstance("ML-KEM", NATIVE_PROVIDER);
     byte[] seedDer = Base64.getDecoder().decode(seedPem(algorithm));
 

--- a/tst/com/amazon/corretto/crypto/provider/test/MlKemUtilsTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/MlKemUtilsTest.java
@@ -79,11 +79,6 @@ public class MlKemUtilsTest {
   @ValueSource(strings = {"ML-KEM-512", "ML-KEM-768", "ML-KEM-1024"})
   @DisabledIf("mlKemDisabled")
   public void testExpandSeedKey(String algorithm) throws Exception {
-    // Runs in every build: expandPrivateKeyInternal parses through der2EvpPrivateKey, which
-    // handles the seed and expandedKey CHOICEs of RFC 9935 everywhere, and re-encodes with the
-    // unguarded encodeExpandedMLKEMPrivateKey. In regular FIPS the KeyFactory-imported seed key
-    // already reports the expanded encoding (AWS-LC-FIPS 3.1.0 retains no seed), so the expansion
-    // is a no-op there.
     KeyFactory kf = KeyFactory.getInstance("ML-KEM", NATIVE_PROVIDER);
     byte[] seedDer = Base64.getDecoder().decode(seedPem(algorithm));
 

--- a/tst/com/amazon/corretto/crypto/provider/test/MlKemUtilsTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/MlKemUtilsTest.java
@@ -4,7 +4,6 @@ package com.amazon.corretto.crypto.provider.test;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import com.amazon.corretto.crypto.provider.AmazonCorrettoCryptoProvider;
 import com.amazon.corretto.crypto.utils.MlKemUtils;
@@ -80,13 +79,11 @@ public class MlKemUtilsTest {
   @ValueSource(strings = {"ML-KEM-512", "ML-KEM-768", "ML-KEM-1024"})
   @DisabledIf("mlKemDisabled")
   public void testExpandSeedKey(String algorithm) throws Exception {
-    // MlKemUtils.expandPrivateKey's native method (expandPrivateKeyInternal) is compiled only in
-    // non-FIPS / experimental-FIPS builds. Seed PARSING via KeyFactory is supported in regular FIPS
-    // (see MlKemTest#testSeedFormatPrivateKeyParses).
-    assumeTrue(
-        !AmazonCorrettoCryptoProvider.INSTANCE.isFips()
-            || AmazonCorrettoCryptoProvider.INSTANCE.isExperimentalFips(),
-        "MlKemUtils.expandPrivateKey is unavailable in regular FIPS");
+    // Runs in every build: expandPrivateKeyInternal parses through der2EvpPrivateKey, which
+    // handles the seed and expandedKey CHOICEs of RFC 9935 everywhere, and re-encodes with the
+    // unguarded encodeExpandedMLKEMPrivateKey. In regular FIPS the KeyFactory-imported seed key
+    // already reports the expanded encoding (AWS-LC-FIPS 3.1.0 retains no seed), so the expansion
+    // is a no-op there.
     KeyFactory kf = KeyFactory.getInstance("ML-KEM", NATIVE_PROVIDER);
     byte[] seedDer = Base64.getDecoder().decode(seedPem(algorithm));
 

--- a/tst/com/amazon/corretto/crypto/provider/test/MlKemUtilsTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/MlKemUtilsTest.java
@@ -100,5 +100,30 @@ public class MlKemUtilsTest {
   @DisabledIf("mlKemDisabled")
   public void testExpandPrivateKeyInvalidArgs() {
     TestUtil.assertThrows(IllegalArgumentException.class, () -> MlKemUtils.expandPrivateKey(null));
+
+    // A PrivateKey is permitted to return null from getEncoded() when it does not support encoding,
+    // as a key held in hardware would. The algorithm check alone does not catch that, and the null
+    // must be refused here rather than passed to JNI, where GetArrayLength would dereference it.
+    final PrivateKey unencodable =
+        new PrivateKey() {
+          static final long serialVersionUID = 1L;
+
+          @Override
+          public String getAlgorithm() {
+            return "ML-KEM-768";
+          }
+
+          @Override
+          public String getFormat() {
+            return null;
+          }
+
+          @Override
+          public byte[] getEncoded() {
+            return null;
+          }
+        };
+    TestUtil.assertThrows(
+        IllegalArgumentException.class, () -> MlKemUtils.expandPrivateKey(unencodable));
   }
 }

--- a/tst/com/amazon/corretto/crypto/provider/test/jdk17plus/MlKemTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/jdk17plus/MlKemTest.java
@@ -256,14 +256,10 @@ public class MlKemTest {
 
   @Test
   public void testKeyFactorySelfConversion() throws Exception {
-    // ML-KEM private keys encode in seed format, which requires seed support in the
-    // underlying AWS-LC -- present only in non-FIPS / experimental-FIPS builds (matches the
-    // native #if !defined(FIPS_BUILD) || defined(EXPERIMENTAL_FIPS_BUILD) guard).
-    // TODO: remove this guard once AWS-LC-FIPS is bumped to v5.0.0, which provides
-    // FIPS-validated ML-KEM private-key (seed-format) parsing.
-    assumeTrue(
-        !NATIVE_PROVIDER.isFips() || NATIVE_PROVIDER.isExperimentalFips(),
-        "ML-KEM seed-format keys are unavailable in FIPS builds");
+    // Round-trips ACCP's own ML-KEM key pair through its KeyFactory. In regular FIPS the private
+    // key
+    // serializes in expanded format (seed format is unavailable there), so this exercises the
+    // expanded encode/decode; in other builds it exercises the seed format. Public keys use X.509.
     KeyPairGenerator keyGen = KeyPairGenerator.getInstance("ML-KEM", NATIVE_PROVIDER);
     KeyPair originalKeyPair = keyGen.generateKeyPair();
 
@@ -276,6 +272,51 @@ public class MlKemTest {
     byte[] privateKeyEncoded = originalKeyPair.getPrivate().getEncoded();
     PrivateKey privateKey = keyFactory.generatePrivate(new PKCS8EncodedKeySpec(privateKeyEncoded));
     assertArrayEquals(privateKeyEncoded, privateKey.getEncoded());
+  }
+
+  @ParameterizedTest
+  @MethodSource("mlKemParamSets")
+  public void testSeedFormatPrivateKeyParses(String paramSet) throws Exception {
+    // ACCP cannot *emit* seed-format ML-KEM private keys in regular FIPS (AWS-LC-FIPS 3.1.0 stores
+    // no
+    // keygen seed, so getEncoded emits the expanded form), but it can *parse* one: a seed-format
+    // PKCS#8 is expanded into a full key via EVP_PKEY_keygen_deterministic. This verifies that path
+    // by importing a BouncyCastle-produced key in both its seed and expanded encodings and
+    // confirming
+    // the two ACCP keys decapsulate a ciphertext to the same shared secret. The assertion is
+    // encoding-independent, so it runs in all builds (regular FIPS uses the hand-rolled seed
+    // expansion; other builds parse the seed via AWS-LC directly).
+    KeyPairGenerator bcKeyGen = KeyPairGenerator.getInstance("ML-KEM", TestUtil.BC_PROVIDER);
+    bcKeyGen.initialize(TestUtil.getMlKemParamSpec(paramSet));
+    KeyPair bcKeyPair = bcKeyGen.generateKeyPair();
+    MLKEMPrivateKey bcPriv = (MLKEMPrivateKey) bcKeyPair.getPrivate();
+
+    KeyFactory accpKf = KeyFactory.getInstance(paramSet, NATIVE_PROVIDER);
+    // getPrivateKey(true) yields the seed-format encoding; getPrivateKey(false) the expanded form.
+    PrivateKey fromSeed =
+        accpKf.generatePrivate(new PKCS8EncodedKeySpec(bcPriv.getPrivateKey(true).getEncoded()));
+    PrivateKey fromExpanded =
+        accpKf.generatePrivate(new PKCS8EncodedKeySpec(bcPriv.getPrivateKey(false).getEncoded()));
+    PublicKey accpPub =
+        accpKf.generatePublic(new X509EncodedKeySpec(bcKeyPair.getPublic().getEncoded()));
+
+    KEM kem = KEM.getInstance(paramSet, NATIVE_PROVIDER);
+    NamedParameterSpec paramSpec = new NamedParameterSpec(paramSet);
+    KEM.Encapsulated encapsulated = kem.newEncapsulator(accpPub, paramSpec, null).encapsulate();
+    byte[] ciphertext = encapsulated.encapsulation();
+
+    SecretKey secretFromSeed = kem.newDecapsulator(fromSeed, paramSpec).decapsulate(ciphertext);
+    SecretKey secretFromExpanded =
+        kem.newDecapsulator(fromExpanded, paramSpec).decapsulate(ciphertext);
+
+    assertArrayEquals(
+        encapsulated.key().getEncoded(),
+        secretFromSeed.getEncoded(),
+        paramSet + " seed-parsed private key must decapsulate to the encapsulated shared secret");
+    assertArrayEquals(
+        secretFromExpanded.getEncoded(),
+        secretFromSeed.getEncoded(),
+        paramSet + " seed-parsed and expanded-parsed keys must decapsulate identically");
   }
 
   @ParameterizedTest
@@ -587,14 +628,15 @@ public class MlKemTest {
   @ParameterizedTest
   @MethodSource("mlKemParamSets")
   public void testPrivateKeyEncodingIsSeedFormat(String paramSet) throws Exception {
-    // ML-KEM seed-format keys require seed support in the underlying AWS-LC,
-    // which is only present in non-FIPS / experimental-FIPS builds (matches the
-    // #if !defined(FIPS_BUILD) || defined(EXPERIMENTAL_FIPS_BUILD) guard in native code).
-    // TODO: remove this guard once AWS-LC-FIPS is bumped to v5.0.0, which provides
-    // FIPS-validated ML-KEM private-key (seed-format) parsing.
+    // ACCP cannot EMIT the seed encoding in regular FIPS: AWS-LC-FIPS 3.1.0 stores no keygen seed,
+    // so
+    // getEncoded() produces the expanded form instead. (Seed PARSING is supported -- see
+    // testSeedFormatPrivateKeyParses.) TODO: remove this guard once AWS-LC-FIPS is bumped to
+    // v5.0.0,
+    // which retains the seed and can re-emit it.
     assumeTrue(
         !NATIVE_PROVIDER.isFips() || NATIVE_PROVIDER.isExperimentalFips(),
-        "ML-KEM seed-format keys are unavailable in FIPS builds");
+        "ML-KEM seed-format encoding is unavailable in regular FIPS");
     // Seed format is 64 bytes (d || z) for all ML-KEM parameter sets.
     // PKCS#8 DER wrapping adds 22 bytes of ASN.1 overhead, totaling 86 bytes.
     // Expanded format would be 1632/2400/3168 bytes plus overhead.
@@ -612,14 +654,13 @@ public class MlKemTest {
   @ParameterizedTest
   @MethodSource("mlKemParamSets")
   public void testBouncyCastleInteroperability(String paramSet) throws Exception {
-    // Interop exchanges ML-KEM private keys in seed format, which requires seed support in
-    // the underlying AWS-LC -- present only in non-FIPS / experimental-FIPS builds (matches the
-    // native #if !defined(FIPS_BUILD) || defined(EXPERIMENTAL_FIPS_BUILD) guard).
-    // TODO: remove this guard once AWS-LC-FIPS is bumped to v5.0.0, which provides
-    // FIPS-validated ML-KEM private-key (seed-format) parsing.
+    // This interop compares seed-format private-key encodings across providers, which needs ACCP to
+    // EMIT seed format; ACCP emits the expanded form in regular FIPS (AWS-LC-FIPS 3.1.0 stores no
+    // seed). Seed PARSING is supported -- see testSeedFormatPrivateKeyParses for a FIPS-capable BC
+    // seed round-trip. TODO: remove this guard once AWS-LC-FIPS is bumped to v5.0.0.
     assumeTrue(
         !NATIVE_PROVIDER.isFips() || NATIVE_PROVIDER.isExperimentalFips(),
-        "ML-KEM seed-format keys are unavailable in FIPS builds");
+        "ML-KEM seed-format encoding is unavailable in regular FIPS");
 
     KeyPair accpKeyPair = KeyPairGenerator.getInstance(paramSet, NATIVE_PROVIDER).generateKeyPair();
 
@@ -699,13 +740,12 @@ public class MlKemTest {
   @ParameterizedTest
   @MethodSource("mlKemParamSets")
   public void testDecapsulationEquivalenceSeedAndExpanded(String paramSet) throws Exception {
-    // Seed-format ML-KEM is only available in non-FIPS / experimental-FIPS builds
-    // (matches the native #if !defined(FIPS_BUILD) || defined(EXPERIMENTAL_FIPS_BUILD) guard).
-    // TODO: remove this guard once AWS-LC-FIPS is bumped to v5.0.0, which provides
-    // FIPS-validated ML-KEM private-key (seed-format) parsing.
+    // This test expands via MlKemUtils.expandPrivateKey, whose native method
+    // (expandPrivateKeyInternal) is compiled only in non-FIPS / experimental-FIPS builds. Seed
+    // PARSING itself is supported in regular FIPS -- see testSeedFormatPrivateKeyParses.
     assumeTrue(
         !NATIVE_PROVIDER.isFips() || NATIVE_PROVIDER.isExperimentalFips(),
-        "ML-KEM seed-format keys are unavailable in FIPS builds");
+        "MlKemUtils.expandPrivateKey is unavailable in regular FIPS");
     KeyPairGenerator keyGen = KeyPairGenerator.getInstance(paramSet, NATIVE_PROVIDER);
     KeyPair keyPair = keyGen.generateKeyPair();
 

--- a/tst/com/amazon/corretto/crypto/provider/test/jdk17plus/MlKemTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/jdk17plus/MlKemTest.java
@@ -263,9 +263,6 @@ public class MlKemTest {
 
   @Test
   public void testKeyFactorySelfConversion() throws Exception {
-    // Round-trips ACCP's own ML-KEM key pair through its KeyFactory. In regular FIPS the private
-    // key serializes in expanded format (seed format is unavailable there), so this exercises the
-    // expanded encode/decode; in other builds it exercises the seed format. Public keys use X.509.
     KeyPairGenerator keyGen = KeyPairGenerator.getInstance("ML-KEM", NATIVE_PROVIDER);
     KeyPair originalKeyPair = keyGen.generateKeyPair();
 
@@ -553,13 +550,11 @@ public class MlKemTest {
               algorithm, new DERTaggedObject(false, 0, new DEROctetString(new byte[seedLen]))));
     }
 
-    // Wrong encoding form for the attributes field: mainline AWS-LC's EVP_parse_private_key
-    // recognizes attributes only as a constructed [0] (kAttributesTag), so a primitive [0] is
-    // unrecognized and trips its trailing-data check. ACCP's fallover parser spells the same tag,
-    // which is what this pins. There is deliberately no matching case for a constructed [1] where
-    // a primitive [1] publicKey belongs: mainline rejects that as trailing data too, but the
-    // AWS-LC v1.72.0 the non-FIPS build links predates the trailing-data check and accepts it, so
-    // asserting on it would pin the AWS-LC version rather than the ML-KEM grammar.
+    // Wrong encoding form for each of the two optional trailing fields. AWS-LC's
+    // EVP_parse_private_key recognizes attributes only as a constructed [0] (kAttributesTag) and
+    // publicKey only as a primitive [1] (kPublicKeyTag), so the other form of either tag goes
+    // unrecognized and trips its check for trailing data inside the SEQUENCE. ACCP's fallover
+    // parser spells both tags the same way, which is what these two cases pin.
     assertPrivateKeyRejected(
         keyFactory,
         paramSet + " primitive [0] attributes",
@@ -569,6 +564,18 @@ public class MlKemTest {
                   algorithm,
                   privateKey,
                   new DERTaggedObject(false, 0, new DEROctetString(new byte[0]))
+                })
+            .getEncoded("DER"));
+
+    assertPrivateKeyRejected(
+        keyFactory,
+        paramSet + " constructed [1] publicKey",
+        new DERSequence(
+                new ASN1Encodable[] {
+                  new ASN1Integer(1),
+                  algorithm,
+                  privateKey,
+                  new DERTaggedObject(true, 1, new DERBitString(new byte[32]))
                 })
             .getEncoded("DER"));
 
@@ -835,13 +842,6 @@ public class MlKemTest {
   @ParameterizedTest
   @MethodSource("mlKemParamSets")
   public void testBouncyCastleInteroperability(String paramSet) throws Exception {
-    // Runs in every build. Nothing here depends on WHICH private-key CHOICE ACCP emits: the
-    // assertions only require that BouncyCastle preserve whatever ACCP hands it, and BC
-    // round-trips the seed and expandedKey encodings alike byte for byte. So this covers the seed
-    // encoding in non-FIPS and experimental-FIPS builds and the expanded encoding in regular FIPS,
-    // where AWS-LC-FIPS 3.1.0 retains no keygen seed. testPrivateKeyChoicesParse covers the other
-    // direction, ACCP parsing BouncyCastle's seed and expandedKey encodings, and
-    // testBothChoiceRejected covers BouncyCastle's default both encoding.
     KeyPair accpKeyPair = KeyPairGenerator.getInstance(paramSet, NATIVE_PROVIDER).generateKeyPair();
 
     // Test BouncyCastle can import ACCP keys
@@ -935,10 +935,6 @@ public class MlKemTest {
   @ParameterizedTest
   @MethodSource("mlKemParamSets")
   public void testDecapsulationEquivalenceSeedAndExpanded(String paramSet) throws Exception {
-    // Runs in every build: expandPrivateKeyInternal is compiled unconditionally and parses through
-    // der2EvpPrivateKey, which accepts the seed and expandedKey CHOICEs of RFC 9935 everywhere. In
-    // regular FIPS the generated key already reports the expanded encoding, so the expansion is a
-    // no-op there and this degenerates into an expanded-to-expanded check, still worth running.
     KeyPairGenerator keyGen = KeyPairGenerator.getInstance(paramSet, NATIVE_PROVIDER);
     KeyPair keyPair = keyGen.generateKeyPair();
 

--- a/tst/com/amazon/corretto/crypto/provider/test/jdk17plus/MlKemTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/jdk17plus/MlKemTest.java
@@ -213,8 +213,8 @@ public class MlKemTest {
   @MethodSource("mlKemParamSets")
   public void testKeyPairGeneratorGeneratesWithoutInitialize(String paramSet) throws Exception {
     // Each ML-KEM KeyPairGenerator is bound to its parameter set at construction, so
-    // generateKeyPair
-    // works with no initialize() call at all -- the path a caller that never sets a spec takes.
+    // generateKeyPair works with no initialize() call at all -- the path a caller that never sets
+    // a spec takes.
     KeyPair keyPair = KeyPairGenerator.getInstance(paramSet, NATIVE_PROVIDER).generateKeyPair();
     assertEquals(paramSet, keyPair.getPublic().getAlgorithm());
     assertEquals(paramSet, keyPair.getPrivate().getAlgorithm());
@@ -493,10 +493,11 @@ public class MlKemTest {
   @MethodSource("mlKemParamSets")
   public void testMalformedPkcs8PrivateKeysRejected(String paramSet) throws Exception {
     // Negative counterpart to testPkcs8OneAsymmetricKeyFieldsAccepted. Every variant below is
-    // outside
-    // the PKCS#8 grammar for ML-KEM and must be rejected both by AWS-LC's EVP_parse_private_key
-    // (the
-    // non-FIPS decoder) and by ACCP's hand-rolled regular-FIPS fallover parser.
+    // outside the PKCS#8 grammar for ML-KEM, and each is rejected by both decoders that can see
+    // it: AWS-LC's EVP_parse_private_key in non-FIPS and experimental-FIPS builds, and ACCP's
+    // hand-rolled fallover parser in regular FIPS. There is exactly one input class the two
+    // disagree on under the currently pinned AWS-LC; it is asserted build-conditionally and
+    // explained where it appears.
     ASN1Sequence pkcs8 =
         ASN1Sequence.getInstance(
             KeyPairGenerator.getInstance(paramSet, NATIVE_PROVIDER)
@@ -550,11 +551,15 @@ public class MlKemTest {
               algorithm, new DERTaggedObject(false, 0, new DEROctetString(new byte[seedLen]))));
     }
 
-    // Wrong encoding form for each of the two optional trailing fields. AWS-LC's
-    // EVP_parse_private_key recognizes attributes only as a constructed [0] (kAttributesTag) and
-    // publicKey only as a primitive [1] (kPublicKeyTag), so the other form of either tag goes
-    // unrecognized and trips its check for trailing data inside the SEQUENCE. ACCP's fallover
-    // parser spells both tags the same way, which is what these two cases pin.
+    // Wrong encoding form for each of the two optional trailing fields. ACCP's fallover parser
+    // recognizes attributes only as a constructed [0] and publicKey only as a primitive [1], the
+    // way AWS-LC v5.0.0 spells kAttributesTag and kPublicKeyTag, so it treats the other form of
+    // either tag as unrecognized trailing data inside the SEQUENCE and rejects the key.
+    //
+    // A primitive [0] where attributes belong is rejected everywhere, though the pinned non-FIPS
+    // AWS-LC v1.72.0 gets there by another route: its kAttributesTag is the primitive form, so it
+    // matches, but it then tries to consume the field from the outer CBS it has already advanced
+    // past the SEQUENCE, and fails.
     assertPrivateKeyRejected(
         keyFactory,
         paramSet + " primitive [0] attributes",
@@ -567,9 +572,15 @@ public class MlKemTest {
                 })
             .getEncoded("DER"));
 
-    assertPrivateKeyRejected(
-        keyFactory,
-        paramSet + " constructed [1] publicKey",
+    // A constructed [1] where a primitive [1] publicKey belongs is the one input class the builds
+    // disagree on, and the disagreement is entirely on AWS-LC's side of it. ACCP's parser rejects
+    // it, so regular FIPS -- where that parser is the whole ML-KEM decoder -- rejects it. AWS-LC
+    // v1.72.0 matches neither of its tags against 0xA1 and never checks for trailing data inside
+    // the SEQUENCE, so it accepts the key and silently ignores the field; in non-FIPS and
+    // experimental-FIPS builds d2i_PrivateKey therefore succeeds before the fallover is consulted.
+    // v5.0.0 rejects it, so this collapses to an unconditional rejection once the pinned mainline
+    // tag reaches v5.x, at which point the else branch below should be deleted.
+    byte[] constructedPublicKey =
         new DERSequence(
                 new ASN1Encodable[] {
                   new ASN1Integer(1),
@@ -577,7 +588,20 @@ public class MlKemTest {
                   privateKey,
                   new DERTaggedObject(true, 1, new DERBitString(new byte[32]))
                 })
-            .getEncoded("DER"));
+            .getEncoded("DER");
+    if (NATIVE_PROVIDER.isFips() && !NATIVE_PROVIDER.isExperimentalFips()) {
+      assertPrivateKeyRejected(
+          keyFactory, paramSet + " constructed [1] publicKey", constructedPublicKey);
+    } else {
+      // Pin that AWS-LC ignores the field rather than absorbing any of it into the key: the result
+      // must re-encode to exactly the key the bogus field was grafted onto.
+      PrivateKey ignored =
+          keyFactory.generatePrivate(new PKCS8EncodedKeySpec(constructedPublicKey));
+      assertArrayEquals(
+          pkcs8.getEncoded("DER"),
+          ignored.getEncoded(),
+          paramSet + " AWS-LC v1.72.0 must ignore a constructed [1] publicKey, not absorb it");
+    }
 
     // A publicKey field is permitted only in a version 1 OneAsymmetricKey.
     assertPrivateKeyRejected(

--- a/tst/com/amazon/corretto/crypto/provider/test/jdk17plus/MlKemTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/jdk17plus/MlKemTest.java
@@ -495,8 +495,8 @@ public class MlKemTest {
     // Negative counterpart to testPkcs8OneAsymmetricKeyFieldsAccepted. Every variant below is
     // outside the PKCS#8 grammar for ML-KEM, and each is rejected by both decoders that can see
     // it: AWS-LC's EVP_parse_private_key in non-FIPS and experimental-FIPS builds, and ACCP's
-    // hand-rolled fallover parser in regular FIPS. There is exactly one input class the two
-    // disagree on under the currently pinned AWS-LC; it is asserted build-conditionally and
+    // hand-rolled fallover parser in regular FIPS. There is exactly one input class the decoders
+    // disagree on, both across builds and across AWS-LC versions; it is handled separately and
     // explained where it appears.
     ASN1Sequence pkcs8 =
         ASN1Sequence.getInstance(
@@ -572,14 +572,15 @@ public class MlKemTest {
                 })
             .getEncoded("DER"));
 
-    // A constructed [1] where a primitive [1] publicKey belongs is the one input class the builds
+    // A constructed [1] where a primitive [1] publicKey belongs is the one input class the decoders
     // disagree on, and the disagreement is entirely on AWS-LC's side of it. ACCP's parser rejects
-    // it, so regular FIPS -- where that parser is the whole ML-KEM decoder -- rejects it. AWS-LC
-    // v1.72.0 matches neither of its tags against 0xA1 and never checks for trailing data inside
-    // the SEQUENCE, so it accepts the key and silently ignores the field; in non-FIPS and
-    // experimental-FIPS builds d2i_PrivateKey therefore succeeds before the fallover is consulted.
-    // v5.0.0 rejects it, so this collapses to an unconditional rejection once the pinned mainline
-    // tag reaches v5.x, at which point the else branch below should be deleted.
+    // it, so regular FIPS -- where that parser is the whole ML-KEM decoder -- rejects it, and so
+    // does AWS-LC v5.0.0 and later. The pinned v1.72.0 matches neither of its tags against 0xA1 and
+    // never checks for trailing data inside the SEQUENCE, so it accepts the key and silently
+    // ignores the field; in non-FIPS and experimental-FIPS builds d2i_PrivateKey therefore succeeds
+    // before the fallover is consulted. ACCP is built against both the pinned tag and AWS-LC HEAD,
+    // so pin neither answer: require only that the field is never absorbed into the key, which
+    // leaves rejecting it and ignoring it equally acceptable.
     byte[] constructedPublicKey =
         new DERSequence(
                 new ASN1Encodable[] {
@@ -593,14 +594,18 @@ public class MlKemTest {
       assertPrivateKeyRejected(
           keyFactory, paramSet + " constructed [1] publicKey", constructedPublicKey);
     } else {
-      // Pin that AWS-LC ignores the field rather than absorbing any of it into the key: the result
-      // must re-encode to exactly the key the bogus field was grafted onto.
-      PrivateKey ignored =
-          keyFactory.generatePrivate(new PKCS8EncodedKeySpec(constructedPublicKey));
-      assertArrayEquals(
-          pkcs8.getEncoded("DER"),
-          ignored.getEncoded(),
-          paramSet + " AWS-LC v1.72.0 must ignore a constructed [1] publicKey, not absorb it");
+      try {
+        // If AWS-LC accepts the key, it must have ignored the field rather than absorbed any of it:
+        // the result has to re-encode to exactly the key the bogus field was grafted onto.
+        PrivateKey ignored =
+            keyFactory.generatePrivate(new PKCS8EncodedKeySpec(constructedPublicKey));
+        assertArrayEquals(
+            pkcs8.getEncoded("DER"),
+            ignored.getEncoded(),
+            paramSet + " a constructed [1] publicKey must be ignored, not absorbed");
+      } catch (InvalidKeySpecException expected) {
+        // AWS-LC v5.0.0 and later reject it outright, which is the stricter of the two answers.
+      }
     }
 
     // A publicKey field is permitted only in a version 1 OneAsymmetricKey.

--- a/tst/com/amazon/corretto/crypto/provider/test/jdk17plus/MlKemTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/jdk17plus/MlKemTest.java
@@ -393,6 +393,13 @@ public class MlKemTest {
             new PKCS8EncodedKeySpec(
                 pkcs8WithPrivateKeyChoice(algorithm, new DEROctetString(expanded)))),
         paramSet + " the expandedKey half alone must be accepted");
+
+    // MlKemUtils.expandPrivateKey parses through the same grammar, so it rejects the both CHOICE
+    // too rather than handing the input back unchanged. Note that this is reachable with a stock
+    // BouncyCastle key: getAlgorithm() on one is the parameter-set name, so the ML-KEM check in
+    // expandPrivateKey passes and the both-encoded getEncoded() reaches the native parser. The
+    // rejection is unchecked because expandPrivateKey declares no checked exceptions.
+    assertThrows(RuntimeCryptoException.class, () -> MlKemUtils.expandPrivateKey(bcPriv));
   }
 
   @ParameterizedTest
@@ -631,6 +638,88 @@ public class MlKemTest {
             .getEncoded("DER");
     assertPrivateKeyRejected(
         keyFactory, paramSet + " trailing byte", Arrays.copyOf(valid, valid.length + 1));
+
+    // Trailing garbage after the CHOICE but still inside the privateKey OCTET STRING. ACCP's parser
+    // rejects this, which is deliberately stricter than kem_priv_decode: that function extracts the
+    // CHOICE and never looks at what follows it, in every AWS-LC version. Ignoring the bytes would
+    // let unbounded caller-controlled data ride along inside an encoding ACCP declares well-formed,
+    // and would make two distinct DER encodings decode to the same key so that getEncoded() no
+    // longer round-trips. Nothing any AWS-LC encoder emits has such trailing bytes, so the extra
+    // strictness cannot refuse a key the library itself produced. As with the constructed [1]
+    // publicKey above, only regular FIPS -- where ACCP's parser is the whole ML-KEM decoder -- can
+    // be held to the stricter answer; elsewhere d2i_PrivateKey is consulted first and all that can
+    // be required is that the trailing byte is not absorbed into the key.
+    byte[] choice = ASN1OctetString.getInstance(privateKey).getOctets();
+    byte[] trailingInsideChoice =
+        new DERSequence(
+                new ASN1Encodable[] {
+                  new ASN1Integer(0),
+                  algorithm,
+                  new DEROctetString(Arrays.copyOf(choice, choice.length + 1))
+                })
+            .getEncoded("DER");
+    if (NATIVE_PROVIDER.isFips() && !NATIVE_PROVIDER.isExperimentalFips()) {
+      assertPrivateKeyRejected(
+          keyFactory,
+          paramSet + " trailing byte inside the privateKey OCTET STRING",
+          trailingInsideChoice);
+    } else {
+      try {
+        PrivateKey ignored =
+            keyFactory.generatePrivate(new PKCS8EncodedKeySpec(trailingInsideChoice));
+        assertArrayEquals(
+            pkcs8.getEncoded("DER"),
+            ignored.getEncoded(),
+            paramSet + " a trailing byte inside the privateKey OCTET STRING must be ignored");
+      } catch (InvalidKeySpecException expected) {
+        // Rejecting it outright is the stricter of the two acceptable answers.
+      }
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("mlKemParamSets")
+  public void testExpandPrivateKeyNormalizesEncoding(String paramSet) throws Exception {
+    // MlKemUtils.expandPrivateKey parses and re-encodes every input rather than short-circuiting on
+    // the input length the way its ML-DSA counterpart does, so its output is always the canonical
+    // minimal expandedKey PKCS#8: version 0, no attributes, no publicKey. The optional
+    // OneAsymmetricKey fields are accepted on input but are not carried over, so the method is
+    // idempotent on its own output rather than byte-preserving on arbitrary input.
+    KeyPair keyPair = KeyPairGenerator.getInstance(paramSet, NATIVE_PROVIDER).generateKeyPair();
+    byte[] canonical = MlKemUtils.expandPrivateKey(keyPair.getPrivate());
+    assertEquals(
+        CHOICE_TAG_EXPANDED,
+        privateKeyChoiceTag(canonical),
+        paramSet + " expandPrivateKey must emit the expandedKey CHOICE");
+    ASN1Sequence canonicalSeq = ASN1Sequence.getInstance(canonical);
+    assertEquals(
+        3, canonicalSeq.size(), paramSet + " expandPrivateKey must emit no optional fields");
+    assertEquals(
+        0,
+        ASN1Integer.getInstance(canonicalSeq.getObjectAt(0)).intValueExact(),
+        paramSet + " expandPrivateKey must emit a version 0 PrivateKeyInfo");
+    assertArrayEquals(
+        canonical,
+        MlKemUtils.expandPrivateKey(rawPrivateKey(paramSet, canonical)),
+        paramSet + " expandPrivateKey must be idempotent on its own output");
+
+    // Decorate that canonical encoding with both optional fields a version 1 OneAsymmetricKey may
+    // carry: a constructed [0] attributes SET and a primitive [1] publicKey BIT STRING. Both are
+    // accepted, and both are dropped rather than reflected in the output.
+    byte[] decorated =
+        new DERSequence(
+                new ASN1Encodable[] {
+                  new ASN1Integer(1),
+                  canonicalSeq.getObjectAt(1),
+                  canonicalSeq.getObjectAt(2),
+                  new DERTaggedObject(false, 0, new DERSet()),
+                  new DERTaggedObject(false, 1, new DERBitString(new byte[32]))
+                })
+            .getEncoded("DER");
+    assertArrayEquals(
+        canonical,
+        MlKemUtils.expandPrivateKey(rawPrivateKey(paramSet, decorated)),
+        paramSet + " expandPrivateKey must drop attributes and publicKey");
   }
 
   @ParameterizedTest
@@ -738,6 +827,30 @@ public class MlKemTest {
               new DEROctetString(choice.toASN1Primitive().getEncoded("DER"))
             })
         .getEncoded("DER");
+  }
+
+  // MlKemUtils.expandPrivateKey takes a PrivateKey and forwards key.getEncoded(), so exercising it
+  // on a hand-built encoding needs a key that hands those bytes back verbatim. Routing them through
+  // a KeyFactory first would re-encode the key and discard the very fields under test.
+  private static PrivateKey rawPrivateKey(String paramSet, byte[] der) {
+    return new PrivateKey() {
+      private static final long serialVersionUID = 1L;
+
+      @Override
+      public String getAlgorithm() {
+        return paramSet;
+      }
+
+      @Override
+      public String getFormat() {
+        return "PKCS#8";
+      }
+
+      @Override
+      public byte[] getEncoded() {
+        return der.clone();
+      }
+    };
   }
 
   private static ASN1Encodable bothChoice(byte[] seed, byte[] expanded) {

--- a/tst/com/amazon/corretto/crypto/provider/test/jdk17plus/MlKemTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/jdk17plus/MlKemTest.java
@@ -12,6 +12,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import com.amazon.corretto.crypto.provider.AmazonCorrettoCryptoProvider;
+import com.amazon.corretto.crypto.provider.RuntimeCryptoException;
 import com.amazon.corretto.crypto.utils.MlKemUtils;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.KeyFactory;
@@ -34,6 +35,7 @@ import javax.crypto.SecretKey;
 import org.bouncycastle.asn1.ASN1Encodable;
 import org.bouncycastle.asn1.ASN1Integer;
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
+import org.bouncycastle.asn1.ASN1OctetString;
 import org.bouncycastle.asn1.ASN1Sequence;
 import org.bouncycastle.asn1.DERBitString;
 import org.bouncycastle.asn1.DEROctetString;
@@ -62,6 +64,11 @@ public class MlKemTest {
   private static final String[] ML_KEM_PARAM_SETS = {"ML-KEM-512", "ML-KEM-768", "ML-KEM-1024"};
   // An OID under an unassigned private-enterprise arc, so no provider maps it to an algorithm.
   private static final String UNASSIGNED_OID = "1.3.6.1.4.1.99999.1";
+  // Identifying tag bytes of the three ML-KEM private-key CHOICEs of RFC 9935 Section 6, as they
+  // appear at the start of the privateKey OCTET STRING's contents.
+  private static final int CHOICE_TAG_SEED = 0x80; // [0] IMPLICIT OCTET STRING, primitive
+  private static final int CHOICE_TAG_EXPANDED = 0x04; // OCTET STRING
+  private static final int CHOICE_TAG_BOTH = 0x30; // SEQUENCE { seed, expandedKey }
 
   private static String[] mlKemParamSets() {
     return ML_KEM_PARAM_SETS;
@@ -257,8 +264,7 @@ public class MlKemTest {
   @Test
   public void testKeyFactorySelfConversion() throws Exception {
     // Round-trips ACCP's own ML-KEM key pair through its KeyFactory. In regular FIPS the private
-    // key
-    // serializes in expanded format (seed format is unavailable there), so this exercises the
+    // key serializes in expanded format (seed format is unavailable there), so this exercises the
     // expanded encode/decode; in other builds it exercises the seed format. Public keys use X.509.
     KeyPairGenerator keyGen = KeyPairGenerator.getInstance("ML-KEM", NATIVE_PROVIDER);
     KeyPair originalKeyPair = keyGen.generateKeyPair();
@@ -276,27 +282,33 @@ public class MlKemTest {
 
   @ParameterizedTest
   @MethodSource("mlKemParamSets")
-  public void testSeedFormatPrivateKeyParses(String paramSet) throws Exception {
-    // ACCP cannot *emit* seed-format ML-KEM private keys in regular FIPS (AWS-LC-FIPS 3.1.0 stores
-    // no
-    // keygen seed, so getEncoded emits the expanded form), but it can *parse* one: a seed-format
-    // PKCS#8 is expanded into a full key via EVP_PKEY_keygen_deterministic. This verifies that path
-    // by importing a BouncyCastle-produced key in both its seed and expanded encodings and
-    // confirming
-    // the two ACCP keys decapsulate a ciphertext to the same shared secret. The assertion is
-    // encoding-independent, so it runs in all builds (regular FIPS uses the hand-rolled seed
-    // expansion; other builds parse the seed via AWS-LC directly).
+  public void testPrivateKeyChoicesParse(String paramSet) throws Exception {
+    // ACCP parses the seed and expandedKey CHOICEs of RFC 9935 Section 6 in every build. Those
+    // are the two mainline AWS-LC implements, and ACCP's regular-FIPS fallover parser exists to
+    // stand in for that decoder, so it accepts exactly them and no more (see the both CHOICE in
+    // testBothChoiceRejected). AWS-LC-FIPS 3.1.0 decodes neither, so in regular FIPS the fallover
+    // parser is what accepts both encodings here. Every assertion is encoding-independent: the
+    // two encodings carry the same key material, so each must decapsulate a given ciphertext to
+    // the same shared secret.
     KeyPairGenerator bcKeyGen = KeyPairGenerator.getInstance("ML-KEM", TestUtil.BC_PROVIDER);
     bcKeyGen.initialize(TestUtil.getMlKemParamSpec(paramSet));
     KeyPair bcKeyPair = bcKeyGen.generateKeyPair();
     MLKEMPrivateKey bcPriv = (MLKEMPrivateKey) bcKeyPair.getPrivate();
 
+    byte[] seedForm = bcPriv.getPrivateKey(true).getEncoded();
+    byte[] expandedForm = bcPriv.getPrivateKey(false).getEncoded();
+    // Guard the premise of the test: these really are the two distinct CHOICEs, so a change in what
+    // BouncyCastle emits cannot quietly turn this into two copies of the same coverage.
+    assertEquals(
+        CHOICE_TAG_SEED,
+        privateKeyChoiceTag(seedForm),
+        paramSet + " getPrivateKey(true) is the seed");
+    assertEquals(
+        CHOICE_TAG_EXPANDED,
+        privateKeyChoiceTag(expandedForm),
+        paramSet + " getPrivateKey(false) is the expandedKey");
+
     KeyFactory accpKf = KeyFactory.getInstance(paramSet, NATIVE_PROVIDER);
-    // getPrivateKey(true) yields the seed-format encoding; getPrivateKey(false) the expanded form.
-    PrivateKey fromSeed =
-        accpKf.generatePrivate(new PKCS8EncodedKeySpec(bcPriv.getPrivateKey(true).getEncoded()));
-    PrivateKey fromExpanded =
-        accpKf.generatePrivate(new PKCS8EncodedKeySpec(bcPriv.getPrivateKey(false).getEncoded()));
     PublicKey accpPub =
         accpKf.generatePublic(new X509EncodedKeySpec(bcKeyPair.getPublic().getEncoded()));
 
@@ -305,18 +317,117 @@ public class MlKemTest {
     KEM.Encapsulated encapsulated = kem.newEncapsulator(accpPub, paramSpec, null).encapsulate();
     byte[] ciphertext = encapsulated.encapsulation();
 
-    SecretKey secretFromSeed = kem.newDecapsulator(fromSeed, paramSpec).decapsulate(ciphertext);
-    SecretKey secretFromExpanded =
-        kem.newDecapsulator(fromExpanded, paramSpec).decapsulate(ciphertext);
+    for (byte[] encoding : new byte[][] {seedForm, expandedForm}) {
+      PrivateKey parsed = accpKf.generatePrivate(new PKCS8EncodedKeySpec(encoding));
+      assertArrayEquals(
+          encapsulated.key().getEncoded(),
+          kem.newDecapsulator(parsed, paramSpec).decapsulate(ciphertext).getEncoded(),
+          paramSet
+              + " private key parsed from CHOICE tag 0x"
+              + Integer.toHexString(privateKeyChoiceTag(encoding))
+              + " must decapsulate to the encapsulated shared secret");
+    }
 
+    // Re-encoding a seed-imported key is where the builds diverge, so pin both sides of it:
+    // regular FIPS silently widens the seed to the expanded form because AWS-LC-FIPS 3.1.0
+    // retains no keygen seed, while every other flavor gives the seed encoding back unchanged.
+    // TODO [AWS-LC-FIPS 5.0]: regular FIPS should re-emit the seed once the module retains it.
+    byte[] reEncodedSeed = accpKf.generatePrivate(new PKCS8EncodedKeySpec(seedForm)).getEncoded();
+    if (NATIVE_PROVIDER.isFips() && !NATIVE_PROVIDER.isExperimentalFips()) {
+      assertEquals(
+          CHOICE_TAG_EXPANDED,
+          privateKeyChoiceTag(reEncodedSeed),
+          paramSet + " regular FIPS re-emits a seed-imported private key in expanded form");
+      assertArrayEquals(
+          expandedForm,
+          reEncodedSeed,
+          paramSet + " the widened encoding must match BouncyCastle's expandedKey encoding");
+    } else {
+      assertArrayEquals(
+          seedForm, reEncodedSeed, paramSet + " the seed encoding must round-trip unchanged");
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("mlKemParamSets")
+  public void testBothChoiceRejected(String paramSet) throws Exception {
+    // The both CHOICE (SEQUENCE { seed, expandedKey }) is well-formed RFC 9935 Section 6 and is
+    // what BouncyCastle's ML-KEM getEncoded() emits by default, but no AWS-LC flavor decodes it,
+    // mainline included: kem_priv_decode there still says "Case 3 ... not implemented yet".
+    // ACCP's regular-FIPS fallover parser deliberately matches that rejection instead of filling
+    // the gap, so that deleting the parser once AWS-LC-FIPS decodes ML-KEM natively cannot
+    // silently withdraw support ACCP had advertised. This test pins the rejection so that support
+    // can only ever be added on purpose, together with AWS-LC.
+    KeyPairGenerator bcKeyGen = KeyPairGenerator.getInstance("ML-KEM", TestUtil.BC_PROVIDER);
+    bcKeyGen.initialize(TestUtil.getMlKemParamSpec(paramSet));
+    MLKEMPrivateKey bcPriv = (MLKEMPrivateKey) bcKeyGen.generateKeyPair().getPrivate();
+    byte[] bothForm = bcPriv.getEncoded();
+    assertEquals(
+        CHOICE_TAG_BOTH,
+        privateKeyChoiceTag(bothForm),
+        paramSet + " BouncyCastle getEncoded() is the both SEQUENCE");
+
+    KeyFactory keyFactory = KeyFactory.getInstance(paramSet, NATIVE_PROVIDER);
+    assertPrivateKeyRejected(
+        keyFactory, paramSet + " BouncyCastle's default both encoding", bothForm);
+
+    // Also reject it when nothing else about the encoding is unusual: same algorithm, same version
+    // 0 PrivateKeyInfo shell as the seed and expandedKey encodings ACCP does accept, and a seed and
+    // expandedKey that agree with each other. The CHOICE alone is the reason for the rejection.
+    ASN1Encodable algorithm = ASN1Sequence.getInstance(bothForm).getObjectAt(1);
+    ASN1Sequence both = ASN1Sequence.getInstance(privateKeyChoiceBytes(bothForm));
+    byte[] seed = ASN1OctetString.getInstance(both.getObjectAt(0)).getOctets();
+    byte[] expanded = ASN1OctetString.getInstance(both.getObjectAt(1)).getOctets();
+    assertPrivateKeyRejected(
+        keyFactory,
+        paramSet + " a self-consistent both CHOICE in a version 0 PrivateKeyInfo",
+        pkcs8WithPrivateKeyChoice(algorithm, bothChoice(seed, expanded)));
+
+    // The halves on their own are accepted, so the rejections above are attributable to the CHOICE
+    // rather than to this test having mangled the key material or the shell.
+    assertNotNull(
+        keyFactory.generatePrivate(
+            new PKCS8EncodedKeySpec(
+                pkcs8WithPrivateKeyChoice(
+                    algorithm, new DERTaggedObject(false, 0, new DEROctetString(seed))))),
+        paramSet + " the seed half alone must be accepted");
+    assertNotNull(
+        keyFactory.generatePrivate(
+            new PKCS8EncodedKeySpec(
+                pkcs8WithPrivateKeyChoice(algorithm, new DEROctetString(expanded)))),
+        paramSet + " the expandedKey half alone must be accepted");
+  }
+
+  @ParameterizedTest
+  @MethodSource("mlKemParamSets")
+  public void testImportedPrivateKeyPublicKeyAvailability(String paramSet) throws Throwable {
+    // ACCP reconstructs an imported ML-KEM private key the same way mainline AWS-LC's decoder
+    // does, one CHOICE at a time, so the two agree per CHOICE in every build: seed derives the
+    // whole key pair, while expandedKey sets only the raw secret key (KEM_KEY_set_raw_secret_key)
+    // and leaves the public key unpopulated. Encoding the public key of an expandedKey-imported
+    // private key therefore fails instead of returning its SPKI. Pinned here so the asymmetry
+    // cannot change silently in either direction: closing it in ACCP alone would be a divergence
+    // from AWS-LC.
+    KeyPairGenerator bcKeyGen = KeyPairGenerator.getInstance("ML-KEM", TestUtil.BC_PROVIDER);
+    bcKeyGen.initialize(TestUtil.getMlKemParamSpec(paramSet));
+    KeyPair bcKeyPair = bcKeyGen.generateKeyPair();
+    MLKEMPrivateKey bcPriv = (MLKEMPrivateKey) bcKeyPair.getPrivate();
+    byte[] spki = bcKeyPair.getPublic().getEncoded();
+    KeyFactory accpKf = KeyFactory.getInstance(paramSet, NATIVE_PROVIDER);
+
+    PrivateKey fromSeed =
+        accpKf.generatePrivate(new PKCS8EncodedKeySpec(bcPriv.getPrivateKey(true).getEncoded()));
+    PublicKey pubFromSeed = TestUtil.sneakyInvoke(fromSeed, "getPublicKey");
     assertArrayEquals(
-        encapsulated.key().getEncoded(),
-        secretFromSeed.getEncoded(),
-        paramSet + " seed-parsed private key must decapsulate to the encapsulated shared secret");
-    assertArrayEquals(
-        secretFromExpanded.getEncoded(),
-        secretFromSeed.getEncoded(),
-        paramSet + " seed-parsed and expanded-parsed keys must decapsulate identically");
+        spki,
+        pubFromSeed.getEncoded(),
+        paramSet + " a seed-derived private key must carry the matching public key");
+
+    PrivateKey fromExpanded =
+        accpKf.generatePrivate(new PKCS8EncodedKeySpec(bcPriv.getPrivateKey(false).getEncoded()));
+    PublicKey pubFromExpanded = TestUtil.sneakyInvoke(fromExpanded, "getPublicKey");
+    // An expandedKey-imported private key carries no public key, so encoding it fails.
+    assertThrows(RuntimeCryptoException.class, pubFromExpanded::getEncoded);
   }
 
   @ParameterizedTest
@@ -430,6 +541,50 @@ public class MlKemTest {
                 })
             .getEncoded("DER"));
 
+    // Seed CHOICEs of the wrong size. Every ML-KEM parameter set uses a 64-byte keygen seed
+    // (d || z), so each of these must be rejected outright rather than truncated, zero-padded, or
+    // handed to EVP_PKEY_keygen_deterministic to validate. 0 exercises the empty OCTET STRING, 63
+    // and 65 the off-by-one boundaries, and 128 a plausible-looking multiple of 64.
+    for (int seedLen : new int[] {0, 63, 65, 128}) {
+      assertPrivateKeyRejected(
+          keyFactory,
+          paramSet + " seed of " + seedLen + " bytes",
+          pkcs8WithPrivateKeyChoice(
+              algorithm, new DERTaggedObject(false, 0, new DEROctetString(new byte[seedLen]))));
+    }
+
+    // Wrong encoding form for the attributes field: mainline AWS-LC's EVP_parse_private_key
+    // recognizes attributes only as a constructed [0] (kAttributesTag), so a primitive [0] is
+    // unrecognized and trips its trailing-data check. ACCP's fallover parser spells the same tag,
+    // which is what this pins. There is deliberately no matching case for a constructed [1] where
+    // a primitive [1] publicKey belongs: mainline rejects that as trailing data too, but the
+    // AWS-LC v1.72.0 the non-FIPS build links predates the trailing-data check and accepts it, so
+    // asserting on it would pin the AWS-LC version rather than the ML-KEM grammar.
+    assertPrivateKeyRejected(
+        keyFactory,
+        paramSet + " primitive [0] attributes",
+        new DERSequence(
+                new ASN1Encodable[] {
+                  new ASN1Integer(0),
+                  algorithm,
+                  privateKey,
+                  new DERTaggedObject(false, 0, new DEROctetString(new byte[0]))
+                })
+            .getEncoded("DER"));
+
+    // A publicKey field is permitted only in a version 1 OneAsymmetricKey.
+    assertPrivateKeyRejected(
+        keyFactory,
+        paramSet + " version 0 with a publicKey",
+        new DERSequence(
+                new ASN1Encodable[] {
+                  new ASN1Integer(0),
+                  algorithm,
+                  privateKey,
+                  new DERTaggedObject(false, 1, new DERBitString(new byte[32]))
+                })
+            .getEncoded("DER"));
+
     // Trailing garbage after the PrivateKeyInfo SEQUENCE.
     byte[] valid =
         new DERSequence(new ASN1Encodable[] {new ASN1Integer(0), algorithm, privateKey})
@@ -521,6 +676,33 @@ public class MlKemTest {
     } catch (InvalidKeySpecException expected) {
       // Expected: the encoding is outside the grammar ACCP accepts.
     }
+  }
+
+  // Contents of the privateKey OCTET STRING of a PKCS#8 ML-KEM private key, i.e. the DER of
+  // whichever CHOICE of RFC 9935 Section 6 the encoding carries.
+  private static byte[] privateKeyChoiceBytes(byte[] pkcs8) {
+    return ASN1OctetString.getInstance(ASN1Sequence.getInstance(pkcs8).getObjectAt(2)).getOctets();
+  }
+
+  private static int privateKeyChoiceTag(byte[] pkcs8) {
+    return privateKeyChoiceBytes(pkcs8)[0] & 0xFF;
+  }
+
+  // Wraps a private-key CHOICE, well-formed or not, in an otherwise valid version 0 PrivateKeyInfo.
+  private static byte[] pkcs8WithPrivateKeyChoice(ASN1Encodable algorithm, ASN1Encodable choice)
+      throws Exception {
+    return new DERSequence(
+            new ASN1Encodable[] {
+              new ASN1Integer(0),
+              algorithm,
+              new DEROctetString(choice.toASN1Primitive().getEncoded("DER"))
+            })
+        .getEncoded("DER");
+  }
+
+  private static ASN1Encodable bothChoice(byte[] seed, byte[] expanded) {
+    return new DERSequence(
+        new ASN1Encodable[] {new DEROctetString(seed), new DEROctetString(expanded)});
   }
 
   private static void assertPublicKeyRejected(KeyFactory keyFactory, String label, byte[] der)
@@ -628,12 +810,11 @@ public class MlKemTest {
   @ParameterizedTest
   @MethodSource("mlKemParamSets")
   public void testPrivateKeyEncodingIsSeedFormat(String paramSet) throws Exception {
-    // ACCP cannot EMIT the seed encoding in regular FIPS: AWS-LC-FIPS 3.1.0 stores no keygen seed,
-    // so
-    // getEncoded() produces the expanded form instead. (Seed PARSING is supported -- see
-    // testSeedFormatPrivateKeyParses.) TODO: remove this guard once AWS-LC-FIPS is bumped to
-    // v5.0.0,
-    // which retains the seed and can re-emit it.
+    // ACCP cannot EMIT the seed encoding in regular FIPS: AWS-LC-FIPS 3.1.0 stores no keygen
+    // seed, so getEncoded() produces the expanded form instead. (Seed PARSING is supported
+    // everywhere; see testPrivateKeyChoicesParse, which also pins the expanded form regular FIPS
+    // emits here.)
+    // TODO [AWS-LC-FIPS 5.0]: drop this guard once the module retains the seed and can re-emit it.
     assumeTrue(
         !NATIVE_PROVIDER.isFips() || NATIVE_PROVIDER.isExperimentalFips(),
         "ML-KEM seed-format encoding is unavailable in regular FIPS");
@@ -654,14 +835,13 @@ public class MlKemTest {
   @ParameterizedTest
   @MethodSource("mlKemParamSets")
   public void testBouncyCastleInteroperability(String paramSet) throws Exception {
-    // This interop compares seed-format private-key encodings across providers, which needs ACCP to
-    // EMIT seed format; ACCP emits the expanded form in regular FIPS (AWS-LC-FIPS 3.1.0 stores no
-    // seed). Seed PARSING is supported -- see testSeedFormatPrivateKeyParses for a FIPS-capable BC
-    // seed round-trip. TODO: remove this guard once AWS-LC-FIPS is bumped to v5.0.0.
-    assumeTrue(
-        !NATIVE_PROVIDER.isFips() || NATIVE_PROVIDER.isExperimentalFips(),
-        "ML-KEM seed-format encoding is unavailable in regular FIPS");
-
+    // Runs in every build. Nothing here depends on WHICH private-key CHOICE ACCP emits: the
+    // assertions only require that BouncyCastle preserve whatever ACCP hands it, and BC
+    // round-trips the seed and expandedKey encodings alike byte for byte. So this covers the seed
+    // encoding in non-FIPS and experimental-FIPS builds and the expanded encoding in regular FIPS,
+    // where AWS-LC-FIPS 3.1.0 retains no keygen seed. testPrivateKeyChoicesParse covers the other
+    // direction, ACCP parsing BouncyCastle's seed and expandedKey encodings, and
+    // testBothChoiceRejected covers BouncyCastle's default both encoding.
     KeyPair accpKeyPair = KeyPairGenerator.getInstance(paramSet, NATIVE_PROVIDER).generateKeyPair();
 
     // Test BouncyCastle can import ACCP keys
@@ -682,14 +862,29 @@ public class MlKemTest {
         bcPriv.getEncoded(),
         "Private key encoding should be preserved");
 
+    // The expanded encoding is ACCP's other private-key output, and MlKemUtils.expandPrivateKey is
+    // the only way to obtain it in builds whose getEncoded() emits the seed. Feeding it to BC too
+    // means every private-key encoding ACCP can produce is checked against BC in this test.
+    byte[] accpExpanded = MlKemUtils.expandPrivateKey(accpKeyPair.getPrivate());
+    PrivateKey bcPrivFromExpanded = bcKf.generatePrivate(new PKCS8EncodedKeySpec(accpExpanded));
+    assertArrayEquals(
+        accpExpanded,
+        bcPrivFromExpanded.getEncoded(),
+        "Expanded private key encoding should be preserved");
+    assertArrayEquals(
+        ((MLKEMPrivateKey) bcPriv).getPrivateKey(false).getEncoded(),
+        accpExpanded,
+        "BouncyCastle and ACCP should agree on the expanded encoding of the same key");
+
     // Test BC keys and convert to ACCP using ACCP's key factory, test if they're equal
     KeyPairGenerator bcKeyGen = KeyPairGenerator.getInstance("ML-KEM", TestUtil.BC_PROVIDER);
     bcKeyGen.initialize(TestUtil.getMlKemParamSpec(paramSet));
     KeyPair bcKeyPair = bcKeyGen.generateKeyPair();
 
-    // set BC's private key to be encoded in expandedKey format, not seed, by passing false to
-    // getPrivateKey(), per https://datatracker.ietf.org/doc/draft-ietf-lamps-kyber-certificates/
-    // This is due to AWS-LC currently only supporting expandedKey format for encode/decode
+    // Ask BC for the expandedKey CHOICE specifically, per RFC 9935 Section 6, so this stays a
+    // like-for-like comparison of re-encodings: an expandedKey-imported ACCP key has no seed to
+    // emit, so it round-trips to the expanded form in every build. testPrivateKeyChoicesParse
+    // covers the seed CHOICE.
     // https://github.com/bcgit/bc-java/blob/b41f23936724284a20f10dff13c76896a846031b/prov/src/main/java/org/bouncycastle/jcajce/interfaces/MLKEMPrivateKey.java#L35
     MLKEMPrivateKey bcPrivateKeyExpanded =
         ((MLKEMPrivateKey) bcKeyPair.getPrivate()).getPrivateKey(false);
@@ -740,12 +935,10 @@ public class MlKemTest {
   @ParameterizedTest
   @MethodSource("mlKemParamSets")
   public void testDecapsulationEquivalenceSeedAndExpanded(String paramSet) throws Exception {
-    // This test expands via MlKemUtils.expandPrivateKey, whose native method
-    // (expandPrivateKeyInternal) is compiled only in non-FIPS / experimental-FIPS builds. Seed
-    // PARSING itself is supported in regular FIPS -- see testSeedFormatPrivateKeyParses.
-    assumeTrue(
-        !NATIVE_PROVIDER.isFips() || NATIVE_PROVIDER.isExperimentalFips(),
-        "MlKemUtils.expandPrivateKey is unavailable in regular FIPS");
+    // Runs in every build: expandPrivateKeyInternal is compiled unconditionally and parses through
+    // der2EvpPrivateKey, which accepts the seed and expandedKey CHOICEs of RFC 9935 everywhere. In
+    // regular FIPS the generated key already reports the expanded encoding, so the expansion is a
+    // no-op there and this degenerates into an expanded-to-expanded check, still worth running.
     KeyPairGenerator keyGen = KeyPairGenerator.getInstance(paramSet, NATIVE_PROVIDER);
     KeyPair keyPair = keyGen.generateKeyPair();
 

--- a/tst/com/amazon/corretto/crypto/provider/test/jdk17plus/MlKemTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/jdk17plus/MlKemTest.java
@@ -581,6 +581,10 @@ public class MlKemTest {
     // before the fallover is consulted. ACCP is built against both the pinned tag and AWS-LC HEAD,
     // so pin neither answer: require only that the field is never absorbed into the key, which
     // leaves rejecting it and ignoring it equally acceptable.
+    //
+    // TODO [AWS-LC-FIPS 4.x]: collapse this to the tolerant branch alone once the FIPS module
+    // implements priv_decode for ML-KEM. parseMLKEMPrivateKey goes away with it, and regular FIPS
+    // then answers with AWS-LC-FIPS's decoder rather than ACCP's own.
     byte[] constructedPublicKey =
         new DERSequence(
                 new ASN1Encodable[] {


### PR DESCRIPTION
Follow-up to #568. Adds ML-KEM **seed-format private-key parsing** in regular FIPS.

## Context

AWS-LC-FIPS 3.1.0's ML-KEM ASN.1 method implements no `priv_decode`/`priv_encode`. #568 hand-rolled the X.509 SubjectPublicKeyInfo and the expanded-format PKCS#8 for regular FIPS; it did not handle the seed CHOICE of [RFC 9935 Section 6](https://datatracker.ietf.org/doc/html/rfc9935#section-6).

## Change

`parseMLKEMPrivateKey` now peeks the privateKey CHOICE and handles both arms:

- **expandedKey** `OCTET STRING` -> `EVP_PKEY_kem_new_raw_secret_key` (public key left unpopulated, as in AWS-LC)
- **seed** `[0] IMPLICIT OCTET STRING` -> `EVP_PKEY_keygen_deterministic`, expanding the raw `d || z` into a full key pair

The parser itself is compiled in every build so its grammar cannot drift per flavor, but it only runs as a fallover after `d2i_PrivateKey` fails, so in non-FIPS and experimental FIPS it is effectively dead; in regular FIPS it is the entire ML-KEM decoder. The seed arm's expansion helper, and with it the `<openssl/experimental/kem_deterministic_api.h>` include that has no API-stability guarantee, are compiled only for regular FIPS -- the one flavor that can reach them -- and stubbed out elsewhere.

`MlKemUtils.expandPrivateKey` now routes through `der2EvpPrivateKey` and works in regular FIPS too.

`build.gradle` pins `awsLcMainTag` to `v1.72.0`. AWS-LC `be77a8ad3` (#3159) raised the CMake Go floor to 1.20 with a `FATAL_ERROR`, first released in v1.72.1; our Ubuntu CI image ships Go 1.18 and is difficult to change, so v1.72.0 is the highest mainline tag that still builds there. This costs no ML-KEM capability: v1.72.0's `kem_key_st` already carries a seed field, `pkey_kem_keygen` retains it, and `kem_priv_encode` re-emits the seed CHOICE.

## Behavior changes to `MlKemUtils.expandPrivateKey`

It previously short-circuited on the input length, handing anything already expanded straight back. It now parses and re-encodes unconditionally, which is what lets it work under FIPS, and that has three consequences worth calling out:

- **Inputs outside the grammar are rejected rather than echoed.** The `both` CHOICE (`SEQUENCE { seed, expandedKey }`) is the case that matters in practice, because it is what BouncyCastle's ML-KEM `getEncoded()` emits by default, and BC's `getAlgorithm()` is the parameter-set name so the method's ML-KEM check passes. Pinned by `testBothChoiceRejected`.
- **The rejection is unchecked.** `der2EvpPrivateKey` is now given `EX_RUNTIME_CRYPTO` rather than `EX_INVALID_KEY_SPEC`: `InvalidKeySpecException` is checked, and JNI would otherwise have thrown one out of a method whose signature does not declare it, where no caller can legally catch it. `@throws` tags added to the javadoc.
- **The output is always the canonical minimal form** -- version 0 `PrivateKeyInfo`, no `attributes`, no `publicKey`. Those optional `OneAsymmetricKey` fields are still accepted on input, but they are not carried over, so the method is idempotent on its own output rather than byte-preserving on arbitrary input. Pinned by `testExpandPrivateKeyNormalizesEncoding`.

## Parser strictness

Two places where the hand-rolled code is deliberately not just a transcription of AWS-LC:

- **Trailing bytes after the CHOICE, inside the privateKey `OCTET STRING`, are rejected.** `kem_priv_decode` extracts the CHOICE and never looks at what follows it, in every AWS-LC version. Ignoring them would let unbounded caller-controlled data ride along inside an encoding ACCP declares well-formed, and would make two distinct DER encodings decode to the same key so that `getEncoded()` no longer round-trips. Nothing any AWS-LC encoder emits has such trailing bytes, so this cannot refuse a key the library produced. Pinned build-conditionally in `testMalformedPkcs8PrivateKeysRejected`.
- **`encodeExpandedMLKEMPrivateKey` cross-checks the secret-key length against the public-key length** instead of inferring the ML-KEM OID from the secret-key length alone. Legacy Kyber-R3 sits under the same `EVP_PKEY_KEM` type with byte-for-byte identical key lengths, and unlike `encodeMLKEMPublicKey` this function has no caller-side guarantee that the library refused to encode the key -- `MlKemUtils.expandPrivateKey` reaches it in every build. Requiring both lengths to name the same parameter set refuses a KEM key of another family rather than relabeling it with an ML-KEM OID.

## Parser fidelity

The parser otherwise mirrors AWS-LC **v5.0.0** -- the decoder it is destined to be deleted in favor of -- not the v1.72.0 now pinned, so removing it after the AWS-LC-FIPS bump is as close to a no-op as it can be. It therefore rejects the `both` CHOICE (AWS-LC: "Case 3 ... not implemented yet") and spells attributes as constructed `[0]` and publicKey as primitive `[1]`.

v1.72.0 differs on that last point, and **neither grammar contains the other**, so the flavors are not strictly ordered: v1.72.0 accepts a constructed `[1]` where a primitive `[1]` publicKey belongs (it matches neither of its tags and never checks for trailing data inside the SEQUENCE), while this parser accepts a version 1 key carrying both a constructed `[0]` attributes and a primitive `[1]` publicKey, which v1.72.0 rejects. What makes that safe is not a containment relation but the fallover structure: outside regular FIPS a key is accepted if *either* decoder accepts it, so this parser can only ever widen what those builds accept, and in regular FIPS it is the only decoder. The divergence disappears once the pinned mainline tag reaches v5.x. The two input classes where the answer is version-dependent are asserted build-conditionally, requiring only that the bogus field is never absorbed into the key.

## Known difference

Regular FIPS cannot *serialize* the seed CHOICE: AWS-LC-FIPS 3.1.0's `KEM_KEY` has no seed field, so `getEncoded()` emits `expandedKey` where the other builds emit `seed`. Both CHOICEs are *parsed* everywhere, so a seed-format key imported via `KeyFactory` works in every build; it just re-encodes to the expanded form under FIPS. This is the only intended FIPS-vs-non-FIPS difference in ML-KEM key handling for well-formed keys, it is documented in `README.md`, and it goes away with the AWS-LC-FIPS v5.0.0 bump. Experimental FIPS tracks mainline AWS-LC and is unaffected.


<details>
<summary><b>ACCP / BouncyCastle ML-KEM compatibility matrix</b> (parse and serialize, per build flavor)</summary>

Only one of the three ACCP builds differs from the others for well-formed keys, and only in what it *emits* -- parsing of well-formed keys is identical across all three.

### A. Private key PKCS#8 -- parse (RFC 9935 Section 6 CHOICEs)

| Encoding | ACCP non-FIPS | ACCP exp-FIPS | ACCP regular FIPS | BC 1.85 |
|---|---|---|---|---|
| `seed [0]` (0x80, 86 bytes) | accept | accept | accept | accept |
| `expandedKey` (0x04) | accept | accept | accept | accept |
| `both SEQUENCE` (0x30) | **reject** | **reject** | **reject** | accept |
| CHOICE + trailing bytes inside the privateKey `OCTET STRING` | ignored by AWS-LC | ignored by AWS-LC | **reject** | -- |

ACCP's acceptance set for well-formed keys is uniform by design. In non-FIPS/exp-FIPS it comes from AWS-LC's `kem_priv_decode`; in regular FIPS from `parseMLKEMPrivateKey`. The `both` rejection is not a FIPS artifact -- no AWS-LC flavor implements Case 3 ("not implemented yet"), so ACCP rejects it everywhere. BC accepts it because BC is the thing that produces it. The last row is the one place ACCP is stricter than the library it wraps, and it only bites in regular FIPS, where ACCP's parser is the whole decoder.

Shell tolerance is otherwise uniform: RFC 5208 version 0 and RFC 5958 version 1, with optional `[0]` attributes and `[1]` publicKey, all accepted in every build.

### B. Private key PKCS#8 -- serialize

| Producer | `getEncoded()` of a generated key | re-encode of a seed-imported key | re-encode of an expanded-imported key |
|---|---|---|---|
| ACCP non-FIPS | `seed` (86 B) | `seed`, byte-identical | `expandedKey`, byte-identical |
| ACCP exp-FIPS | `seed` (86 B) | `seed`, byte-identical | `expandedKey`, byte-identical |
| ACCP regular FIPS | **`expandedKey`** | **widened to `expandedKey`** | `expandedKey`, byte-identical |
| BC 1.85 | **`both`** | `seed`, byte-identical | `expandedKey`, byte-identical |

`MlKemUtils.expandPrivateKey` yields the canonical minimal `expandedKey` PKCS#8 in all three builds and is idempotent on that form. It is not byte-preserving on arbitrary input: optional `OneAsymmetricKey` fields are accepted and dropped, and encodings it cannot parse raise `RuntimeCryptoException` rather than being handed back.

### C. End-to-end interop

| Direction | non-FIPS | exp-FIPS | regular FIPS |
|---|---|---|---|
| ACCP `getEncoded()` -> BC | works, BC re-emits byte-identically | same | works, BC re-emits byte-identically |
| **BC `getEncoded()` -> ACCP** | **fails** (`InvalidKeySpecException`) | **fails** | **fails** |
| **BC `getEncoded()` -> `MlKemUtils.expandPrivateKey`** | **fails** (`RuntimeCryptoException`) | **fails** | **fails** |
| BC `getPrivateKey(true)` (seed) -> ACCP | works | works | works |
| BC `getPrivateKey(false)` (expanded) -> ACCP | works | works | works |
| Public key SPKI, either direction | byte-identical | byte-identical | byte-identical |

Public keys are a non-issue: one canonical SPKI form, byte-identical round-trip both ways in every build, no FIPS guard on the test.

### D. Two gotchas that are not encoding-format issues

**1. BC's default private-key encoding is unreadable by ACCP, in every build.** `bcPriv.getEncoded()` is the `both` SEQUENCE. There is no BC system property in `bcprov-jdk18on-1.85` to change the default -- the only lever is `MLKEMPrivateKey.getPrivateKey(true|false).getEncoded()`. Anyone feeding BC-generated ML-KEM private keys to ACCP has to call that explicitly, including when calling `MlKemUtils.expandPrivateKey`, which rejects the `both` form rather than echoing it. This is the sharpest edge in the matrix, and FIPS mode has nothing to do with it.

**2. Public-key recovery from an `expandedKey`-only import differs between the two providers.**

| | ACCP (all builds) | BC 1.85 |
|---|---|---|
| public key after `seed` import | recovered, matches | recovered, matches |
| public key after `expandedKey` import | **throws `RuntimeCryptoException`** | recovered, matches |
| `getSeed()` after `expandedKey` import | n/a | absent |

BC recovers it because FIPS 203 embeds the encapsulation key inside `dk` (`dk_PKE || ek || H(ek) || z`); AWS-LC's `EVP_PKEY_kem_new_raw_secret_key` chooses not to populate `pub`, and ACCP inherits that. So a key imported into ACCP from `expandedKey` PKCS#8 is decapsulate-only -- carry the SPKI separately if the public half is needed. Round-tripping the same key through BC would appear to "fix" it, which makes this an easy trap. The BC column here was verified directly against BC 1.85; only the ACCP column is pinned by a test.

### E. What changes at the AWS-LC-FIPS milestones

Only two cells above are mutable, and both are TODO-tagged in the source:

| Cell | Milestone | Tagged at |
|---|---|---|
| Regular FIPS widens `seed` -> `expandedKey` on re-encode (B row 3), and cannot emit `seed` at all | AWS-LC-FIPS 5.0 (module must retain the keygen seed) | `encodeMlKemPrivateKey` in `java_evp_keys.cpp`; the two guards in `testPrivateKeyEncodingIsSeedFormat` / `testPrivateKeyChoicesParse` |
| Regular FIPS answers with `parseMLKEMPrivateKey` rather than AWS-LC's decoder (A column 3, including the trailing-bytes row) | AWS-LC-FIPS 4.x (module implements `priv_decode` for ML-KEM) | `der2EvpPrivateKey`, `mlkemKeyFromSeed`, the experimental include, and the seed branch in `keyutils.cpp` |

After 4.x the parse column is AWS-LC's answer in all three builds and the hand-rolled parser -- along with the experimental-header include and the two build-conditional assertions -- is deleted; after 5.0 the regular-FIPS serialize row becomes identical to the other two, and every build/provider difference above except BC's `both` default disappears.

Every cell in A, B, and C is pinned by a currently-passing test: `testPrivateKeyChoicesParse`, `testBothChoiceRejected`, `testMalformedPkcs8PrivateKeysRejected`, `testExpandPrivateKeyNormalizesEncoding`, `testImportedPrivateKeyPublicKeyAvailability`, `testPublicKeyEncodingMatchesBouncyCastle`, `testPrivateKeyEncodingIsSeedFormat`, `testBouncyCastleInteroperability`. `MlKemTest` is 60 tests: 60 pass in non-FIPS and in experimental FIPS, and 57 pass / 3 aborted in regular FIPS. Those 3 aborts are all of `testPrivateKeyEncodingIsSeedFormat`, which is why "regular FIPS cannot emit seed" is the sole documented divergence for well-formed keys.

</details>
