### PR TITLE
Support "Generic" output algorithm in EvpKeyAgreement

### DIFF
--- a/src/com/amazon/corretto/crypto/provider/EvpKeyAgreement.java
+++ b/src/com/amazon/corretto/crypto/provider/EvpKeyAgreement.java
@@ -88,10 +88,16 @@ class EvpKeyAgreement extends KeyAgreementSpi {
     if (algorithm.equalsIgnoreCase("TlsPremasterSecret")) {
       return new SecretKeySpec(secret, "TlsPremasterSecret");
     }
+    // Both "com/sun/crypto/provider/DHKEM.java" (backing HPKE and the "DHKEM"
+    // KEM) and "sun/security/ssl/DHasKEM.java" (the classical half of TLS 1.3
+    // hybrid key exchange, e.g. X25519MLKEM768) obtain the raw agreed secret via
+    // generateSecret("Generic"), "Generic" being the default output algorithm of
+    // the javax.crypto.KEM API. Neither pins a provider when requesting
+    // ECDH/XDH, so ACCP wins the service and must accept "Generic" or it breaks
+    // HPKE and TLS handshakes for anyone who installs it.
     if (algorithm.equalsIgnoreCase("Generic")) {
       return new SecretKeySpec(secret, "Generic");
     }
-    ;
     final Matcher matcher = ALGORITHM_WITH_EXPLICIT_KEYSIZE.matcher(algorithm);
     if (matcher.matches()) {
       switch (matcher.group(1)) {

--- a/src/com/amazon/corretto/crypto/provider/EvpKeyAgreement.java
+++ b/src/com/amazon/corretto/crypto/provider/EvpKeyAgreement.java
@@ -88,6 +88,9 @@ class EvpKeyAgreement extends KeyAgreementSpi {
     if (algorithm.equalsIgnoreCase("TlsPremasterSecret")) {
       return new SecretKeySpec(secret, "TlsPremasterSecret");
     }
+    if (algorithm.equalsIgnoreCase("Generic")) {
+      return new SecretKeySpec(secret, "Generic");
+    }
     ;
     final Matcher matcher = ALGORITHM_WITH_EXPLICIT_KEYSIZE.matcher(algorithm);
     if (matcher.matches()) {

--- a/tst/com/amazon/corretto/crypto/provider/test/EvpKeyAgreementTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/EvpKeyAgreementTest.java
@@ -279,6 +279,20 @@ public class EvpKeyAgreementTest {
         });
   }
 
+  @ParameterizedTest
+  @MethodSource("params")
+  public void genericSecret(TestParams params) throws GeneralSecurityException {
+    // For TLS 1.3 hybrid key exchange we must support the "Generic" algorithm
+    final byte[] rawSecret = params.rawSecrets[0][1];
+    params.nativeAgreement.init(params.pairs[0].getPrivate());
+    assertNull(params.nativeAgreement.doPhase(params.pairs[1].getPublic(), true));
+
+    final SecretKey genericKey = params.nativeAgreement.generateSecret("Generic");
+    assertEquals("Generic", genericKey.getAlgorithm());
+    assertEquals("RAW", genericKey.getFormat());
+    assertArrayEquals(rawSecret, genericKey.getEncoded());
+  }
+
   private static Stream<TestParams> aesKeysParams() {
     return params().stream()
         .filter(


### PR DESCRIPTION
JDK 27's TLS 1.3 hybrid key exchange (JEP 527) derives the classical DH
shared secret via `KeyAgreement.generateSecret("Generic")`. ACCP currently
rejects this with `InvalidKeyException("Unsupported algorithm: Generic")`,
which breaks TLS handshakes that route key agreement through ACCP.

The default JDK provider returns the raw agreed secret when asked for the
`"Generic"` output algorithm. This change makes `EvpKeyAgreement` do the
same: when `generateSecret("Generic")` is called, it wraps the raw agreed
secret in a `SecretKeySpec` with algorithm `"Generic"` (RAW format),
matching the JDK behavior so TLS handshakes using ACCP succeed.

## Changes

- `EvpKeyAgreement.java`: handle `"Generic"` in `engineGenerateSecret(String)`,
  returning the raw agreed secret as a `Generic`/RAW `SecretKeySpec`.
- `EvpKeyAgreementTest.java`: add a parameterized `genericSecret` test
  asserting the returned key has algorithm `Generic`, format `RAW`, and
  encoding equal to the raw shared secret.

## Testing

- Added unit test `genericSecret` covering the new algorithm across all
  existing key-agreement test parameters.