### PR TITLE
Make the generic ML-KEM KeyPairGenerator parameter-set-selectable; harden MlDsaUtils against unencodable keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,14 @@ caller-supplied `SecureRandom` is accepted but ignored: AWS-LC always draws ML-K
 its own DRBG. Passing a custom `SecureRandom` (for example to force a specific entropy source) has
 no effect on these operations.
 
+The parameter-set-agnostic `ML-KEM` service name lets a `NamedParameterSpec` choose the parameter
+set, mirroring how SunEC's generic `XDH` service accepts either `X25519` or `X448`:
+`KeyPairGenerator.getInstance("ML-KEM")` generates ML-KEM-768 when left uninitialized, and generates
+the named parameter set after `initialize(new NamedParameterSpec("ML-KEM-512"))`. The
+parameter-set-specific `ML-KEM-512`/`ML-KEM-768`/`ML-KEM-1024` generators stay bound to their own
+parameter set and reject a spec naming a different one, so the JCA fails over to another provider
+rather than this one silently returning a key of the wrong parameter set.
+
 # Notes on ACCP-FIPS
 ACCP-FIPS is a variation of ACCP which uses AWS-LC-FIPS 2.x as its cryptographic module. This version of AWS-LC-FIPS has FIPS certificate [4816](https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/4816).
 

--- a/README.md
+++ b/README.md
@@ -161,8 +161,12 @@ set, mirroring how SunEC's generic `XDH` service accepts either `X25519` or `X44
 `KeyPairGenerator.getInstance("ML-KEM")` generates ML-KEM-768 when left uninitialized, and generates
 the named parameter set after `initialize(new NamedParameterSpec("ML-KEM-512"))`. The
 parameter-set-specific `ML-KEM-512`/`ML-KEM-768`/`ML-KEM-1024` generators stay bound to their own
-parameter set and reject a spec naming a different one, so the JCA fails over to another provider
-rather than this one silently returning a key of the wrong parameter set.
+parameter set and reject a spec naming a different one with `InvalidAlgorithmParameterException`,
+rather than silently returning a key of the wrong parameter set. When the caller obtained the
+generator without naming a provider (`KeyPairGenerator.getInstance("ML-KEM-768")`), that rejection is
+what lets the JCA fail over to another provider; a caller that named ACCP explicitly
+(`KeyPairGenerator.getInstance("ML-KEM-768", accp)`) sees the exception instead, since the JCA has no
+other provider to try.
 
 # Notes on ACCP-FIPS
 ACCP-FIPS is a variation of ACCP which uses AWS-LC-FIPS 2.x as its cryptographic module. This version of AWS-LC-FIPS has FIPS certificate [4816](https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/4816).

--- a/csrc/util_class.cpp
+++ b/csrc/util_class.cpp
@@ -92,6 +92,13 @@ JNIEXPORT jint JNICALL Java_com_amazon_corretto_crypto_provider_Utils_getDigestL
  * Class:     com_amazon_corretto_crypto_utils_MlDsaUtils
  * Method:    expandPrivateKeyInternal
  * Signature: ([B)[B
+ *
+ * Every input is parsed and re-encoded, as in the ML-KEM helper below, so the output is always the
+ * canonical minimal expandedKey PKCS8. Deliberately not short-circuiting on the input length: that
+ * echoed any encoding longer than a 54-byte seed key back to the caller unvalidated.
+ *
+ * EX_RUNTIME_CRYPTO rather than EX_INVALID_KEY_SPEC because InvalidKeySpecException is checked and
+ * MlDsaUtils.expandPrivateKey does not declare it.
  */
 JNIEXPORT jbyteArray JNICALL
 Java_com_amazon_corretto_crypto_utils_MlDsaUtils_expandPrivateKeyInternal(JNIEnv* pEnv, jclass, jbyteArray keyBytes)
@@ -100,36 +107,29 @@ Java_com_amazon_corretto_crypto_utils_MlDsaUtils_expandPrivateKeyInternal(JNIEnv
     try {
         raii_env env(pEnv);
         jsize key_der_len = env->GetArrayLength(keyBytes);
-
-        if (key_der_len > 54) { // If they key is already expanded, return it
-            return keyBytes;
-        }
-        CHECK_OPENSSL(key_der_len == 54); // seed-only keys are always 54 bytes when PKCS8-encoded
         uint8_t* key_der = (uint8_t*)env->GetByteArrayElements(keyBytes, nullptr);
         CHECK_OPENSSL(key_der);
 
+        EVP_PKEY_auto key;
         try {
-            // Parse the seed key
-            BIO* key_bio = BIO_new_mem_buf(key_der, key_der_len);
-            CHECK_OPENSSL(key_bio);
-            PKCS8_PRIV_KEY_INFO_auto pkcs8
-                = PKCS8_PRIV_KEY_INFO_auto::from(d2i_PKCS8_PRIV_KEY_INFO_bio(key_bio, nullptr));
-            CHECK_OPENSSL(pkcs8.isInitialized());
-            EVP_PKEY_auto key = EVP_PKEY_auto::from(EVP_PKCS82PKEY(pkcs8));
-
-            // Expand the seed key and encode it before returning
-            OPENSSL_buffer_auto new_der;
-            int new_der_len = encodeExpandedMLDSAPrivateKey(key, &new_der);
-            CHECK_OPENSSL(new_der_len > 0);
-            if (!(result = env->NewByteArray(new_der_len))) {
-                throw_java_ex(EX_OOM, "Unable to allocate DER array");
-            }
-            env->SetByteArrayRegion(result, 0, new_der_len, (const jbyte*)new_der);
+            key.set(der2EvpPrivateKey(
+                key_der, key_der_len, EVP_PKEY_PQDSA, /*shouldCheckPrivate*/ false, EX_RUNTIME_CRYPTO));
         } catch (...) {
             env->ReleaseByteArrayElements(keyBytes, (jbyte*)key_der, JNI_ABORT);
             throw;
         }
         env->ReleaseByteArrayElements(keyBytes, (jbyte*)key_der, JNI_ABORT);
+
+        // Expand the key and encode it before returning. key.get() rather than an implicit
+        // conversion, which aborts the process on a null pointer.
+        OPENSSL_buffer_auto new_der;
+        int new_der_len = encodeExpandedMLDSAPrivateKey(key.get(), &new_der);
+        CHECK_OPENSSL(new_der_len > 0);
+
+        if (!(result = env->NewByteArray(new_der_len))) {
+            throw_java_ex(EX_OOM, "Unable to allocate DER array");
+        }
+        env->SetByteArrayRegion(result, 0, new_der_len, (const jbyte*)new_der);
     } catch (java_ex& ex) {
         ex.throw_to_java(pEnv);
         return 0;
@@ -148,13 +148,12 @@ Java_com_amazon_corretto_crypto_utils_MlDsaUtils_expandPrivateKeyInternal(JNIEnv
  * -- in regular FIPS through the fallover parser in keyutils.cpp -- and encodeExpandedMLKEMPrivateKey
  * is likewise available everywhere.
  *
- * Every input is parsed and re-encoded, rather than short-circuiting on the input length the way the
- * ML-DSA helper above still does. So the output is always the canonical minimal expandedKey PKCS8
- * (version 0, no attributes, no publicKey), making this idempotent on that form rather than
- * byte-preserving in general, and an input der2EvpPrivateKey will not accept is rejected instead of
- * handed back unchanged. EX_RUNTIME_CRYPTO is passed down rather than the EX_INVALID_KEY_SPEC the
- * KeyFactory callers use: InvalidKeySpecException is checked, and MlKemUtils.expandPrivateKey does
- * not declare it.
+ * Every input is parsed and re-encoded, as in the ML-DSA helper above. So the output is always the
+ * canonical minimal expandedKey PKCS8 (version 0, no attributes, no publicKey), making this
+ * idempotent on that form rather than byte-preserving in general, and an input der2EvpPrivateKey will
+ * not accept is rejected instead of handed back unchanged. EX_RUNTIME_CRYPTO is passed down rather
+ * than the EX_INVALID_KEY_SPEC the KeyFactory callers use: InvalidKeySpecException is checked, and
+ * MlKemUtils.expandPrivateKey does not declare it.
  */
 JNIEXPORT jbyteArray JNICALL Java_com_amazon_corretto_crypto_utils_MlKemUtils_expandPrivateKeyInternal(
     JNIEnv* pEnv, jclass, jbyteArray keyBytes)
@@ -215,8 +214,13 @@ JNIEXPORT jbyteArray JNICALL Java_com_amazon_corretto_crypto_utils_MlDsaUtils_co
 
             CBS cbs;
             CBS_init(&cbs, pub_key_der, pub_key_der_len);
-            EVP_PKEY_auto pkey = EVP_PKEY_auto::from((EVP_parse_public_key(&cbs)));
-            EVP_PKEY_CTX_auto ctx = EVP_PKEY_CTX_auto::from(EVP_PKEY_CTX_new(pkey.get(), nullptr));
+            EVP_PKEY_auto pkey = EVP_PKEY_auto::from(EVP_parse_public_key(&cbs));
+            CHECK_OPENSSL(pkey.isInitialized());
+            // A well-formed SPKI for another algorithm parses fine, so without this check mu could
+            // be computed over a non-ML-DSA public key.
+            if (EVP_PKEY_id(pkey.get()) != EVP_PKEY_PQDSA) {
+                throw_java_ex(EX_ILLEGAL_ARGUMENT, "Not an ML-DSA public key");
+            }
             EVP_MD_CTX_auto md_ctx_mu = EVP_MD_CTX_auto::from(EVP_MD_CTX_new());
             EVP_MD_CTX_auto md_ctx_pk = EVP_MD_CTX_auto::from(EVP_MD_CTX_new());
 

--- a/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
+++ b/src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
@@ -174,7 +174,7 @@ public final class AmazonCorrettoCryptoProvider extends java.security.Provider {
     }
 
     if (shouldRegisterMLKEM) {
-      addService("KeyPairGenerator", "ML-KEM", "MlKemGen$MlKemGen768");
+      addService("KeyPairGenerator", "ML-KEM", "MlKemGen$MlKemGenGeneric");
       addService("KeyPairGenerator", "ML-KEM-512", "MlKemGen$MlKemGen512");
       addService("KeyPairGenerator", "ML-KEM-768", "MlKemGen$MlKemGen768");
       addService("KeyPairGenerator", "ML-KEM-1024", "MlKemGen$MlKemGen1024");

--- a/src/com/amazon/corretto/crypto/provider/MlDsaGen.java
+++ b/src/com/amazon/corretto/crypto/provider/MlDsaGen.java
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.amazon.corretto.crypto.provider;
 
+import java.security.InvalidAlgorithmParameterException;
 import java.security.KeyPair;
 import java.security.KeyPairGeneratorSpi;
 import java.security.SecureRandom;
@@ -29,8 +30,18 @@ class MlDsaGen extends KeyPairGeneratorSpi {
     this(provider, null);
   }
 
-  public void initialize(AlgorithmParameterSpec params, final SecureRandom random) {
-    throw new UnsupportedOperationException();
+  /**
+   * Rejects every spec, since each of these generators is bound to its parameter set at
+   * construction. {@code InvalidAlgorithmParameterException} rather than {@code
+   * UnsupportedOperationException} because the checked exception is what {@code
+   * KeyPairGenerator.Delegate} expects, so the JCA can fail over instead of propagating.
+   */
+  @Override
+  public void initialize(AlgorithmParameterSpec params, final SecureRandom random)
+      throws InvalidAlgorithmParameterException {
+    throw new InvalidAlgorithmParameterException(
+        "ACCP's ML-DSA KeyPairGenerator cannot be initialized with an AlgorithmParameterSpec. Use"
+            + " the ML-DSA-44, ML-DSA-65, or ML-DSA-87 service name to select a parameter set.");
   }
 
   public void initialize(final int keysize, final SecureRandom random) {

--- a/src/com/amazon/corretto/crypto/provider/MlKemGen.java
+++ b/src/com/amazon/corretto/crypto/provider/MlKemGen.java
@@ -41,13 +41,26 @@ class MlKemGen extends KeyPairGeneratorSpi {
 
   private MlKemParameter parameterSet = null;
 
+  /**
+   * True for the parameter-set-agnostic "ML-KEM" service, whose parameter set may be chosen by
+   * {@link #initialize(AlgorithmParameterSpec, SecureRandom)}. False for the parameter-set-specific
+   * services (ML-KEM-512/768/1024), which are bound at construction and reject any spec naming a
+   * different parameter set.
+   */
+  private final boolean parameterSetSelectable;
+
   /** Generates a new ML-KEM key and returns a pointer to it. */
   private static native long generateEvpMlKemKey(int parameterSet);
 
   private MlKemGen(MlKemParameter parameterSet) {
+    this(parameterSet, false);
+  }
+
+  private MlKemGen(MlKemParameter parameterSet, boolean parameterSetSelectable) {
     Loader.checkNativeLibraryAvailability();
     Utils.requireNonNull(parameterSet, "MlKemParameter can not be null");
     this.parameterSet = parameterSet;
+    this.parameterSetSelectable = parameterSetSelectable;
   }
 
   @Override
@@ -58,10 +71,20 @@ class MlKemGen extends KeyPairGeneratorSpi {
   /**
    * Accepts the standard {@code NamedParameterSpec} initialization that JSSE providers (e.g.
    * BouncyCastle's TLS 1.3 stack) and application code perform before {@code generateKeyPair()}.
-   * Each {@code MlKemGen} instance is bound to a single parameter set at construction, so any spec
-   * naming that same parameter set (case-insensitively) is a no-op; any other spec is rejected with
-   * {@code InvalidAlgorithmParameterException} so this generator never silently produces a key of
-   * the wrong parameter set.
+   *
+   * <p>Behavior depends on which service this instance came from, mirroring how SunEC treats its
+   * generic {@code XDH} service versus its curve-specific {@code X25519}/{@code X448} services:
+   *
+   * <ul>
+   *   <li>the parameter-set-agnostic {@code ML-KEM} service is <em>selectable</em> -- any spec
+   *       naming a supported ML-KEM parameter set (case-insensitively) chooses that parameter set
+   *       for subsequent {@code generateKeyPair()} calls;
+   *   <li>the parameter-set-specific {@code ML-KEM-512/768/1024} services are bound at
+   *       construction, so a spec naming that same parameter set is a no-op and any other spec is
+   *       rejected with {@code InvalidAlgorithmParameterException}, letting the JCA fail over to a
+   *       provider that supports it rather than this one silently producing a key of the wrong
+   *       parameter set.
+   * </ul>
    *
    * <p>{@code NamedParameterSpec} was introduced in JDK 11, but ACCP's main sources are compiled
    * for an older bytecode target, so the spec's name is read reflectively rather than by importing
@@ -79,6 +102,17 @@ class MlKemGen extends KeyPairGeneratorSpi {
     if (name == null) {
       throw new InvalidAlgorithmParameterException(
           "Unsupported AlgorithmParameterSpec: " + params.getClass().getName());
+    }
+    if (parameterSetSelectable) {
+      final MlKemParameter selected = MlKemParameter.fromAlgorithmName(name);
+      if (selected == null) {
+        throw new InvalidAlgorithmParameterException(
+            "Unsupported ML-KEM parameter set: "
+                + name
+                + ". Supported parameter sets are ML-KEM-512, ML-KEM-768, and ML-KEM-1024.");
+      }
+      parameterSet = selected;
+      return;
     }
     if (!parameterSet.matchesAlgorithmName(name)) {
       throw new InvalidAlgorithmParameterException(
@@ -114,6 +148,18 @@ class MlKemGen extends KeyPairGeneratorSpi {
     final EvpKemPrivateKey privateKey = new EvpKemPrivateKey(pkey_ptr);
     final EvpKemPublicKey publicKey = privateKey.getPublicKey();
     return new KeyPair(publicKey, privateKey);
+  }
+
+  /**
+   * Backs the parameter-set-agnostic {@code KeyPairGenerator.ML-KEM} service. Defaults to
+   * ML-KEM-768 when used without initialization (preserving the historical behavior of this
+   * service), but a {@code NamedParameterSpec} passed to {@code initialize} selects any supported
+   * parameter set.
+   */
+  public static final class MlKemGenGeneric extends MlKemGen {
+    public MlKemGenGeneric(AmazonCorrettoCryptoProvider provider) {
+      super(MlKemParameter.MLKEM_768, true);
+    }
   }
 
   public static final class MlKemGen512 extends MlKemGen {

--- a/src/com/amazon/corretto/crypto/provider/MlKemGen.java
+++ b/src/com/amazon/corretto/crypto/provider/MlKemGen.java
@@ -39,28 +39,23 @@ class MlKemGen extends KeyPairGeneratorSpi {
     NAMED_PARAMETER_SPEC_GET_NAME = getName;
   }
 
-  private MlKemParameter parameterSet = null;
-
-  /**
-   * True for the parameter-set-agnostic "ML-KEM" service, whose parameter set may be chosen by
-   * {@link #initialize(AlgorithmParameterSpec, SecureRandom)}. False for the parameter-set-specific
-   * services (ML-KEM-512/768/1024), which are bound at construction and reject any spec naming a
-   * different parameter set.
-   */
-  private final boolean parameterSetSelectable;
+  // Volatile because MlKemGenGeneric writes it from initialize() while generateKeyPair() reads it;
+  // a generator shared between threads could otherwise read a stale parameter set.
+  private volatile MlKemParameter parameterSet;
 
   /** Generates a new ML-KEM key and returns a pointer to it. */
   private static native long generateEvpMlKemKey(int parameterSet);
 
   private MlKemGen(MlKemParameter parameterSet) {
-    this(parameterSet, false);
-  }
-
-  private MlKemGen(MlKemParameter parameterSet, boolean parameterSetSelectable) {
     Loader.checkNativeLibraryAvailability();
     Utils.requireNonNull(parameterSet, "MlKemParameter can not be null");
     this.parameterSet = parameterSet;
-    this.parameterSetSelectable = parameterSetSelectable;
+  }
+
+  // Sole writer of |parameterSet| after construction. Package-private rather than private because a
+  // private member of this class is not inherited by the nested MlKemGenGeneric subclass.
+  final void setParameterSet(final MlKemParameter selected) {
+    this.parameterSet = selected;
   }
 
   @Override
@@ -72,19 +67,12 @@ class MlKemGen extends KeyPairGeneratorSpi {
    * Accepts the standard {@code NamedParameterSpec} initialization that JSSE providers (e.g.
    * BouncyCastle's TLS 1.3 stack) and application code perform before {@code generateKeyPair()}.
    *
-   * <p>Behavior depends on which service this instance came from, mirroring how SunEC treats its
-   * generic {@code XDH} service versus its curve-specific {@code X25519}/{@code X448} services:
-   *
-   * <ul>
-   *   <li>the parameter-set-agnostic {@code ML-KEM} service is <em>selectable</em> -- any spec
-   *       naming a supported ML-KEM parameter set (case-insensitively) chooses that parameter set
-   *       for subsequent {@code generateKeyPair()} calls;
-   *   <li>the parameter-set-specific {@code ML-KEM-512/768/1024} services are bound at
-   *       construction, so a spec naming that same parameter set is a no-op and any other spec is
-   *       rejected with {@code InvalidAlgorithmParameterException}, letting the JCA fail over to a
-   *       provider that supports it rather than this one silently producing a key of the wrong
-   *       parameter set.
-   * </ul>
+   * <p>This parameter-set-specific implementation is bound to its own parameter set at
+   * construction, so a spec naming that same parameter set is a no-op and any other spec is
+   * rejected with {@code InvalidAlgorithmParameterException}, letting the JCA fail over rather than
+   * this one silently producing a key of the wrong parameter set. {@link MlKemGenGeneric} overrides
+   * this to make the generic {@code ML-KEM} service selectable instead, mirroring how SunEC treats
+   * {@code XDH} versus {@code X25519}/{@code X448}.
    *
    * <p>{@code NamedParameterSpec} was introduced in JDK 11, but ACCP's main sources are compiled
    * for an older bytecode target, so the spec's name is read reflectively rather than by importing
@@ -95,25 +83,7 @@ class MlKemGen extends KeyPairGeneratorSpi {
   @Override
   public void initialize(AlgorithmParameterSpec params, SecureRandom random)
       throws InvalidAlgorithmParameterException {
-    if (params == null) {
-      throw new InvalidAlgorithmParameterException("params must not be null");
-    }
-    final String name = getNamedParameter(params);
-    if (name == null) {
-      throw new InvalidAlgorithmParameterException(
-          "Unsupported AlgorithmParameterSpec: " + params.getClass().getName());
-    }
-    if (parameterSetSelectable) {
-      final MlKemParameter selected = MlKemParameter.fromAlgorithmName(name);
-      if (selected == null) {
-        throw new InvalidAlgorithmParameterException(
-            "Unsupported ML-KEM parameter set: "
-                + name
-                + ". Supported parameter sets are ML-KEM-512, ML-KEM-768, and ML-KEM-1024.");
-      }
-      parameterSet = selected;
-      return;
-    }
+    final String name = requireParameterSetName(params);
     if (!parameterSet.matchesAlgorithmName(name)) {
       throw new InvalidAlgorithmParameterException(
           "Unsupported ML-KEM parameter set: "
@@ -125,19 +95,52 @@ class MlKemGen extends KeyPairGeneratorSpi {
     // Nothing else to configure: generateKeyPair() always produces a |parameterSet| key pair.
   }
 
-  // Returns the parameter set name if |params| is a java.security.spec.NamedParameterSpec (or a
-  // subclass, matching SunJCE's instanceof semantics -- NamedParameterSpec is not final), else
-  // null.
-  private static String getNamedParameter(final AlgorithmParameterSpec params) {
-    if (NAMED_PARAMETER_SPEC_CLASS == null || !NAMED_PARAMETER_SPEC_CLASS.isInstance(params)) {
-      return null;
+  // Extracts the parameter set name |params| designates, rejecting a spec that designates none.
+  // Shared with MlKemGenGeneric so both agree on which specs are well-formed.
+  private static String requireParameterSetName(final AlgorithmParameterSpec params)
+      throws InvalidAlgorithmParameterException {
+    if (params == null) {
+      throw new InvalidAlgorithmParameterException("params must not be null");
     }
+    final String name = getNamedParameter(params);
+    if (name == null) {
+      throw new InvalidAlgorithmParameterException(
+          "Unsupported AlgorithmParameterSpec: " + params.getClass().getName());
+    }
+    return name;
+  }
+
+  // Returns the parameter set name |params| carries, else null. A NamedParameterSpec (or subclass,
+  // per SunJCE's instanceof semantics) is read through the accessor resolved at class load.
+  private static String getNamedParameter(final AlgorithmParameterSpec params) {
+    if (NAMED_PARAMETER_SPEC_CLASS != null && NAMED_PARAMETER_SPEC_CLASS.isInstance(params)) {
+      try {
+        return (String) NAMED_PARAMETER_SPEC_GET_NAME.invoke(params);
+      } catch (final ReflectiveOperationException e) {
+        // getName() is a public method on a public JDK type resolved successfully at class load, so
+        // a failure here signals a broken runtime rather than an unsupported spec -- fail fast.
+        throw new AssertionError("Failed to invoke NamedParameterSpec.getName()", e);
+      }
+    }
+    return getNameFromForeignSpec(params);
+  }
+
+  // Some providers name a parameter set with their own spec type, exposing it through the same
+  // public getName() accessor. BouncyCastle's MLKEMParameterSpec is the one that matters: its TLS
+  // stack initializes KeyPairGenerator.getInstance("ML-KEM") with one, and BC's own generic ML-KEM
+  // generator accepts either shape there (see BC's SpecUtil.getNameFrom).
+  //
+  // Returns null when the name is not readable. Unlike NamedParameterSpec, that means "unsupported
+  // spec" rather than a broken runtime, since any spec reaching here belongs to another provider.
+  private static String getNameFromForeignSpec(final AlgorithmParameterSpec params) {
     try {
-      return (String) NAMED_PARAMETER_SPEC_GET_NAME.invoke(params);
+      final Method getName = params.getClass().getMethod("getName");
+      if (!String.class.equals(getName.getReturnType())) {
+        return null;
+      }
+      return (String) getName.invoke(params);
     } catch (final ReflectiveOperationException e) {
-      // getName() is a public method on a public JDK type resolved successfully at class load, so a
-      // failure here signals a broken runtime rather than an unsupported spec -- fail fast.
-      throw new AssertionError("Failed to invoke NamedParameterSpec.getName()", e);
+      return null;
     }
   }
 
@@ -153,12 +156,31 @@ class MlKemGen extends KeyPairGeneratorSpi {
   /**
    * Backs the parameter-set-agnostic {@code KeyPairGenerator.ML-KEM} service. Defaults to
    * ML-KEM-768 when used without initialization (preserving the historical behavior of this
-   * service), but a {@code NamedParameterSpec} passed to {@code initialize} selects any supported
-   * parameter set.
+   * service), but a spec passed to {@code initialize} selects any supported parameter set.
    */
   public static final class MlKemGenGeneric extends MlKemGen {
     public MlKemGenGeneric(AmazonCorrettoCryptoProvider provider) {
-      super(MlKemParameter.MLKEM_768, true);
+      super(MlKemParameter.MLKEM_768);
+    }
+
+    /**
+     * Selects the parameter set named by {@code params} (case-insensitively) for subsequent {@code
+     * generateKeyPair()} calls, rather than requiring a spec naming ML-KEM-768.
+     */
+    @Override
+    public void initialize(final AlgorithmParameterSpec params, final SecureRandom random)
+        throws InvalidAlgorithmParameterException {
+      final String name = requireParameterSetName(params);
+      final MlKemParameter selected = MlKemParameter.fromAlgorithmName(name);
+      if (selected == null) {
+        throw new InvalidAlgorithmParameterException(
+            "Unsupported ML-KEM parameter set: "
+                + name
+                + ". Supported parameter sets are "
+                + MlKemParameter.supportedAlgorithmNames()
+                + ".");
+      }
+      setParameterSet(selected);
     }
   }
 

--- a/src/com/amazon/corretto/crypto/provider/MlKemParameter.java
+++ b/src/com/amazon/corretto/crypto/provider/MlKemParameter.java
@@ -58,6 +58,21 @@ enum MlKemParameter {
     return getAlgorithmName().equalsIgnoreCase(name);
   }
 
+  /**
+   * Case-insensitive lookup of the parameter set whose JCA standard algorithm name is {@code name},
+   * or null if {@code name} does not name a supported parameter set. Unlike {@link
+   * #fromKemName(String)} this is case-insensitive and returns null rather than throwing, which
+   * suits an SPI deciding whether to accept a caller-supplied {@code NamedParameterSpec} name.
+   */
+  public static MlKemParameter fromAlgorithmName(final String name) {
+    for (final MlKemParameter candidate : values()) {
+      if (candidate.matchesAlgorithmName(name)) {
+        return candidate;
+      }
+    }
+    return null;
+  }
+
   public static MlKemParameter fromKeySize(int keySize) {
     if (keySize == MLKEM_512.publicKeySize || keySize == MLKEM_512.secretKeySize) {
       return MLKEM_512;

--- a/src/com/amazon/corretto/crypto/provider/MlKemParameter.java
+++ b/src/com/amazon/corretto/crypto/provider/MlKemParameter.java
@@ -23,17 +23,17 @@ enum MlKemParameter {
     this.ciphertextSize = ciphertextSize;
   }
 
+  /**
+   * As {@link #fromAlgorithmName(String)}, but throws rather than returning null. Delegates so the
+   * name-to-parameter-set mapping lives in one place; matching is therefore case-insensitive.
+   */
   public static MlKemParameter fromKemName(String name) {
-    switch (name) {
-      case "ML-KEM-512":
-        return MLKEM_512;
-      case "ML-KEM-768":
-        return MLKEM_768;
-      case "ML-KEM-1024":
-        return MLKEM_1024;
-      default:
-        throw new IllegalArgumentException("Invalid ML-KEM name: " + name);
+    final MlKemParameter result = fromAlgorithmName(name);
+    if (result == null) {
+      throw new IllegalArgumentException(
+          "Invalid ML-KEM name: " + name + ". Supported names are " + supportedAlgorithmNames());
     }
+    return result;
   }
 
   public int getCiphertextSize() {
@@ -71,6 +71,21 @@ enum MlKemParameter {
       }
     }
     return null;
+  }
+
+  /**
+   * The supported algorithm names, comma-separated, for error messages that would otherwise
+   * hardcode (and go stale against) the enum constants.
+   */
+  public static String supportedAlgorithmNames() {
+    final StringBuilder names = new StringBuilder();
+    for (final MlKemParameter candidate : values()) {
+      if (names.length() > 0) {
+        names.append(", ");
+      }
+      names.append(candidate.getAlgorithmName());
+    }
+    return names.toString();
   }
 
   public static MlKemParameter fromKeySize(int keySize) {

--- a/src/com/amazon/corretto/crypto/utils/MlDsaUtils.java
+++ b/src/com/amazon/corretto/crypto/utils/MlDsaUtils.java
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.amazon.corretto.crypto.utils;
 
+import java.security.Key;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 
@@ -14,6 +15,27 @@ public final class MlDsaUtils {
   private static native byte[] expandPrivateKeyInternal(byte[] key);
 
   /**
+   * Returns {@code key}'s encoding, rejecting a key this class cannot hand to JNI. Both null checks
+   * have to happen in Java: {@code getAlgorithm()} is not specified to be non-null, and {@code
+   * getEncoded()} is null for a key that does not support encoding, which in JNI would reach {@code
+   * GetArrayLength(nullptr)}.
+   */
+  private static byte[] requireEncodableMlDsaKey(final Key key) {
+    if (key == null) {
+      throw new IllegalArgumentException("key must not be null");
+    }
+    final String algorithm = key.getAlgorithm();
+    if (algorithm == null || !algorithm.startsWith("ML-DSA")) {
+      throw new IllegalArgumentException("Not an ML-DSA key: " + algorithm);
+    }
+    final byte[] encoded = key.getEncoded();
+    if (encoded == null) {
+      throw new IllegalArgumentException("Key does not support encoding");
+    }
+    return encoded;
+  }
+
+  /**
    * Computes mu as defined on line 6 of Algorithm 7 and line 7 of Algorithm 8 in NIST FIPS 204.
    *
    * <p>See <a href="https://csrc.nist.gov/pubs/fips/204/final">FIPS 204</a>
@@ -21,19 +43,16 @@ public final class MlDsaUtils {
    * @param publicKey ML-DSA public key
    * @param message byte array of the message over which to compute mu
    * @return a byte[] of length 64 containing mu
-   * @throws IllegalArgumentException if {@code publicKey} is null, is not an ML-DSA key, or returns
-   *     null from {@code getEncoded()} because it does not support encoding, or if {@code message}
-   *     is null
+   * @throws IllegalArgumentException if {@code publicKey} is null, is not an ML-DSA key (including
+   *     one whose {@code getEncoded()} is not an ML-DSA public key), or returns null from {@code
+   *     getAlgorithm()} or {@code getEncoded()}, or if {@code message} is null
+   * @throws com.amazon.corretto.crypto.provider.RuntimeCryptoException if {@code
+   *     publicKey.getEncoded()} is not a X.509 SubjectPublicKeyInfo ACCP can parse
    */
   public static byte[] computeMu(PublicKey publicKey, byte[] message) {
-    if (publicKey == null || !publicKey.getAlgorithm().startsWith("ML-DSA") || message == null) {
-      throw new IllegalArgumentException();
-    }
-    // Key.getEncoded() is specified to return null for a key that does not support encoding, so it
-    // has to be checked here rather than in JNI, where it would reach GetArrayLength(nullptr).
-    final byte[] encoded = publicKey.getEncoded();
-    if (encoded == null) {
-      throw new IllegalArgumentException();
+    final byte[] encoded = requireEncodableMlDsaKey(publicKey);
+    if (message == null) {
+      throw new IllegalArgumentException("message must not be null");
     }
     return computeMuInternal(encoded, message);
   }
@@ -42,21 +61,19 @@ public final class MlDsaUtils {
    * Returns an expanded ML-DSA private key, whether the key passed in is based on a seed or
    * expanded. It returns the PKCS8-encoded expanded key.
    *
+   * <p>The returned encoding is always the canonical minimal form: a version 0 {@code
+   * PrivateKeyInfo} with no {@code attributes} and no {@code publicKey}. Those optional fields are
+   * accepted on input but not carried over, so this is idempotent on its own output rather than
+   * byte-preserving on arbitrary input.
+   *
    * @param key an ML-DSA private key
-   * @return a byte[] containing the PKCS8-encoded seed private key
+   * @return a byte[] containing the PKCS8-encoded expanded private key
    * @throws IllegalArgumentException if {@code key} is null, is not an ML-DSA key, or returns null
-   *     from {@code getEncoded()} because it does not support encoding
+   *     from {@code getAlgorithm()} or {@code getEncoded()}
+   * @throws com.amazon.corretto.crypto.provider.RuntimeCryptoException if {@code key.getEncoded()}
+   *     is not a PKCS8 ML-DSA private key ACCP can parse
    */
   public static byte[] expandPrivateKey(PrivateKey key) {
-    if (key == null || !key.getAlgorithm().startsWith("ML-DSA")) {
-      throw new IllegalArgumentException();
-    }
-    // Key.getEncoded() is specified to return null for a key that does not support encoding, so it
-    // has to be checked here rather than in JNI, where it would reach GetArrayLength(nullptr).
-    final byte[] encoded = key.getEncoded();
-    if (encoded == null) {
-      throw new IllegalArgumentException();
-    }
-    return expandPrivateKeyInternal(encoded);
+    return expandPrivateKeyInternal(requireEncodableMlDsaKey(key));
   }
 }

--- a/src/com/amazon/corretto/crypto/utils/MlDsaUtils.java
+++ b/src/com/amazon/corretto/crypto/utils/MlDsaUtils.java
@@ -21,12 +21,21 @@ public final class MlDsaUtils {
    * @param publicKey ML-DSA public key
    * @param message byte array of the message over which to compute mu
    * @return a byte[] of length 64 containing mu
+   * @throws IllegalArgumentException if {@code publicKey} is null, is not an ML-DSA key, or returns
+   *     null from {@code getEncoded()} because it does not support encoding, or if {@code message}
+   *     is null
    */
   public static byte[] computeMu(PublicKey publicKey, byte[] message) {
     if (publicKey == null || !publicKey.getAlgorithm().startsWith("ML-DSA") || message == null) {
       throw new IllegalArgumentException();
     }
-    return computeMuInternal(publicKey.getEncoded(), message);
+    // Key.getEncoded() is specified to return null for a key that does not support encoding, so it
+    // has to be checked here rather than in JNI, where it would reach GetArrayLength(nullptr).
+    final byte[] encoded = publicKey.getEncoded();
+    if (encoded == null) {
+      throw new IllegalArgumentException();
+    }
+    return computeMuInternal(encoded, message);
   }
 
   /**
@@ -35,11 +44,19 @@ public final class MlDsaUtils {
    *
    * @param key an ML-DSA private key
    * @return a byte[] containing the PKCS8-encoded seed private key
+   * @throws IllegalArgumentException if {@code key} is null, is not an ML-DSA key, or returns null
+   *     from {@code getEncoded()} because it does not support encoding
    */
   public static byte[] expandPrivateKey(PrivateKey key) {
     if (key == null || !key.getAlgorithm().startsWith("ML-DSA")) {
       throw new IllegalArgumentException();
     }
-    return expandPrivateKeyInternal(key.getEncoded());
+    // Key.getEncoded() is specified to return null for a key that does not support encoding, so it
+    // has to be checked here rather than in JNI, where it would reach GetArrayLength(nullptr).
+    final byte[] encoded = key.getEncoded();
+    if (encoded == null) {
+      throw new IllegalArgumentException();
+    }
+    return expandPrivateKeyInternal(encoded);
   }
 }

--- a/src/com/amazon/corretto/crypto/utils/MlKemUtils.java
+++ b/src/com/amazon/corretto/crypto/utils/MlKemUtils.java
@@ -31,19 +31,24 @@ public final class MlKemUtils {
    * @param key an ML-KEM private key
    * @return a byte[] containing the PKCS8-encoded expanded private key
    * @throws IllegalArgumentException if {@code key} is null, is not an ML-KEM key, or returns null
-   *     from {@code getEncoded()} because it does not support encoding
+   *     from {@code getAlgorithm()} or {@code getEncoded()}
    * @throws com.amazon.corretto.crypto.provider.RuntimeCryptoException if {@code key.getEncoded()}
    *     is not a PKCS8 ML-KEM private key ACCP can parse
    */
   public static byte[] expandPrivateKey(PrivateKey key) {
-    if (key == null || !key.getAlgorithm().startsWith("ML-KEM")) {
-      throw new IllegalArgumentException();
+    if (key == null) {
+      throw new IllegalArgumentException("key must not be null");
+    }
+    // Key.getAlgorithm() is not specified to be non-null, so it cannot be dereferenced directly.
+    final String algorithm = key.getAlgorithm();
+    if (algorithm == null || !algorithm.startsWith("ML-KEM")) {
+      throw new IllegalArgumentException("Not an ML-KEM key: " + algorithm);
     }
     // Key.getEncoded() is specified to return null for a key that does not support encoding, so it
     // has to be checked here rather than in JNI, where it would reach GetArrayLength(nullptr).
     final byte[] encoded = key.getEncoded();
     if (encoded == null) {
-      throw new IllegalArgumentException();
+      throw new IllegalArgumentException("Key does not support encoding");
     }
     return expandPrivateKeyInternal(encoded);
   }

--- a/tst/com/amazon/corretto/crypto/provider/test/MlDsaUtilsTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/MlDsaUtilsTest.java
@@ -102,4 +102,61 @@ public class MlDsaUtilsTest {
     signature.update(message);
     assertTrue(signature.verify(signatureBytes));
   }
+
+  // A Key is permitted to return null from getEncoded() when it does not support encoding, as a key
+  // held in hardware would. The algorithm check alone does not catch that, and the null must be
+  // refused in Java rather than passed to JNI, where GetArrayLength would dereference it.
+  @Test
+  @DisabledIf("mlDsaDisabled")
+  public void testUnencodableKeysAreRejected() {
+    final PublicKey unencodablePub =
+        new PublicKey() {
+          static final long serialVersionUID = 1L;
+
+          @Override
+          public String getAlgorithm() {
+            return "ML-DSA-44";
+          }
+
+          @Override
+          public String getFormat() {
+            return null;
+          }
+
+          @Override
+          public byte[] getEncoded() {
+            return null;
+          }
+        };
+    final PrivateKey unencodablePriv =
+        new PrivateKey() {
+          static final long serialVersionUID = 1L;
+
+          @Override
+          public String getAlgorithm() {
+            return "ML-DSA-44";
+          }
+
+          @Override
+          public String getFormat() {
+            return null;
+          }
+
+          @Override
+          public byte[] getEncoded() {
+            return null;
+          }
+        };
+
+    final byte[] message = new byte[256];
+    Arrays.fill(message, (byte) 0x41);
+
+    TestUtil.assertThrows(
+        IllegalArgumentException.class, () -> MlDsaUtils.computeMu(null, message));
+    TestUtil.assertThrows(
+        IllegalArgumentException.class, () -> MlDsaUtils.computeMu(unencodablePub, message));
+    TestUtil.assertThrows(IllegalArgumentException.class, () -> MlDsaUtils.expandPrivateKey(null));
+    TestUtil.assertThrows(
+        IllegalArgumentException.class, () -> MlDsaUtils.expandPrivateKey(unencodablePriv));
+  }
 }

--- a/tst/com/amazon/corretto/crypto/provider/test/MlDsaUtilsTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/MlDsaUtilsTest.java
@@ -103,50 +103,51 @@ public class MlDsaUtilsTest {
     assertTrue(signature.verify(signatureBytes));
   }
 
-  // A Key is permitted to return null from getEncoded() when it does not support encoding, as a key
-  // held in hardware would. The algorithm check alone does not catch that, and the null must be
-  // refused in Java rather than passed to JNI, where GetArrayLength would dereference it.
+  /**
+   * Reports whatever algorithm and encoding a test needs, including the nulls the interface
+   * permits. Implements both key interfaces so one instance drives both entry points.
+   */
+  private static final class TestKey implements PublicKey, PrivateKey {
+    private static final long serialVersionUID = 1L;
+
+    private final String algorithm;
+    private final byte[] encoded;
+
+    private TestKey(final String algorithm, final byte[] encoded) {
+      this.algorithm = algorithm;
+      this.encoded = encoded;
+    }
+
+    @Override
+    public String getAlgorithm() {
+      return algorithm;
+    }
+
+    @Override
+    public String getFormat() {
+      return null;
+    }
+
+    @Override
+    public byte[] getEncoded() {
+      return encoded;
+    }
+  }
+
+  // A Key may return null from getEncoded() when it does not support encoding, as a key held in
+  // hardware would, and getAlgorithm() is not specified to be non-null either. Both nulls must be
+  // refused in Java: one reaches GetArrayLength(nullptr) in JNI, the other is dereferenced by the
+  // algorithm check itself.
+  //
+  // Not gated on mlDsaDisabled(): every case is rejected before JNI, so this must also run in the
+  // FIPS builds where computeMuInternal is not compiled at all.
   @Test
-  @DisabledIf("mlDsaDisabled")
-  public void testUnencodableKeysAreRejected() {
-    final PublicKey unencodablePub =
-        new PublicKey() {
-          static final long serialVersionUID = 1L;
-
-          @Override
-          public String getAlgorithm() {
-            return "ML-DSA-44";
-          }
-
-          @Override
-          public String getFormat() {
-            return null;
-          }
-
-          @Override
-          public byte[] getEncoded() {
-            return null;
-          }
-        };
-    final PrivateKey unencodablePriv =
-        new PrivateKey() {
-          static final long serialVersionUID = 1L;
-
-          @Override
-          public String getAlgorithm() {
-            return "ML-DSA-44";
-          }
-
-          @Override
-          public String getFormat() {
-            return null;
-          }
-
-          @Override
-          public byte[] getEncoded() {
-            return null;
-          }
-        };
+  public void testUnusableKeysAreRejected() {
+    final TestKey unencodable = new TestKey("ML-DSA-44", null);
+    final TestKey nullAlgorithm = new TestKey(null, new byte[32]);
+    final TestKey wrongAlgorithm = new TestKey("RSA", new byte[32]);
+    // Passes every key check, so it reaches the message check without reaching JNI.
+    final TestKey encodable = new TestKey("ML-DSA-44", new byte[32]);
 
     final byte[] message = new byte[256];
     Arrays.fill(message, (byte) 0x41);
@@ -154,9 +155,20 @@ public class MlDsaUtilsTest {
     TestUtil.assertThrows(
         IllegalArgumentException.class, () -> MlDsaUtils.computeMu(null, message));
     TestUtil.assertThrows(
-        IllegalArgumentException.class, () -> MlDsaUtils.computeMu(unencodablePub, message));
+        IllegalArgumentException.class, () -> MlDsaUtils.computeMu(unencodable, message));
+    TestUtil.assertThrows(
+        IllegalArgumentException.class, () -> MlDsaUtils.computeMu(nullAlgorithm, message));
+    TestUtil.assertThrows(
+        IllegalArgumentException.class, () -> MlDsaUtils.computeMu(wrongAlgorithm, message));
+    TestUtil.assertThrows(
+        IllegalArgumentException.class, () -> MlDsaUtils.computeMu(encodable, null));
+
     TestUtil.assertThrows(IllegalArgumentException.class, () -> MlDsaUtils.expandPrivateKey(null));
     TestUtil.assertThrows(
-        IllegalArgumentException.class, () -> MlDsaUtils.expandPrivateKey(unencodablePriv));
+        IllegalArgumentException.class, () -> MlDsaUtils.expandPrivateKey(unencodable));
+    TestUtil.assertThrows(
+        IllegalArgumentException.class, () -> MlDsaUtils.expandPrivateKey(nullAlgorithm));
+    TestUtil.assertThrows(
+        IllegalArgumentException.class, () -> MlDsaUtils.expandPrivateKey(wrongAlgorithm));
   }
 }

--- a/tst/com/amazon/corretto/crypto/provider/test/jdk17plus/MlKemTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/jdk17plus/MlKemTest.java
@@ -70,8 +70,23 @@ public class MlKemTest {
   private static final int CHOICE_TAG_EXPANDED = 0x04; // OCTET STRING
   private static final int CHOICE_TAG_BOTH = 0x30; // SEQUENCE { seed, expandedKey }
 
+  private static final String BC_KEM_UNAVAILABLE =
+      "BouncyCastle does not register the KEM API on JDK versions older than 21. Please try"
+          + " building with JDK 21 or above.";
+
   private static String[] mlKemParamSets() {
     return ML_KEM_PARAM_SETS;
+  }
+
+  // BouncyCastle does not register the KEM API for ML-KEM on JDK versions older than 21, so tests
+  // that cross the KEM API have to check the runtime environment and skip rather than fail there.
+  private static boolean bcRegistersKemService() {
+    try {
+      KEM.getInstance("ML-KEM", TestUtil.BC_PROVIDER);
+      return true;
+    } catch (final java.security.NoSuchAlgorithmException e) {
+      return false;
+    }
   }
 
   private static int getCiphertextSizeForParamSet(String paramSet) throws Throwable {
@@ -259,6 +274,61 @@ public class MlKemTest {
     assertThrows(
         InvalidAlgorithmParameterException.class,
         () -> kem512.newDecapsulator(pair768.getPrivate(), wrongSpec));
+  }
+
+  /**
+   * The parameter-set-agnostic "ML-KEM" KeyPairGenerator lets a NamedParameterSpec choose the
+   * parameter set, mirroring how SunEC's generic "XDH" service accepts either X25519 or X448.
+   */
+  @ParameterizedTest
+  @MethodSource("mlKemParamSets")
+  public void testGenericKeyPairGeneratorIsParameterSetSelectable(String paramSet)
+      throws Exception {
+    final KeyPairGenerator keyGen = KeyPairGenerator.getInstance("ML-KEM", NATIVE_PROVIDER);
+    keyGen.initialize(new NamedParameterSpec(paramSet));
+    final KeyPair keyPair = keyGen.generateKeyPair();
+
+    assertEquals(paramSet, keyPair.getPublic().getAlgorithm());
+    assertEquals(paramSet, keyPair.getPrivate().getAlgorithm());
+  }
+
+  /** Without initialization the generic service keeps its historical ML-KEM-768 default. */
+  @Test
+  public void testGenericKeyPairGeneratorDefaultsTo768() throws Exception {
+    final KeyPair keyPair =
+        KeyPairGenerator.getInstance("ML-KEM", NATIVE_PROVIDER).generateKeyPair();
+
+    assertEquals("ML-KEM-768", keyPair.getPublic().getAlgorithm());
+  }
+
+  /** A spec naming something that is not an ML-KEM parameter set is still rejected. */
+  @Test
+  public void testGenericKeyPairGeneratorRejectsUnknownParameterSet() throws Exception {
+    final KeyPairGenerator keyGen = KeyPairGenerator.getInstance("ML-KEM", NATIVE_PROVIDER);
+
+    assertThrows(
+        InvalidAlgorithmParameterException.class,
+        () -> keyGen.initialize(new NamedParameterSpec("ML-KEM-4096")));
+    assertThrows(
+        InvalidAlgorithmParameterException.class,
+        () -> keyGen.initialize(NamedParameterSpec.X25519));
+  }
+
+  /**
+   * The parameter-set-specific services stay strict: they accept a spec naming their own parameter
+   * set and reject any other, so the JCA can fail over rather than silently produce the wrong key.
+   */
+  @Test
+  public void testSpecificKeyPairGeneratorsRemainStrict() throws Exception {
+    final KeyPairGenerator keyGen768 = KeyPairGenerator.getInstance("ML-KEM-768", NATIVE_PROVIDER);
+    keyGen768.initialize(new NamedParameterSpec("ML-KEM-768"));
+    assertEquals("ML-KEM-768", keyGen768.generateKeyPair().getPublic().getAlgorithm());
+
+    assertThrows(
+        InvalidAlgorithmParameterException.class,
+        () ->
+            KeyPairGenerator.getInstance("ML-KEM-768", NATIVE_PROVIDER)
+                .initialize(new NamedParameterSpec("ML-KEM-512")));
   }
 
   @Test
@@ -1050,21 +1120,8 @@ public class MlKemTest {
     KEM.Encapsulated encapsulated =
         accpKem.newEncapsulator(accpKeyPair.getPublic(), accpParamSpec, null).encapsulate();
 
-    // BouncyCastle does not register the KEM API for ML-KEM on JDK versions older than JDK 21
-    // We need to check the runtime environment supports BouncyCastle's KEM API
-    boolean bcHasKemProvider = false;
-    try {
-      KEM.getInstance("ML-KEM", TestUtil.BC_PROVIDER);
-      bcHasKemProvider = true;
-    } catch (java.security.NoSuchAlgorithmException e) {
-
-      bcHasKemProvider = false;
-    }
-    // Skip the test if BouncyCastle doesn't support KEM API
-    assumeTrue(
-        bcHasKemProvider,
-        "BouncyCastle does not register the KEM API on JDK versions older than 21. Please try"
-            + " building with JDK 21 or above.");
+    // Skip the rest of the test if BouncyCastle doesn't support the KEM API
+    assumeTrue(bcRegistersKemService(), BC_KEM_UNAVAILABLE);
 
     KEM bcKem = KEM.getInstance("ML-KEM", TestUtil.BC_PROVIDER); // BC uses Generic ML-KEM
 
@@ -1076,6 +1133,82 @@ public class MlKemTest {
         encapsulated.key().getEncoded(),
         bcSecret.getEncoded(),
         "ACCP and BouncyCastle should produce identical shared secrets for " + paramSet);
+  }
+
+  /**
+   * Interop driven entirely through the parameter-set-agnostic service names, which is the shape a
+   * JSSE stack or a provider-agnostic application uses: {@code KeyPairGenerator}, {@code
+   * KeyFactory} and {@code KEM} named "ML-KEM", with a {@code NamedParameterSpec} choosing the
+   * parameter set. BouncyCastle's generic ML-KEM KeyPairGenerator has always accepted such a spec;
+   * before ACCP's generic generator became selectable this path only reached ML-KEM-768, and threw
+   * {@code InvalidAlgorithmParameterException} for 512 and 1024. {@link
+   * #testBouncyCastleInteroperability(String)} covers the same interop through the service names
+   * that name a parameter set.
+   */
+  @ParameterizedTest
+  @MethodSource("mlKemParamSets")
+  public void testGenericServiceNameInteropWithBouncyCastle(String paramSet) throws Exception {
+    final NamedParameterSpec paramSpec = new NamedParameterSpec(paramSet);
+
+    final KeyPairGenerator accpKeyGen = KeyPairGenerator.getInstance("ML-KEM", NATIVE_PROVIDER);
+    accpKeyGen.initialize(paramSpec);
+    final KeyPair accpKeyPair = accpKeyGen.generateKeyPair();
+    assertEquals(paramSet, accpKeyPair.getPublic().getAlgorithm());
+    assertEquals(paramSet, accpKeyPair.getPrivate().getAlgorithm());
+
+    final KeyPairGenerator bcKeyGen = KeyPairGenerator.getInstance("ML-KEM", TestUtil.BC_PROVIDER);
+    bcKeyGen.initialize(paramSpec);
+    final KeyPair bcKeyPair = bcKeyGen.generateKeyPair();
+    assertEquals(paramSet, bcKeyPair.getPublic().getAlgorithm());
+
+    // Each side's generic KeyFactory imports the other side's key pair. ACCP rejects the both
+    // CHOICE that BouncyCastle's getEncoded() emits by default, so ask BC for the expandedKey
+    // CHOICE; testPrivateKeyChoicesParse covers which CHOICEs ACCP accepts.
+    final KeyFactory accpKf = KeyFactory.getInstance("ML-KEM", NATIVE_PROVIDER);
+    final KeyFactory bcKf = KeyFactory.getInstance("ML-KEM", TestUtil.BC_PROVIDER);
+    final PrivateKey bcImportedPriv =
+        bcKf.generatePrivate(new PKCS8EncodedKeySpec(accpKeyPair.getPrivate().getEncoded()));
+    final PublicKey accpImportedPub =
+        accpKf.generatePublic(new X509EncodedKeySpec(bcKeyPair.getPublic().getEncoded()));
+    final PrivateKey accpImportedPriv =
+        accpKf.generatePrivate(
+            new PKCS8EncodedKeySpec(
+                ((MLKEMPrivateKey) bcKeyPair.getPrivate()).getPrivateKey(false).getEncoded()));
+    assertArrayEquals(
+        bcKeyPair.getPublic().getEncoded(),
+        accpImportedPub.getEncoded(),
+        paramSet + " ACCP must preserve a BouncyCastle SPKI imported through the generic name");
+    assertEquals(paramSet, accpImportedPriv.getAlgorithm());
+
+    assumeTrue(bcRegistersKemService(), BC_KEM_UNAVAILABLE);
+
+    final KEM accpKem = KEM.getInstance("ML-KEM", NATIVE_PROVIDER);
+    final KEM bcKem = KEM.getInstance("ML-KEM", TestUtil.BC_PROVIDER);
+    // Configure BC to not apply KDF processing so both sides report the raw ML-KEM shared secret.
+    final KTSParameterSpec bcKtsSpec =
+        new KTSParameterSpec.Builder("Generic", 256).withNoKdf().build();
+
+    // ACCP encapsulates, BouncyCastle decapsulates.
+    final KEM.Encapsulated accpEncapsulated =
+        accpKem.newEncapsulator(accpKeyPair.getPublic(), paramSpec, null).encapsulate();
+    assertArrayEquals(
+        accpEncapsulated.key().getEncoded(),
+        bcKem
+            .newDecapsulator(bcImportedPriv, bcKtsSpec)
+            .decapsulate(accpEncapsulated.encapsulation())
+            .getEncoded(),
+        paramSet + " BouncyCastle must recover the secret ACCP encapsulated");
+
+    // BouncyCastle encapsulates, ACCP decapsulates.
+    final KEM.Encapsulated bcEncapsulated =
+        bcKem.newEncapsulator(bcKeyPair.getPublic(), bcKtsSpec, null).encapsulate();
+    assertArrayEquals(
+        bcEncapsulated.key().getEncoded(),
+        accpKem
+            .newDecapsulator(accpImportedPriv, paramSpec)
+            .decapsulate(bcEncapsulated.encapsulation())
+            .getEncoded(),
+        paramSet + " ACCP must recover the secret BouncyCastle encapsulated");
   }
 
   @ParameterizedTest

--- a/tst/com/amazon/corretto/crypto/provider/test/jdk17plus/MlKemTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/jdk17plus/MlKemTest.java
@@ -331,6 +331,34 @@ public class MlKemTest {
                 .initialize(new NamedParameterSpec("ML-KEM-512")));
   }
 
+  /**
+   * A parameter set may be named by a spec that is not a {@code NamedParameterSpec}. BouncyCastle's
+   * {@code MLKEMParameterSpec} is the case that matters: BC's TLS stack hands its KeyPairGenerator
+   * that spec, which a generator understanding only {@code NamedParameterSpec} would reject. The
+   * name is still matched against the supported parameter sets, so a foreign spec cannot select an
+   * unsupported one or bypass the strict services' check.
+   */
+  @ParameterizedTest
+  @MethodSource("mlKemParamSets")
+  public void testKeyPairGeneratorAcceptsForeignNamedSpec(String paramSet) throws Exception {
+    final AlgorithmParameterSpec bcSpec = TestUtil.getMlKemParamSpec(paramSet);
+
+    final KeyPairGenerator generic = KeyPairGenerator.getInstance("ML-KEM", NATIVE_PROVIDER);
+    generic.initialize(bcSpec);
+    assertEquals(paramSet, generic.generateKeyPair().getPublic().getAlgorithm());
+
+    final KeyPairGenerator specific = KeyPairGenerator.getInstance(paramSet, NATIVE_PROVIDER);
+    specific.initialize(bcSpec);
+    assertEquals(paramSet, specific.generateKeyPair().getPublic().getAlgorithm());
+
+    // The strict services still reject a foreign spec naming a different parameter set.
+    assertThrows(
+        InvalidAlgorithmParameterException.class,
+        () ->
+            KeyPairGenerator.getInstance("ML-KEM-768", NATIVE_PROVIDER)
+                .initialize(TestUtil.getMlKemParamSpec("ML-KEM-512")));
+  }
+
   @Test
   public void testKeyFactorySelfConversion() throws Exception {
     KeyPairGenerator keyGen = KeyPairGenerator.getInstance("ML-KEM", NATIVE_PROVIDER);
@@ -1058,131 +1086,103 @@ public class MlKemTest {
   @ParameterizedTest
   @MethodSource("mlKemParamSets")
   public void testBouncyCastleInteroperability(String paramSet) throws Exception {
-    KeyPair accpKeyPair = KeyPairGenerator.getInstance(paramSet, NATIVE_PROVIDER).generateKeyPair();
-
-    // Test BouncyCastle can import ACCP keys
-    KeyFactory bcKf = KeyFactory.getInstance("ML-KEM", TestUtil.BC_PROVIDER);
-    PublicKey bcPub =
-        bcKf.generatePublic(new X509EncodedKeySpec(accpKeyPair.getPublic().getEncoded()));
-    PrivateKey bcPriv =
-        bcKf.generatePrivate(new PKCS8EncodedKeySpec(accpKeyPair.getPrivate().getEncoded()));
-
-    assertNotNull(bcPub, "BouncyCastle should import ACCP public key");
-    assertNotNull(bcPriv, "BouncyCastle should import ACCP private key");
-    assertArrayEquals(
-        accpKeyPair.getPublic().getEncoded(),
-        bcPub.getEncoded(),
-        "Public key encoding should be preserved");
-    assertArrayEquals(
-        accpKeyPair.getPrivate().getEncoded(),
-        bcPriv.getEncoded(),
-        "Private key encoding should be preserved");
-
-    // The expanded encoding is ACCP's other private-key output, and MlKemUtils.expandPrivateKey is
-    // the only way to obtain it in builds whose getEncoded() emits the seed. Feeding it to BC too
-    // means every private-key encoding ACCP can produce is checked against BC in this test.
-    byte[] accpExpanded = MlKemUtils.expandPrivateKey(accpKeyPair.getPrivate());
-    PrivateKey bcPrivFromExpanded = bcKf.generatePrivate(new PKCS8EncodedKeySpec(accpExpanded));
-    assertArrayEquals(
-        accpExpanded,
-        bcPrivFromExpanded.getEncoded(),
-        "Expanded private key encoding should be preserved");
-    assertArrayEquals(
-        ((MLKEMPrivateKey) bcPriv).getPrivateKey(false).getEncoded(),
-        accpExpanded,
-        "BouncyCastle and ACCP should agree on the expanded encoding of the same key");
-
-    // Test BC keys and convert to ACCP using ACCP's key factory, test if they're equal
-    KeyPairGenerator bcKeyGen = KeyPairGenerator.getInstance("ML-KEM", TestUtil.BC_PROVIDER);
-    bcKeyGen.initialize(TestUtil.getMlKemParamSpec(paramSet));
-    KeyPair bcKeyPair = bcKeyGen.generateKeyPair();
-
-    // Ask BC for the expandedKey CHOICE specifically, per RFC 9935 Section 6, so this stays a
-    // like-for-like comparison of re-encodings: an expandedKey-imported ACCP key has no seed to
-    // emit, so it round-trips to the expanded form in every build. testPrivateKeyChoicesParse
-    // covers the seed CHOICE.
-    // https://github.com/bcgit/bc-java/blob/b41f23936724284a20f10dff13c76896a846031b/prov/src/main/java/org/bouncycastle/jcajce/interfaces/MLKEMPrivateKey.java#L35
-    MLKEMPrivateKey bcPrivateKeyExpanded =
-        ((MLKEMPrivateKey) bcKeyPair.getPrivate()).getPrivateKey(false);
-
-    KeyFactory accpKeyFactory =
-        KeyFactory.getInstance(bcKeyPair.getPrivate().getAlgorithm(), NATIVE_PROVIDER);
-    PublicKey accpPublicKey =
-        accpKeyFactory.generatePublic(new X509EncodedKeySpec(bcKeyPair.getPublic().getEncoded()));
-    PrivateKey accpPrivateKey =
-        accpKeyFactory.generatePrivate(new PKCS8EncodedKeySpec(bcPrivateKeyExpanded.getEncoded()));
-    assertArrayEquals(accpPublicKey.getEncoded(), bcKeyPair.getPublic().getEncoded());
-    assertArrayEquals(accpPrivateKey.getEncoded(), bcPrivateKeyExpanded.getEncoded());
-
-    // Test ACCP's encapsulation can be decapsulated by BouncyCastle
-    KEM accpKem = KEM.getInstance(paramSet, NATIVE_PROVIDER);
-    NamedParameterSpec accpParamSpec = new NamedParameterSpec(paramSet);
-    KEM.Encapsulated encapsulated =
-        accpKem.newEncapsulator(accpKeyPair.getPublic(), accpParamSpec, null).encapsulate();
-
-    // Skip the rest of the test if BouncyCastle doesn't support the KEM API
-    assumeTrue(bcRegistersKemService(), BC_KEM_UNAVAILABLE);
-
-    KEM bcKem = KEM.getInstance("ML-KEM", TestUtil.BC_PROVIDER); // BC uses Generic ML-KEM
-
-    // Configure BC to not apply KDF processing to get raw shared secret
-    KTSParameterSpec bcParamSpec = new KTSParameterSpec.Builder("Generic", 256).withNoKdf().build();
-    SecretKey bcSecret =
-        bcKem.newDecapsulator(bcPriv, bcParamSpec).decapsulate(encapsulated.encapsulation());
-    assertArrayEquals(
-        encapsulated.key().getEncoded(),
-        bcSecret.getEncoded(),
-        "ACCP and BouncyCastle should produce identical shared secrets for " + paramSet);
+    assertBouncyCastleInterop(paramSet, paramSet);
   }
 
   /**
-   * Interop driven entirely through the parameter-set-agnostic service names, which is the shape a
-   * JSSE stack or a provider-agnostic application uses: {@code KeyPairGenerator}, {@code
-   * KeyFactory} and {@code KEM} named "ML-KEM", with a {@code NamedParameterSpec} choosing the
-   * parameter set. BouncyCastle's generic ML-KEM KeyPairGenerator has always accepted such a spec;
-   * before ACCP's generic generator became selectable this path only reached ML-KEM-768, and threw
-   * {@code InvalidAlgorithmParameterException} for 512 and 1024. {@link
-   * #testBouncyCastleInteroperability(String)} covers the same interop through the service names
-   * that name a parameter set.
+   * The interop of {@link #testBouncyCastleInteroperability(String)} driven entirely through the
+   * parameter-set-agnostic service name, which is the shape a provider-agnostic application (or a
+   * JSSE stack) uses: {@code KeyPairGenerator}, {@code KeyFactory} and {@code KEM} named "ML-KEM",
+   * with the parameter set chosen by a spec. Before ACCP's generic generator became selectable this
+   * path reached only ML-KEM-768 and threw {@code InvalidAlgorithmParameterException} for 512 and
+   * 1024.
    */
   @ParameterizedTest
   @MethodSource("mlKemParamSets")
   public void testGenericServiceNameInteropWithBouncyCastle(String paramSet) throws Exception {
+    assertBouncyCastleInterop("ML-KEM", paramSet);
+  }
+
+  /**
+   * Cross-provider interop: generate on both sides, import each side's key pair with the other's
+   * KeyFactory, and -- where the runtime provides BouncyCastle's KEM API -- run a KEM round trip in
+   * both directions.
+   *
+   * <p>{@code accpServiceName} is the only difference between the callers: ACCP's spec
+   * initialization is a strict no-op on the parameter-set-specific services and a selection on the
+   * generic one, and the two must interoperate identically. BouncyCastle is always looked up under
+   * its generic name, the only one it registers here.
+   */
+  private static void assertBouncyCastleInterop(final String accpServiceName, final String paramSet)
+      throws Exception {
     final NamedParameterSpec paramSpec = new NamedParameterSpec(paramSet);
 
-    final KeyPairGenerator accpKeyGen = KeyPairGenerator.getInstance("ML-KEM", NATIVE_PROVIDER);
+    final KeyPairGenerator accpKeyGen =
+        KeyPairGenerator.getInstance(accpServiceName, NATIVE_PROVIDER);
     accpKeyGen.initialize(paramSpec);
     final KeyPair accpKeyPair = accpKeyGen.generateKeyPair();
     assertEquals(paramSet, accpKeyPair.getPublic().getAlgorithm());
     assertEquals(paramSet, accpKeyPair.getPrivate().getAlgorithm());
 
+    // BouncyCastle imports ACCP's keys. Both of ACCP's private-key encodings are covered: whichever
+    // getEncoded() emits in this build, and the expanded encoding that MlKemUtils.expandPrivateKey
+    // is the only way to obtain in builds whose getEncoded() emits the seed.
+    final KeyFactory bcKf = KeyFactory.getInstance("ML-KEM", TestUtil.BC_PROVIDER);
+    final PublicKey bcImportedPub =
+        bcKf.generatePublic(new X509EncodedKeySpec(accpKeyPair.getPublic().getEncoded()));
+    final PrivateKey bcImportedPriv =
+        bcKf.generatePrivate(new PKCS8EncodedKeySpec(accpKeyPair.getPrivate().getEncoded()));
+    assertArrayEquals(
+        accpKeyPair.getPublic().getEncoded(),
+        bcImportedPub.getEncoded(),
+        paramSet + " BouncyCastle must preserve ACCP's public key encoding");
+    assertArrayEquals(
+        accpKeyPair.getPrivate().getEncoded(),
+        bcImportedPriv.getEncoded(),
+        paramSet + " BouncyCastle must preserve ACCP's private key encoding");
+
+    final byte[] accpExpanded = MlKemUtils.expandPrivateKey(accpKeyPair.getPrivate());
+    assertArrayEquals(
+        accpExpanded,
+        bcKf.generatePrivate(new PKCS8EncodedKeySpec(accpExpanded)).getEncoded(),
+        paramSet + " BouncyCastle must preserve ACCP's expanded private key encoding");
+    assertArrayEquals(
+        ((MLKEMPrivateKey) bcImportedPriv).getPrivateKey(false).getEncoded(),
+        accpExpanded,
+        paramSet + " BouncyCastle and ACCP must agree on the expanded encoding of the same key");
+
+    // ACCP imports BouncyCastle's keys. Ask BC for the expandedKey CHOICE of RFC 9935 Section 6
+    // specifically, so this stays a like-for-like comparison of re-encodings: ACCP rejects the both
+    // CHOICE that BC's getEncoded() emits by default, and an expandedKey-imported ACCP key has no
+    // seed to emit, so it round-trips to the expanded form in every build. The seed CHOICE is
+    // covered by testPrivateKeyChoicesParse.
+    // https://github.com/bcgit/bc-java/blob/b41f23936724284a20f10dff13c76896a846031b/prov/src/main/java/org/bouncycastle/jcajce/interfaces/MLKEMPrivateKey.java#L35
     final KeyPairGenerator bcKeyGen = KeyPairGenerator.getInstance("ML-KEM", TestUtil.BC_PROVIDER);
-    bcKeyGen.initialize(paramSpec);
+    bcKeyGen.initialize(TestUtil.getMlKemParamSpec(paramSet));
     final KeyPair bcKeyPair = bcKeyGen.generateKeyPair();
     assertEquals(paramSet, bcKeyPair.getPublic().getAlgorithm());
 
-    // Each side's generic KeyFactory imports the other side's key pair. ACCP rejects the both
-    // CHOICE that BouncyCastle's getEncoded() emits by default, so ask BC for the expandedKey
-    // CHOICE; testPrivateKeyChoicesParse covers which CHOICEs ACCP accepts.
-    final KeyFactory accpKf = KeyFactory.getInstance("ML-KEM", NATIVE_PROVIDER);
-    final KeyFactory bcKf = KeyFactory.getInstance("ML-KEM", TestUtil.BC_PROVIDER);
-    final PrivateKey bcImportedPriv =
-        bcKf.generatePrivate(new PKCS8EncodedKeySpec(accpKeyPair.getPrivate().getEncoded()));
+    final byte[] bcExpandedPriv =
+        ((MLKEMPrivateKey) bcKeyPair.getPrivate()).getPrivateKey(false).getEncoded();
+    final KeyFactory accpKf = KeyFactory.getInstance(accpServiceName, NATIVE_PROVIDER);
     final PublicKey accpImportedPub =
         accpKf.generatePublic(new X509EncodedKeySpec(bcKeyPair.getPublic().getEncoded()));
     final PrivateKey accpImportedPriv =
-        accpKf.generatePrivate(
-            new PKCS8EncodedKeySpec(
-                ((MLKEMPrivateKey) bcKeyPair.getPrivate()).getPrivateKey(false).getEncoded()));
+        accpKf.generatePrivate(new PKCS8EncodedKeySpec(bcExpandedPriv));
     assertArrayEquals(
         bcKeyPair.getPublic().getEncoded(),
         accpImportedPub.getEncoded(),
-        paramSet + " ACCP must preserve a BouncyCastle SPKI imported through the generic name");
+        paramSet + " ACCP must preserve BouncyCastle's public key encoding");
+    assertArrayEquals(
+        bcExpandedPriv,
+        accpImportedPriv.getEncoded(),
+        paramSet + " ACCP must preserve BouncyCastle's expanded private key encoding");
     assertEquals(paramSet, accpImportedPriv.getAlgorithm());
 
+    // Skip the rest if BouncyCastle does not register the KEM API on this runtime.
     assumeTrue(bcRegistersKemService(), BC_KEM_UNAVAILABLE);
 
-    final KEM accpKem = KEM.getInstance("ML-KEM", NATIVE_PROVIDER);
+    final KEM accpKem = KEM.getInstance(accpServiceName, NATIVE_PROVIDER);
     final KEM bcKem = KEM.getInstance("ML-KEM", TestUtil.BC_PROVIDER);
     // Configure BC to not apply KDF processing so both sides report the raw ML-KEM shared secret.
     final KTSParameterSpec bcKtsSpec =


### PR DESCRIPTION
## Context

Two follow-ups deferred out of #569.

## 1. The generic `ML-KEM` KeyPairGenerator becomes parameter-set-selectable

ACCP registers a parameter-set-agnostic `ML-KEM` service alongside the sized
`ML-KEM-512`/`ML-KEM-768`/`ML-KEM-1024` ones for `KeyPairGenerator`, `KeyFactory` and `KEM`. Two of
those three generic services are already parameter-agnostic: `KEM` takes its parameter set from the
key it is handed, and `KeyFactory` reads it out of the encoding. Only `KeyPairGenerator "ML-KEM"` was
not: it was backed by `MlKemGen768`, so it accepted a `NamedParameterSpec` naming ML-KEM-768 and
rejected ML-KEM-512 and ML-KEM-1024 with `InvalidAlgorithmParameterException`. A caller working
through the generic service names -- a JSSE stack, or provider-agnostic application code -- had to
switch to a sized name for anything other than 768.

It is now backed by a new `MlKemGenGeneric` that overrides `initialize` to select the named parameter
set. This mirrors two existing precedents:

* SunEC's generic `XDH` service accepts either `X25519` or `X448`, while its `X25519`/`X448` services
  stay bound to their own curve.
* BouncyCastle's own generic ML-KEM `KeyPairGenerator` already accepts a `NamedParameterSpec` for all
  three parameter sets, and defaults to ML-KEM-768 when left uninitialized. Verified against
  bcprov-jdk18on 1.85.

The sized generators are unchanged: each still accepts only a spec naming its own parameter set and
rejects any other, so ACCP never silently returns a key of the wrong parameter set. That rejection is
what lets the JCA fail over to another provider when the caller obtained the generator *without*
naming one; a caller that named ACCP explicitly sees the `InvalidAlgorithmParameterException`, since
the JCA has no other provider to try. The uninitialized generic generator still produces ML-KEM-768,
so no existing caller changes behavior.

The parameter set may be named by any spec exposing a public `String getName()`, not only a
`NamedParameterSpec`. BouncyCastle's TLS stack initializes its ML-KEM `KeyPairGenerator` with
`MLKEMParameterSpec`, and BC's own generic generator accepts either shape there, so restricting this
to `NamedParameterSpec` would have left the JSSE interop this change is meant to unblock still broken
for that caller. The name is matched against the supported parameter sets either way, so a foreign
spec cannot select an unsupported set or bypass the sized generators' check.

The case-insensitive name lookup lands on `MlKemParameter` next to `matchesAlgorithmName`, which it
reuses, so every ML-KEM SPI agrees on which parameter set names are accepted. `fromKemName` delegates
to it rather than duplicating the mapping, and the supported-name list in error messages is built
from `values()` instead of hardcoded.

`MlKemGen.parameterSet` is `volatile`: `MlKemGenGeneric` writes it from `initialize()` while
`generateKeyPair()` reads it, so a generator shared between threads could otherwise read a stale
parameter set and produce a key of the wrong one.

### Tests

`MlKemTest` goes from 60 to 72 tests:

* selection through the generic service for each of the three parameter sets;
* the uninitialized ML-KEM-768 default;
* rejection of a name that is not an ML-KEM parameter set (`ML-KEM-4096`, `X25519`);
* the sized generators remaining strict;
* `testKeyPairGeneratorAcceptsForeignNamedSpec`, which drives both the generic and the sized
  generators with BouncyCastle's `MLKEMParameterSpec` and confirms the sized ones still reject a
  foreign spec naming a different parameter set;
* `testGenericServiceNameInteropWithBouncyCastle`, which drives key generation, cross-import through
  both providers' generic `KeyFactory`, and encapsulate/decapsulate in both directions using *only*
  the `"ML-KEM"` service names on both sides, for all three parameter sets. For 512 and 1024 that
  test could not have been written before this change.

That test and `testBouncyCastleInteroperability` differ only in which ACCP service name they use, so
they now share one helper parameterized on it rather than duplicating ~50 lines. The BouncyCastle
KEM-API availability check that `testBouncyCastleInteroperability` carried inline is also a shared
helper now.

## 2. `MlDsaUtils` rejects an unusable key instead of crashing the JVM

`MlDsaUtils.computeMu` and `MlDsaUtils.expandPrivateKey` checked their key argument for null and for
an ML-DSA algorithm name, then passed `key.getEncoded()` straight to JNI. `Key.getEncoded()` is
specified to return null for a key that does not support encoding -- a key held in hardware, say --
and neither check catches that, so the null reached `GetArrayLength(nullptr)` and took the process
down with a `SIGSEGV` rather than throwing. Confirmed for both methods by removing the fix and
re-running the new test: exit 1 with an `hs_err` file.

This is the same defect [justsmth found](https://github.com/corretto/amazon-corretto-crypto-provider/pull/569#discussion_r3863499611)
in `MlKemUtils.expandPrivateKey`, fixed there in #569; this applies the identical guard to the two
ML-DSA entry points and documents the throw.

`Key.getAlgorithm()` is likewise not specified to return a non-null value, so both classes null-check
it instead of dereferencing it -- previously a key returning null there produced a `NullPointerException`
from the `startsWith` call rather than the documented `IllegalArgumentException`. Every
`IllegalArgumentException` these two classes throw now carries a message.

## 3. Hardening in the ML-DSA JNI helpers

Found while reviewing the above.

`MlDsaUtils.expandPrivateKey` short-circuited on the input length:

```c
if (key_der_len > 54) { // If they key is already expanded, return it
    return keyBytes;
}
```

Anything longer than a 54-byte seed key was handed straight back to the caller, so a foreign or
malformed encoding round-tripped as though it were an expanded ML-DSA key -- including a PKCS8 blob
for an entirely different algorithm. The helper now parses and re-encodes every input through
`der2EvpPrivateKey`, matching `MlKemUtils.expandPrivateKey`, which already worked this way.
`der2EvpPrivateKey` rejects what it cannot parse and rejects a key that parses as another algorithm,
so those inputs raise instead of being echoed. The output is therefore always the canonical minimal
`expandedKey` PKCS8, which is documented on the Java method.

That rewrite also removes two problems in the code it replaced:

* `EVP_PKCS82PKEY`'s return value was unchecked and passed to `encodeExpandedMLDSAPrivateKey` by
  `OPENSSL_auto`'s implicit conversion, which calls `abort()` on a null pointer. A PKCS8 blob that
  parsed as a `PKCS8_PRIV_KEY_INFO` but not as an `EVP_PKEY` -- an unsupported algorithm OID -- would
  have taken the process down.
* the `BIO` from `BIO_new_mem_buf` was never freed.

In `computeMuInternal`, `EVP_parse_public_key`'s return value was unchecked; it only failed to crash
because `EVP_PKEY_get_raw_public_key` happens to null-check its argument. It is now checked, and a
well-formed SPKI for another algorithm is rejected rather than having mu computed over a non-ML-DSA
public key. The unused `EVP_PKEY_CTX` in that function is gone.

Finally, `MlDsaGen.initialize(AlgorithmParameterSpec, SecureRandom)` threw
`UnsupportedOperationException`. `KeyPairGenerator.Delegate` expects the checked
`InvalidAlgorithmParameterException` there, so the unchecked throw propagated to the caller instead of
letting the JCA fail over. These generators are bound to their parameter set at construction, so every
spec is still rejected -- just with the exception the JCA can act on.
