### PR TITLE
Fix no arg doFinal throwing on AES/CFB/NoPadding

### DIFF
--- a/src/com/amazon/corretto/crypto/provider/AesCfbSpi.java
+++ b/src/com/amazon/corretto/crypto/provider/AesCfbSpi.java
@@ -245,7 +245,8 @@ class AesCfbSpi extends CipherSpi {
       final byte[] output,
       final int outputOffset)
       throws ShortBufferException, IllegalBlockSizeException, BadPaddingException {
-    Utils.checkArrayLimits(input, inputOffset, inputLen);
+    final byte[] inputNotNull = input == null ? Utils.EMPTY_ARRAY : input;
+    Utils.checkArrayLimits(inputNotNull, inputOffset, inputLen);
     Utils.checkArrayLimits(output, outputOffset, inputLen);
 
     int result;
@@ -260,7 +261,7 @@ class AesCfbSpi extends CipherSpi {
               null,
               0,
               false,
-              input,
+              inputNotNull,
               inputOffset,
               inputLen,
               output,
@@ -273,7 +274,7 @@ class AesCfbSpi extends CipherSpi {
               opMode,
               ctxPtr,
               /*saveCtx*/ false, // then free the context at end of operation
-              input,
+              inputNotNull,
               inputOffset,
               inputLen,
               output,

--- a/tst/com/amazon/corretto/crypto/provider/test/AesCfbTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/AesCfbTest.java
@@ -310,6 +310,27 @@ public class AesCfbTest {
   }
 
   @Test
+  public void testNoArgDoFinal() throws Exception {
+    // Regression test for https://github.com/corretto/amazon-corretto-crypto-provider/issues/570:
+    // a no-arg doFinal() passes a null input array, which used to be rejected outright.
+    final SecretKey key = generateKey(KEY_SIZE_128);
+    final byte[] iv = new byte[BLOCK_SIZE];
+    SECURE_RANDOM.nextBytes(iv);
+    final IvParameterSpec ivSpec = new IvParameterSpec(iv);
+
+    final Cipher accp = Cipher.getInstance(ALGORITHM, TestUtil.NATIVE_PROVIDER);
+    final Cipher sun = Cipher.getInstance(ALGORITHM, "SunJCE");
+
+    accp.init(Cipher.ENCRYPT_MODE, key, ivSpec);
+    sun.init(Cipher.ENCRYPT_MODE, key, ivSpec);
+    assertArrayEquals(sun.doFinal(), accp.doFinal());
+
+    accp.init(Cipher.DECRYPT_MODE, key, ivSpec);
+    sun.init(Cipher.DECRYPT_MODE, key, ivSpec);
+    assertArrayEquals(sun.doFinal(), accp.doFinal());
+  }
+
+  @Test
   public void testInvalidParameters() throws Throwable {
     final SecretKey key = generateKey(KEY_SIZE_128);
     final byte[] iv = new byte[BLOCK_SIZE];


### PR DESCRIPTION
*Issue #, if available:* #570

*Description of changes:*

AES/CFB/NoPadding rejects a no argument doFinal() call. The JDK passes a null input array to AesCfbSpi#engineDoFinal, which forwards it to Utils.checkArrayLimits without a null check. That method throws IllegalArgumentException on null, so no arg doFinal() throws instead of returning an empty array, which is the JCE compatible behavior (SunJCE returns an empty array here).

Fix: mirror the sibling AesCbcSpi class, which already substitutes a null input with Utils.EMPTY_ARRAY at its doFinal implementation and deliberately does not apply this at engineUpdate, since a non null array is required there. This PR applies the same substitution at AesCfbSpi's single doFinal implementation. Its 3 arg overload delegates into the 5 arg one, so this one fix site covers both call paths.

Test: added AesCfbTest.testNoArgDoFinal, comparing ACCP's no arg doFinal() against SunJCE in both encrypt and decrypt directions.

Verification note: this repo's native build only supports 64 bit Linux and macOS per the README, and I do not have access to either locally, so I could not run the test suite myself. I traced the fix by hand against the current main source (Utils.checkArrayLimits, the sibling AesCbcSpi pattern, and every call site of the input parameter inside the modified method). I am confident in its correctness but want to disclose this honestly rather than claim a local run that did not happen.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.