### PR TITLE
Fix CBB failure-path memory handling and decode error reporting

### DIFF
--- a/csrc/java_evp_keys.cpp
+++ b/csrc/java_evp_keys.cpp
@@ -699,30 +699,33 @@ JNIEXPORT jbyteArray JNICALL Java_com_amazon_corretto_crypto_provider_EvpMlDsaPr
         EVP_PKEY* key = reinterpret_cast<EVP_PKEY*>(keyHandle);
         CHECK_OPENSSL(EVP_PKEY_id(key) == EVP_PKEY_PQDSA);
 
-        uint8_t* der;
-        size_t der_len;
+        OPENSSL_buffer_auto der;
+        size_t der_len = 0;
         CBB cbb;
         CHECK_OPENSSL(CBB_init(&cbb, 0));
-        // Failure below may just indicate that we don't have the seed, so retry with |encodeExpandedMLDSAPrivateKey|
-        // and encode in PKCS8 (RFC 5208) format after clearing the error queue.
+        // Failure below may just indicate that we don't have the seed, so retry with
+        // |encodeExpandedMLDSAPrivateKey| and encode in PKCS8 (RFC 5208) format. Scope away the errors
+        // that expected failure queues; the guard has to be set before the call, since ERR_set_mark
+        // marks the newest error rather than deleting it.
+        ErrorQueueMark error_mark;
         if (EVP_marshal_private_key(&cbb, key)) {
             if (!CBB_finish(&cbb, &der, &der_len)) {
-                OPENSSL_free(der);
+                // CBB_finish does not write |der| on failure, and the CBB still owns its buffer.
+                CBB_cleanup(&cbb);
                 throw_java_ex(EX_RUNTIME_CRYPTO, "Error finalizing seed ML-DSA key");
             }
+            // A successful CBB_finish hands the buffer to |der| and cleans the CBB up itself.
         } else {
-            ERR_clear_error();
+            // Clean the CBB up before calling a helper that throws on failure.
+            CBB_cleanup(&cbb);
             der_len = encodeExpandedMLDSAPrivateKey(key, &der);
         }
-        CBB_cleanup(&cbb);
 
         if (!(result = env->NewByteArray(der_len))) {
-            OPENSSL_free(der);
             throw_java_ex(EX_OOM, "Unable to allocate DER array");
         }
         // This may throw, if it does we'll just keep the exception state as we return.
-        env->SetByteArrayRegion(result, 0, der_len, (const jbyte*)der);
-        OPENSSL_free(der);
+        env->SetByteArrayRegion(result, 0, der_len, der);
     } catch (java_ex& ex) {
         ex.throw_to_java(pEnv);
     }

--- a/csrc/keyutils.cpp
+++ b/csrc/keyutils.cpp
@@ -23,15 +23,15 @@ EVP_PKEY* der2EvpPrivateKey(const unsigned char* der,
 
     EVP_PKEY* result = d2i_PrivateKey(evpType, NULL, &der_mutable_ptr, derLen);
 
-    if (der + derLen != der_mutable_ptr) {
-        if (result) {
-            EVP_PKEY_free(result);
-        }
-        throw_openssl(javaExceptionClass, "Extra key information");
-    }
-
     if (!result) {
         throw_openssl(javaExceptionClass, "Unable to convert PKCS8_PRIV_KEY_INFO to EVP_PKEY");
+    }
+
+    // Only meaningful once a key came back: d2i_PrivateKey leaves |der_mutable_ptr| untouched when it
+    // fails, so checking it first reported every decode failure as "Extra key information".
+    if (der + derLen != der_mutable_ptr) {
+        EVP_PKEY_free(result);
+        throw_openssl(javaExceptionClass, "Extra key information");
     }
 
     if (isRsaKeyType(EVP_PKEY_base_id(result))) {
@@ -103,14 +103,15 @@ EVP_PKEY* der2EvpPublicKey(const unsigned char* der, const int derLen, const cha
     const unsigned char* der_mutable_ptr = der; // openssl modifies the input pointer
 
     EVP_PKEY* result = d2i_PUBKEY(NULL, &der_mutable_ptr, derLen);
-    if (der + derLen != der_mutable_ptr) {
-        if (result) {
-            EVP_PKEY_free(result);
-        }
-        throw_openssl(javaExceptionClass, "Extra key information");
-    }
     if (!result) {
         throw_openssl(javaExceptionClass, "Unable to parse key");
+    }
+
+    // Only meaningful once a key came back: d2i_PUBKEY leaves |der_mutable_ptr| untouched when it
+    // fails, so checking it first reported every decode failure as "Extra key information".
+    if (der + derLen != der_mutable_ptr) {
+        EVP_PKEY_free(result);
+        throw_openssl(javaExceptionClass, "Extra key information");
     }
 
     if (!checkKey(result)) {
@@ -209,9 +210,11 @@ size_t encodeExpandedMLDSAPrivateKey(const EVP_PKEY* key, uint8_t** out)
         throw_java_ex(EX_ILLEGAL_ARGUMENT, "Invalid ML-DSA signature size");
     }
     OPENSSL_buffer_auto raw_expanded(raw_len);
+    // OPENSSL_buffer_auto does not check its own allocation, and the next call memcpy's into it.
+    CHECK_OPENSSL(raw_expanded.buf != nullptr);
     CHECK_OPENSSL(EVP_PKEY_get_raw_private_key(key, raw_expanded, &raw_len));
     CBB cbb, pkcs8, algorithm, priv, expanded;
-    CBB_init(&cbb, 0);
+    CHECK_OPENSSL(CBB_init(&cbb, 0));
     // Encoding below is based on expandedKey CHOICE member of PrivateKey ASN.1 structures in:
     // https://github.com/lamps-wg/dilithium-certificates/blob/main/X509-ML-DSA-2025.asn
     // spotless:off
@@ -222,12 +225,15 @@ size_t encodeExpandedMLDSAPrivateKey(const EVP_PKEY* key, uint8_t** out)
         !CBB_add_asn1(&pkcs8, &priv, CBS_ASN1_OCTETSTRING) ||
         !CBB_add_asn1(&priv, &expanded, CBS_ASN1_OCTETSTRING) ||
         !CBB_add_bytes(&expanded, raw_expanded, raw_len)) {
+        CBB_cleanup(&cbb);
         throw_java_ex(EX_RUNTIME_CRYPTO, "Error serializing expanded ML-DSA key");
     }
     // spotless:on
     size_t out_len;
+    // A failed CBB_finish leaves the CBB owning its buffer and does not write |*out|, so clean the CBB
+    // up and leave |*out| alone. A successful CBB_finish transfers the buffer to |*out| and cleans up.
     if (!CBB_finish(&cbb, out, &out_len)) {
-        OPENSSL_free(*out);
+        CBB_cleanup(&cbb);
         throw_java_ex(EX_RUNTIME_CRYPTO, "Error finalizing expanded ML-DSA key");
     }
     return out_len;
@@ -256,9 +262,11 @@ size_t encodeExpandedMLKEMPrivateKey(const EVP_PKEY* key, uint8_t** out)
         throw_java_ex(EX_ILLEGAL_ARGUMENT, "Invalid ML-KEM secret key size");
     }
     OPENSSL_buffer_auto raw_expanded(raw_len);
+    // OPENSSL_buffer_auto does not check its own allocation, and the next call memcpy's into it.
+    CHECK_OPENSSL(raw_expanded.buf != nullptr);
     CHECK_OPENSSL(EVP_PKEY_get_raw_private_key(key, raw_expanded, &raw_len));
     CBB cbb, pkcs8, algorithm, priv, expanded;
-    CBB_init(&cbb, 0);
+    CHECK_OPENSSL(CBB_init(&cbb, 0));
     // Encoding below is based on expandedKey CHOICE member of PrivateKey ASN.1 structures in:
     // https://datatracker.ietf.org/doc/rfc9935/ section 6
     // spotless:off
@@ -269,12 +277,15 @@ size_t encodeExpandedMLKEMPrivateKey(const EVP_PKEY* key, uint8_t** out)
         !CBB_add_asn1(&pkcs8, &priv, CBS_ASN1_OCTETSTRING) ||
         !CBB_add_asn1(&priv, &expanded, CBS_ASN1_OCTETSTRING) ||
         !CBB_add_bytes(&expanded, raw_expanded, raw_len)) {
+        CBB_cleanup(&cbb);
         throw_java_ex(EX_RUNTIME_CRYPTO, "Error serializing expanded ML-KEM key");
     }
     // spotless:on
     size_t out_len;
+    // A failed CBB_finish leaves the CBB owning its buffer and does not write |*out|, so clean the CBB
+    // up and leave |*out| alone. A successful CBB_finish transfers the buffer to |*out| and cleans up.
     if (!CBB_finish(&cbb, out, &out_len)) {
-        OPENSSL_free(*out);
+        CBB_cleanup(&cbb);
         throw_java_ex(EX_RUNTIME_CRYPTO, "Error finalizing expanded ML-KEM key");
     }
     return out_len;
@@ -301,7 +312,7 @@ size_t encodeRfc5915EcPrivateKey(const EVP_PKEY* key, uint8_t** out)
     int oid_data_len = OBJ_length(oid_obj);
     const EC_KEY* ec_key = EVP_PKEY_get0_EC_KEY(key);
     CBB cbb, pkcs8, algorithm, oid, priv;
-    CBB_init(&cbb, 0);
+    CHECK_OPENSSL(CBB_init(&cbb, 0));
     // spotless:off
     if (!CBB_add_asn1(&cbb, &pkcs8, CBS_ASN1_SEQUENCE) ||
         !CBB_add_asn1_uint64(&pkcs8, 0 /* version */) ||
@@ -319,9 +330,10 @@ size_t encodeRfc5915EcPrivateKey(const EVP_PKEY* key, uint8_t** out)
     }
     // spotless:on
     size_t out_len;
+    // A failed CBB_finish leaves the CBB owning its buffer and does not write |*out|, so clean the CBB
+    // up and leave |*out| alone. A successful CBB_finish transfers the buffer to |*out| and cleans up.
     if (!CBB_finish(&cbb, out, &out_len)) {
         CBB_cleanup(&cbb);
-        OPENSSL_free(*out);
         throw_java_ex(EX_RUNTIME_CRYPTO, "Error finalizing expanded EC key");
     }
     return out_len;

--- a/csrc/keyutils.h
+++ b/csrc/keyutils.h
@@ -7,6 +7,7 @@
 #include "env.h"
 #include "util.h"
 #include <openssl/bn.h>
+#include <openssl/err.h>
 #include <openssl/evp.h>
 #include <openssl/x509.h>
 
@@ -14,6 +15,24 @@
 // Unlike util.h, this is intended to capture high-level logic with more internal dependencies.
 
 namespace AmazonCorrettoCryptoProvider {
+
+// Scope guard for discarding errors queued by an operation whose failure is expected and handled,
+// such as a marshaler that a fallover encoder retries. Prefer this over a bare ERR_clear_error():
+// it only discards what was queued inside the guarded scope (leaving anything queued earlier for
+// the caller to see), and it runs even when the guarded scope exits by throwing.
+//
+// Errors queued inside the scope remain visible until the guard goes out of scope, so throw_openssl
+// still reports them. Note that ERR_set_mark is a no-op on an empty queue, in which case
+// ERR_pop_to_mark clears the whole queue -- which is the desired behavior there anyway.
+class ErrorQueueMark {
+public:
+    ErrorQueueMark() { ERR_set_mark(); }
+    ~ErrorQueueMark() { ERR_pop_to_mark(); }
+
+private:
+    ErrorQueueMark(const ErrorQueueMark&) DELETE_IMPLICIT;
+    ErrorQueueMark& operator=(const ErrorQueueMark&) DELETE_IMPLICIT;
+};
 
 // This class should generally not be used for new development
 // as it has been replaced by the *_auto classes in auto_free.h


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*

Three pre-existing memory and error-reporting bugs in the native key encode/decode
helpers. All of these are independent of ML-KEM and reachable on `main` today, so
they are split out ahead of #568 / #569 (which build on this code) to keep those
reviews focused on ML-KEM.

## 1. CBB failure paths freed the wrong thing

The three CBB-based key encoders (`encodeExpandedMLDSAPrivateKey`,
`encodeExpandedMLKEMPrivateKey`, `encodeRfc5915EcPrivateKey`) called
`OPENSSL_free(*out)` when `CBB_finish` failed. A failed `CBB_finish` does **not**
write `*out` and leaves the CBB still owning its buffer, so this frees a pointer
the callee never set and leaks the CBB's allocation. The failure paths now
`CBB_cleanup(&cbb)` and leave `*out` alone.

What that was worth in practice differs by call site:

- `Java_..._EvpMlDsaPrivateKey_encodePrivateKey` declared `uint8_t* der;`
  uninitialized, so both its own `OPENSSL_free(der)` and the
  `encodeExpandedMLDSAPrivateKey` it falls over to would free an **indeterminate
  pointer**. That one is a real bad free, not just a leak. `der` is now an
  `OPENSSL_buffer_auto`, so it starts NULL and is released exactly once.
- The `util_class.cpp` call sites already passed an `OPENSSL_buffer_auto`, so
  there `*out` was NULL and the free was a harmless no-op; the defect there is
  the leaked CBB buffer.

The serialization failure paths (the `CBB_add_*` chains) also threw without
cleaning up the CBB; they now clean up first. `CBB_init`'s return value is now
checked, as is the `OPENSSL_malloc` that `OPENSSL_buffer_auto`'s constructor
performs without checking -- the next line `memcpy`s into that buffer.

## 2. Every decode failure reported "Extra key information"

`der2EvpPrivateKey` and `der2EvpPublicKey` tested for trailing input *before*
checking whether a key came back:

```c
EVP_PKEY* result = d2i_PrivateKey(evpType, NULL, &der_mutable_ptr, derLen);
if (der + derLen != der_mutable_ptr) { ...throw "Extra key information"... }
if (!result) { ...throw "Unable to convert..."... }
```

`d2i_PrivateKey` and `d2i_PUBKEY` leave the input pointer untouched when they
fail, so on any decode failure the first check is guaranteed to trip and the
caller saw `Extra key information` regardless of the real cause. The null check
now runs first, so the underlying OpenSSL error is what surfaces.

## 3. `ErrorQueueMark` scope guard

Adds a small RAII guard around `ERR_set_mark`/`ERR_pop_to_mark` and uses it to
replace the bare `ERR_clear_error()` in the ML-DSA private-key encoder, whose
`EVP_marshal_private_key` failure is expected (it just means there is no seed)
and handled by falling over to the expanded encoder. Versus `ERR_clear_error()`
this discards only what the guarded scope queued -- anything the caller had
already queued stays visible -- and it still runs when the scope exits by
throwing.

## Testing

Full local suite at this commit, clean builds, **0 failures** in both modes:

| | all cases | skipped |
|---|---|---|
| regular FIPS (`-DFIPS=true`) | 158984 | 256 |
| non-FIPS | 159265 | 281 |

No behavior change is intended: these are failure-path and error-message fixes,
and no test asserted on the `Extra key information` text. Adding the guard to the
ML-DSA encoder does change which error a genuinely-failed ML-DSA fallover
reports, from nothing to the underlying error.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
