### PR TITLE
Validate the requested output algorithm before consuming the agreed secret, plus review follow-ups

### DIFF
--- a/DIFFERENCES.md
+++ b/DIFFERENCES.md
@@ -107,10 +107,10 @@ This results in better performance for Static-Ephemeral key agreement protocols.
 [KeyAgreement.generateSecret(String)](https://docs.oracle.com/javase/8/docs/api/javax/crypto/KeyAgreement.html#generateSecret-java.lang.String-) can be called with an input of "AES" for all Key Agreement algorithms.
 (The default Java implementation does not support "AES" as input with "ECDH" key agreement.)
 If "AES" is passed to this method, ACCP returns the largest possible AES key corresponding to the agreed secret.
-Alternatively, you can request an AES key of a particular size by appending the size (in bits) surrounded by brackets to this string.
-(Ex: "AES[128]" or "AES[256]")
-This returns a key of the requested strength or an `InvalidKeyException` if the agreed secret is not long enough for the requested AES key length.
-(This method of specifying key size is identical to the way [BouncyCastle](https://bouncycastle.org/java.html) specifies key size for `KeyAgreement.generateSecret(String)`.)
+Alternatively, you can request an AES key of a particular size by appending the size (in bytes) surrounded by brackets to this string.
+(Ex: "AES[16]" for AES-128 or "AES[32]" for AES-256)
+This returns a key of the requested strength or an `InvalidKeyException` if the requested size is not a valid AES key size, or if the agreed secret is not long enough for it.
+([BouncyCastle](https://bouncycastle.org/java.html) accepts the same bracketed syntax for `KeyAgreement.generateSecret(String)`, but interprets the value as a number of *bits*, so "AES[256]" is a 256-bit key there and an error here.)
 
 ## EC Key Equality For Truncated Keys on OpenJDK 10
 

--- a/src/com/amazon/corretto/crypto/provider/EvpKeyAgreement.java
+++ b/src/com/amazon/corretto/crypto/provider/EvpKeyAgreement.java
@@ -18,7 +18,7 @@ import javax.crypto.spec.SecretKeySpec;
 class EvpKeyAgreement extends KeyAgreementSpi {
   private static final int[] AES_KEYSIZES_BYTES = new int[] {16, 24, 32};
   private static final Pattern ALGORITHM_WITH_EXPLICIT_KEYSIZE =
-      Pattern.compile("(\\S+?)(?:\\[(\\d+)\\])?");
+      Pattern.compile("(\\S+?)(?:\\[([^\\]]*)\\])?");
 
   private final AmazonCorrettoCryptoProvider provider_;
   private final EvpKeyType keyType_;
@@ -131,29 +131,61 @@ class EvpKeyAgreement extends KeyAgreementSpi {
     // The bracketed size is a number of BYTES, unlike BouncyCastle's identical-looking syntax,
     // which reads it as bits. See DIFFERENCES.md.
     final String keySizeString = matcher.group(2);
-    int keyLength = 0;
-    if (keySizeString != null) {
+    // pendingSecret() rather than engineGenerateSecret(): the latter resets, so sizing the key
+    // against its return value would destroy the secret before the rejections below, which is
+    // exactly the "agreed secret is not long enough" case DIFFERENCES.md documents. Reading it
+    // before the size is validated also keeps an incomplete agreement an IllegalStateException
+    // whatever size was requested, rather than letting a bad size outrank the missing state.
+    final int secretLength = pendingSecret().length;
+    final int keyLength;
+    if (keySizeString == null) {
+      keyLength = largestAesKeySizeAtMost(secretLength);
+      if (keyLength == 0) {
+        throw new InvalidKeyException(
+            "Agreed secret is " + secretLength + " bytes, too short for any AES key");
+      }
+    } else {
+      // Digits only. The bracket group admits anything but a ']' so that a malformed size is an
+      // invalid length rather than falling wholesale into group(1) and being reported as an
+      // algorithm name that does not exist; Integer.parseInt alone would also accept a '+' sign.
+      if (!isAllDigits(keySizeString)) {
+        throw new InvalidKeyException("Invalid key length");
+      }
+      final int requested;
       try {
-        keyLength = Integer.parseInt(keySizeString);
+        requested = Integer.parseInt(keySizeString);
       } catch (final NumberFormatException e) {
         // The pattern admits digit strings too long for an int.
         throw new InvalidKeyException("Invalid key length", e);
       }
-      if (!isAesKeySize(keyLength)) {
+      if (!isAesKeySize(requested)) {
         throw new InvalidKeyException("Invalid key length");
       }
-    }
-    // pendingSecret() rather than engineGenerateSecret(): the latter resets, so sizing the key
-    // against its return value would destroy the secret before the rejection below, which is
-    // exactly the "agreed secret is not long enough" case DIFFERENCES.md documents.
-    final int secretLength = pendingSecret().length;
-    if (keySizeString == null) {
-      keyLength = largestAesKeySizeAtMost(secretLength);
-    }
-    if (keyLength == 0 || keyLength > secretLength) {
-      throw new InvalidKeyException("Invalid key length");
+      if (requested > secretLength) {
+        // Distinct from "Invalid key length": this is the one case DIFFERENCES.md tells callers
+        // they can recover from by asking for a shorter key.
+        throw new InvalidKeyException(
+            "Agreed secret is "
+                + secretLength
+                + " bytes, too short for a "
+                + requested
+                + "-byte AES key");
+      }
+      keyLength = requested;
     }
     return new SecretKeySpec(engineGenerateSecret(), 0, keyLength, "AES");
+  }
+
+  private static boolean isAllDigits(final String value) {
+    if (value.isEmpty()) {
+      return false;
+    }
+    for (int i = 0; i < value.length(); i++) {
+      if (value.charAt(i) < '0' || value.charAt(i) > '9') {
+        return false;
+      }
+    }
+    return true;
   }
 
   private static boolean isAesKeySize(final int lengthBytes) {

--- a/src/com/amazon/corretto/crypto/provider/EvpKeyAgreement.java
+++ b/src/com/amazon/corretto/crypto/provider/EvpKeyAgreement.java
@@ -68,15 +68,23 @@ class EvpKeyAgreement extends KeyAgreementSpi {
     }
   }
 
-  @Override
-  protected byte[] engineGenerateSecret() throws IllegalStateException {
+  // The agreed secret, still owned by this object. The overloads that must inspect it before they
+  // can tell whether they can satisfy the request take it from here and reset() only once the
+  // answer is yes; routing them through engineGenerateSecret() instead would reset() before they
+  // get to reject anything, destroying a secret the caller could still have used.
+  private byte[] pendingSecret() throws IllegalStateException {
     if (privKey == null) {
       throw new IllegalStateException("KeyAgreement has not been initialized");
     }
     if (secret == null) {
       throw new IllegalStateException("KeyAgreement has not been completed");
     }
-    final byte[] result = secret;
+    return secret;
+  }
+
+  @Override
+  protected byte[] engineGenerateSecret() throws IllegalStateException {
+    final byte[] result = pendingSecret();
     reset();
     return result;
   }
@@ -84,10 +92,14 @@ class EvpKeyAgreement extends KeyAgreementSpi {
   @Override
   protected SecretKey engineGenerateSecret(final String algorithm)
       throws IllegalStateException, NoSuchAlgorithmException, InvalidKeyException {
-    // The requested algorithm is resolved before the agreed secret is consumed: the no-arg
-    // engineGenerateSecret() calls reset(), so rejecting a name afterwards would destroy the secret
-    // too, breaking both the reuse documented in DIFFERENCES.md and any caller that tries one
-    // output algorithm name and falls back to another. SunEC validates first for the same reason.
+    // Every rejection below happens before the agreed secret is consumed: the no-arg
+    // engineGenerateSecret() calls reset(), so rejecting a request afterwards would destroy the
+    // secret too, leaving nothing for a caller that tries one output algorithm name (or key size)
+    // and falls back to another. SunEC and SunJCE both validate first for the same reason.
+    //
+    // Consequence of resolving the name first: an unusable name on an agreement that was never
+    // initialized or completed surfaces as NoSuchAlgorithmException rather than the
+    // IllegalStateException a well-formed request gets there. SunEC orders the two the same way.
     if (algorithm == null) {
       throw new NoSuchAlgorithmException("Algorithm must not be null");
     }
@@ -112,9 +124,12 @@ class EvpKeyAgreement extends KeyAgreementSpi {
     if (!matcher.matches()) {
       throw new NoSuchAlgorithmException("Unrecognized algorithm: " + algorithm);
     }
-    if (!"AES".equals(matcher.group(1))) {
+    // equalsIgnoreCase, as JCA algorithm names are case-insensitive and SunJCE's DH accepts "aes".
+    if (!"AES".equalsIgnoreCase(matcher.group(1))) {
       throw new NoSuchAlgorithmException("Unsupported algorithm: " + matcher.group(1));
     }
+    // The bracketed size is a number of BYTES, unlike BouncyCastle's identical-looking syntax,
+    // which reads it as bits. See DIFFERENCES.md.
     final String keySizeString = matcher.group(2);
     int keyLength = 0;
     if (keySizeString != null) {
@@ -128,19 +143,17 @@ class EvpKeyAgreement extends KeyAgreementSpi {
         throw new InvalidKeyException("Invalid key length");
       }
     }
-    final byte[] secret = engineGenerateSecret();
+    // pendingSecret() rather than engineGenerateSecret(): the latter resets, so sizing the key
+    // against its return value would destroy the secret before the rejection below, which is
+    // exactly the "agreed secret is not long enough" case DIFFERENCES.md documents.
+    final int secretLength = pendingSecret().length;
     if (keySizeString == null) {
-      // Largest AES key the agreed secret can supply.
-      for (final int aesLength : AES_KEYSIZES_BYTES) {
-        if (aesLength <= secret.length) {
-          keyLength = aesLength;
-        }
-      }
+      keyLength = largestAesKeySizeAtMost(secretLength);
     }
-    if (keyLength == 0 || keyLength > secret.length) {
+    if (keyLength == 0 || keyLength > secretLength) {
       throw new InvalidKeyException("Invalid key length");
     }
-    return new SecretKeySpec(secret, 0, keyLength, "AES");
+    return new SecretKeySpec(engineGenerateSecret(), 0, keyLength, "AES");
   }
 
   private static boolean isAesKeySize(final int lengthBytes) {
@@ -152,16 +165,41 @@ class EvpKeyAgreement extends KeyAgreementSpi {
     return false;
   }
 
+  // The longest AES key |availableBytes| of agreed secret can supply, or 0 if it cannot supply even
+  // the shortest. Tracks the maximum rather than the last match so it does not quietly depend on
+  // AES_KEYSIZES_BYTES being sorted ascending.
+  private static int largestAesKeySizeAtMost(final int availableBytes) {
+    int largest = 0;
+    for (final int aesLength : AES_KEYSIZES_BYTES) {
+      if (aesLength <= availableBytes && aesLength > largest) {
+        largest = aesLength;
+      }
+    }
+    return largest;
+  }
+
   @Override
   protected int engineGenerateSecret(final byte[] sharedSecret, final int offset)
       throws IllegalStateException, ShortBufferException {
-    final byte[] tmp = engineGenerateSecret();
-    if (sharedSecret.length - offset < tmp.length) {
+    // Same rule as the String overload: the secret is placed first and consumed only afterwards,
+    // so a caller that catches ShortBufferException can retry with a larger buffer. Deriving it
+    // through engineGenerateSecret() would reset() the agreement before the buffer was ever
+    // checked, leaving the retry with an IllegalStateException instead. SunJCE's DH is explicit
+    // about the ordering: "Reset the key agreement after checking for ShortBufferException above,
+    // so user can recover w/o losing internal state." A null buffer is likewise a
+    // ShortBufferException there rather than an NPE.
+    final byte[] agreedSecret = pendingSecret();
+    if (sharedSecret == null) {
+      throw new ShortBufferException("No buffer provided for shared secret");
+    }
+    if (sharedSecret.length - offset < agreedSecret.length) {
       throw new ShortBufferException();
     }
-    System.arraycopy(tmp, 0, sharedSecret, offset, tmp.length);
+    // Copied before the reset so an out-of-range offset, which arraycopy reports as an unchecked
+    // IndexOutOfBoundsException just as the JDK's providers do, does not consume the secret either.
+    System.arraycopy(agreedSecret, 0, sharedSecret, offset, agreedSecret.length);
     reset();
-    return tmp.length;
+    return agreedSecret.length;
   }
 
   @Override

--- a/src/com/amazon/corretto/crypto/provider/EvpKeyAgreement.java
+++ b/src/com/amazon/corretto/crypto/provider/EvpKeyAgreement.java
@@ -84,9 +84,15 @@ class EvpKeyAgreement extends KeyAgreementSpi {
   @Override
   protected SecretKey engineGenerateSecret(final String algorithm)
       throws IllegalStateException, NoSuchAlgorithmException, InvalidKeyException {
-    byte[] secret = engineGenerateSecret();
+    // The requested algorithm is resolved before the agreed secret is consumed: the no-arg
+    // engineGenerateSecret() calls reset(), so rejecting a name afterwards would destroy the secret
+    // too, breaking both the reuse documented in DIFFERENCES.md and any caller that tries one
+    // output algorithm name and falls back to another. SunEC validates first for the same reason.
+    if (algorithm == null) {
+      throw new NoSuchAlgorithmException("Algorithm must not be null");
+    }
     if (algorithm.equalsIgnoreCase("TlsPremasterSecret")) {
-      return new SecretKeySpec(secret, "TlsPremasterSecret");
+      return new SecretKeySpec(engineGenerateSecret(), "TlsPremasterSecret");
     }
     // Both "com/sun/crypto/provider/DHKEM.java" (backing HPKE and the "DHKEM"
     // KEM) and "sun/security/ssl/DHasKEM.java" (the classical half of TLS 1.3
@@ -94,43 +100,56 @@ class EvpKeyAgreement extends KeyAgreementSpi {
     // generateSecret("Generic"), "Generic" being the default output algorithm of
     // the javax.crypto.KEM API. Neither pins a provider when requesting
     // ECDH/XDH, so ACCP wins the service and must accept "Generic" or it breaks
-    // HPKE and TLS handshakes for anyone who installs it.
+    // HPKE and TLS handshakes for anyone who installs it. JTREG test
+    // "sun/security/ssl/HybridKeyExchange/TestHybrid.java" drives that path.
     if (algorithm.equalsIgnoreCase("Generic")) {
-      return new SecretKeySpec(secret, "Generic");
+      return new SecretKeySpec(engineGenerateSecret(), "Generic");
     }
+    // NoSuchAlgorithmException rather than InvalidKeyException for an unavailable output algorithm:
+    // that is what KeyAgreement.generateSecret(String) documents and what SunEC throws, so a caller
+    // that catches it to fall back to generateSecret() + SecretKeySpec still gets its fallback.
     final Matcher matcher = ALGORITHM_WITH_EXPLICIT_KEYSIZE.matcher(algorithm);
-    if (matcher.matches()) {
-      switch (matcher.group(1)) {
-        case "AES":
-          String keySizeString = matcher.group(2);
-          int keyLength = 0;
-          boolean lengthFound = false;
-          if (keySizeString != null) {
-            keyLength = Integer.parseInt(keySizeString);
-            for (final int aesLength : AES_KEYSIZES_BYTES) {
-              if (aesLength == keyLength) {
-                lengthFound = true;
-                break;
-              }
-            }
-          } else {
-            for (final int aesLength : AES_KEYSIZES_BYTES) {
-              if (aesLength <= secret.length) {
-                keyLength = aesLength;
-                lengthFound = true;
-              }
-            }
-          }
-          if (!lengthFound || keyLength > secret.length) {
-            throw new InvalidKeyException("Invalid key length");
-          }
-          return new SecretKeySpec(secret, 0, keyLength, "AES");
-
-        default:
-          throw new InvalidKeyException("Unsupported algorithm: " + matcher.group(1));
+    if (!matcher.matches()) {
+      throw new NoSuchAlgorithmException("Unrecognized algorithm: " + algorithm);
+    }
+    if (!"AES".equals(matcher.group(1))) {
+      throw new NoSuchAlgorithmException("Unsupported algorithm: " + matcher.group(1));
+    }
+    final String keySizeString = matcher.group(2);
+    int keyLength = 0;
+    if (keySizeString != null) {
+      try {
+        keyLength = Integer.parseInt(keySizeString);
+      } catch (final NumberFormatException e) {
+        // The pattern admits digit strings too long for an int.
+        throw new InvalidKeyException("Invalid key length", e);
+      }
+      if (!isAesKeySize(keyLength)) {
+        throw new InvalidKeyException("Invalid key length");
       }
     }
-    throw new InvalidKeyException("Unrecognized algorithm: " + algorithm);
+    final byte[] secret = engineGenerateSecret();
+    if (keySizeString == null) {
+      // Largest AES key the agreed secret can supply.
+      for (final int aesLength : AES_KEYSIZES_BYTES) {
+        if (aesLength <= secret.length) {
+          keyLength = aesLength;
+        }
+      }
+    }
+    if (keyLength == 0 || keyLength > secret.length) {
+      throw new InvalidKeyException("Invalid key length");
+    }
+    return new SecretKeySpec(secret, 0, keyLength, "AES");
+  }
+
+  private static boolean isAesKeySize(final int lengthBytes) {
+    for (final int aesLength : AES_KEYSIZES_BYTES) {
+      if (aesLength == lengthBytes) {
+        return true;
+      }
+    }
+    return false;
   }
 
   @Override

--- a/src/com/amazon/corretto/crypto/provider/MlKemGen.java
+++ b/src/com/amazon/corretto/crypto/provider/MlKemGen.java
@@ -52,8 +52,10 @@ class MlKemGen extends KeyPairGeneratorSpi {
     this.parameterSet = parameterSet;
   }
 
-  // Sole writer of |parameterSet| after construction. Package-private rather than private because a
-  // private member of this class is not inherited by the nested MlKemGenGeneric subclass.
+  // Sole writer of |parameterSet| after construction, so the volatile field can stay private. A
+  // private member is accessible anywhere in this file but is not inherited, so the nested
+  // MlKemGenGeneric subclass could only reach the field as |super.parameterSet|, not
+  // |this.parameterSet|.
   final void setParameterSet(final MlKemParameter selected) {
     this.parameterSet = selected;
   }
@@ -66,6 +68,8 @@ class MlKemGen extends KeyPairGeneratorSpi {
   /**
    * Accepts the standard {@code NamedParameterSpec} initialization that JSSE providers (e.g.
    * BouncyCastle's TLS 1.3 stack) and application code perform before {@code generateKeyPair()}.
+   * Another provider's spec is accepted too when it names its parameter set through a public {@code
+   * String getName()}, which is how BouncyCastle's {@code MLKEMParameterSpec} is honored.
    *
    * <p>This parameter-set-specific implementation is bound to its own parameter set at
    * construction, so a spec naming that same parameter set is a no-op and any other spec is

--- a/tst/com/amazon/corretto/crypto/provider/test/EvpKeyAgreementSpecificTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/EvpKeyAgreementSpecificTest.java
@@ -122,6 +122,26 @@ public class EvpKeyAgreementSpecificTest {
     assertThrows(InvalidKeyException.class, () -> accpAgreement.init(x448KeyPair.getPrivate()));
   }
 
+  // An AES size that is valid in the abstract but larger than the agreed secret must be rejected
+  // before the secret is consumed, so a caller can fall back to a shorter key. Reaching that case
+  // needs an agreement shorter than 32 bytes, which every parameter set in EvpKeyAgreementTest
+  // exceeds; P-224 agrees on 28.
+  @Test
+  public void oversizedAesKeyLeavesSecretIntact() throws Exception {
+    final KeyPairGenerator gen = KeyPairGenerator.getInstance("EC", NATIVE_PROVIDER);
+    gen.initialize(new ECGenParameterSpec("secp224r1"));
+    final KeyPair alice = gen.generateKeyPair();
+    final KeyPair bob = gen.generateKeyPair();
+
+    final KeyAgreement agreement = KeyAgreement.getInstance("ECDH", NATIVE_PROVIDER);
+    agreement.init(alice.getPrivate());
+    agreement.doPhase(bob.getPublic(), true);
+
+    assertThrows(InvalidKeyException.class, () -> agreement.generateSecret("AES[32]"));
+    // Still usable: 28 bytes of secret supplies AES-192 but not AES-256.
+    assertEquals(24, agreement.generateSecret("AES").getEncoded().length);
+  }
+
   @Test
   public void evilEcKeys() {
     final Key privKey = EC_KEYPAIR.getPrivate();

--- a/tst/com/amazon/corretto/crypto/provider/test/EvpKeyAgreementSpecificTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/EvpKeyAgreementSpecificTest.java
@@ -19,6 +19,7 @@ import java.security.SecureRandom;
 import java.security.Security;
 import java.security.interfaces.ECPublicKey;
 import java.security.spec.ECGenParameterSpec;
+import java.util.Arrays;
 import javax.crypto.KeyAgreement;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -137,9 +138,16 @@ public class EvpKeyAgreementSpecificTest {
     agreement.init(alice.getPrivate());
     agreement.doPhase(bob.getPublic(), true);
 
+    // The peer side of the same agreement, so the expected bytes are known independently.
+    final KeyAgreement peer = KeyAgreement.getInstance("ECDH", NATIVE_PROVIDER);
+    peer.init(bob.getPrivate());
+    peer.doPhase(alice.getPublic(), true);
+    final byte[] agreedSecret = peer.generateSecret();
+
     assertThrows(InvalidKeyException.class, () -> agreement.generateSecret("AES[32]"));
-    // Still usable: 28 bytes of secret supplies AES-192 but not AES-256.
-    assertEquals(24, agreement.generateSecret("AES").getEncoded().length);
+    // Still usable, and still the same agreement: 28 bytes supplies AES-192 but not AES-256.
+    assertArrayEquals(
+        Arrays.copyOf(agreedSecret, 24), agreement.generateSecret("AES").getEncoded());
   }
 
   @Test

--- a/tst/com/amazon/corretto/crypto/provider/test/EvpKeyAgreementTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/EvpKeyAgreementTest.java
@@ -315,6 +315,12 @@ public class EvpKeyAgreementTest {
     assertEquals("AES", aesKey.getAlgorithm());
     assertEquals("RAW", aesKey.getFormat());
     assertArrayEquals(Arrays.copyOf(rawSecret, expectedKeyLength), aesKey.getEncoded());
+
+    // JCA algorithm names are case-insensitive, and SunJCE's DH accepts "aes".
+    params.nativeAgreement.init(params.pairs[0].getPrivate());
+    assertNull(params.nativeAgreement.doPhase(params.pairs[1].getPublic(), true));
+    assertArrayEquals(
+        aesKey.getEncoded(), params.nativeAgreement.generateSecret("aes").getEncoded());
   }
 
   @ParameterizedTest

--- a/tst/com/amazon/corretto/crypto/provider/test/EvpKeyAgreementTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/EvpKeyAgreementTest.java
@@ -17,6 +17,7 @@ import java.security.InvalidKeyException;
 import java.security.KeyFactory;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
 import java.security.Provider;
 import java.security.PublicKey;
@@ -344,7 +345,7 @@ public class EvpKeyAgreementTest {
     params.nativeAgreement.init(params.pairs[0].getPrivate());
     assertNull(params.nativeAgreement.doPhase(params.pairs[1].getPublic(), true));
     assertThrows(
-        InvalidKeyException.class, () -> params.nativeAgreement.generateSecret("FAKE_ALG"));
+        NoSuchAlgorithmException.class, () -> params.nativeAgreement.generateSecret("FAKE_ALG"));
   }
 
   @ParameterizedTest
@@ -353,7 +354,7 @@ public class EvpKeyAgreementTest {
     params.nativeAgreement.init(params.pairs[0].getPrivate());
     assertNull(params.nativeAgreement.doPhase(params.pairs[1].getPublic(), true));
     assertThrows(
-        InvalidKeyException.class, () -> params.nativeAgreement.generateSecret("FAKE_ALG[8]"));
+        NoSuchAlgorithmException.class, () -> params.nativeAgreement.generateSecret("FAKE_ALG[8]"));
   }
 
   @ParameterizedTest
@@ -362,7 +363,29 @@ public class EvpKeyAgreementTest {
     params.nativeAgreement.init(params.pairs[0].getPrivate());
     assertNull(params.nativeAgreement.doPhase(params.pairs[1].getPublic(), true));
     assertThrows(
-        InvalidKeyException.class, () -> params.nativeAgreement.generateSecret(" #$*(& DO  3VR89"));
+        NoSuchAlgorithmException.class,
+        () -> params.nativeAgreement.generateSecret(" #$*(& DO  3VR89"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("params")
+  public void algorithmValidatedBeforeSecretConsumed(TestParams params)
+      throws GeneralSecurityException {
+    final byte[] rawSecret = params.rawSecrets[0][1];
+    params.nativeAgreement.init(params.pairs[0].getPrivate());
+    assertNull(params.nativeAgreement.doPhase(params.pairs[1].getPublic(), true));
+
+    assertThrows(NoSuchAlgorithmException.class, () -> params.nativeAgreement.generateSecret(null));
+    assertThrows(
+        NoSuchAlgorithmException.class, () -> params.nativeAgreement.generateSecret("Generic[32]"));
+    assertThrows(InvalidKeyException.class, () -> params.nativeAgreement.generateSecret("AES[20]"));
+    // Digits that overflow an int must not escape as an unchecked NumberFormatException.
+    assertThrows(
+        InvalidKeyException.class,
+        () -> params.nativeAgreement.generateSecret("AES[99999999999999999999]"));
+
+    // None of the above consumed the agreed secret, so the object is still usable.
+    assertArrayEquals(rawSecret, params.nativeAgreement.generateSecret("Generic").getEncoded());
   }
 
   @ParameterizedTest

--- a/tst/com/amazon/corretto/crypto/provider/test/EvpKeyAgreementTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/EvpKeyAgreementTest.java
@@ -406,12 +406,20 @@ public class EvpKeyAgreementTest {
   @ParameterizedTest
   @MethodSource("params")
   public void secretInShortArray(TestParams params) throws GeneralSecurityException {
+    final byte[] rawSecret = params.rawSecrets[0][1];
     params.nativeAgreement.init(params.pairs[0].getPrivate());
     assertNull(params.nativeAgreement.doPhase(params.pairs[1].getPublic(), true));
-    final byte[] largeArray = new byte[params.rawSecrets[0][1].length + 3];
+    final byte[] largeArray = new byte[rawSecret.length + 3];
 
     assertThrows(
         ShortBufferException.class, () -> params.nativeAgreement.generateSecret(largeArray, 5));
+    // A missing buffer is a ShortBufferException rather than a NullPointerException, matching
+    // SunJCE's DH.
+    assertThrows(ShortBufferException.class, () -> params.nativeAgreement.generateSecret(null, 0));
+
+    // Neither rejection consumed the agreed secret, so the caller can retry with enough room.
+    assertEquals(rawSecret.length, params.nativeAgreement.generateSecret(largeArray, 0));
+    assertArrayEquals(rawSecret, Arrays.copyOf(largeArray, rawSecret.length));
   }
 
   @ParameterizedTest

--- a/tst/com/amazon/corretto/crypto/provider/test/MlDsaUtilsTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/MlDsaUtilsTest.java
@@ -203,7 +203,9 @@ public class MlDsaUtilsTest {
         new TestKey("ML-DSA-44", generateEcKeyPair().getPrivate().getEncoded());
 
     TestUtil.assertThrows(
-        RuntimeCryptoException.class, () -> MlDsaUtils.expandPrivateKey(ecKeyClaimingMlDsa));
+        RuntimeCryptoException.class,
+        "Unable to convert PKCS8_PRIV_KEY_INFO to EVP_PKEY",
+        () -> MlDsaUtils.expandPrivateKey(ecKeyClaimingMlDsa));
   }
 
   private static KeyPair generateEcKeyPair() throws GeneralSecurityException {

--- a/tst/com/amazon/corretto/crypto/provider/test/MlDsaUtilsTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/MlDsaUtilsTest.java
@@ -4,6 +4,7 @@ package com.amazon.corretto.crypto.provider.test;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.amazon.corretto.crypto.provider.AmazonCorrettoCryptoProvider;
@@ -202,10 +203,14 @@ public class MlDsaUtilsTest {
     final TestKey ecKeyClaimingMlDsa =
         new TestKey("ML-DSA-44", generateEcKeyPair().getPrivate().getEncoded());
 
-    TestUtil.assertThrows(
-        RuntimeCryptoException.class,
-        "Unable to convert PKCS8_PRIV_KEY_INFO to EVP_PKEY",
-        () -> MlDsaUtils.expandPrivateKey(ecKeyClaimingMlDsa));
+    final RuntimeCryptoException e =
+        assertThrows(
+            RuntimeCryptoException.class, () -> MlDsaUtils.expandPrivateKey(ecKeyClaimingMlDsa));
+    // throw_openssl reports the error AWS-LC queued and uses the string at the throw site only as a
+    // default for an empty queue, so what is pinned here is the reason d2i_PrivateKey records for a
+    // type mismatch, not "Unable to convert PKCS8_PRIV_KEY_INFO to EVP_PKEY". The mnemonic alone:
+    // the packed error code preceding it is an AWS-LC internal.
+    assertTrue(e.getMessage().contains("DIFFERENT_KEY_TYPES"), e.getMessage());
   }
 
   private static KeyPair generateEcKeyPair() throws GeneralSecurityException {

--- a/tst/com/amazon/corretto/crypto/provider/test/MlDsaUtilsTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/MlDsaUtilsTest.java
@@ -171,4 +171,24 @@ public class MlDsaUtilsTest {
     TestUtil.assertThrows(
         IllegalArgumentException.class, () -> MlDsaUtils.expandPrivateKey(wrongAlgorithm));
   }
+
+  // A key claiming ML-DSA whose encoding is a well-formed SPKI for another algorithm passes every
+  // Java-side check, so only the parsed key's type tells the two apart. Unlike the cases above this
+  // one does reach JNI, hence the mlDsaDisabled() gate.
+  @Test
+  @DisabledIf("mlDsaDisabled")
+  public void testNonMlDsaSpkiIsRejected() throws Exception {
+    final KeyPairGenerator ecGen = KeyPairGenerator.getInstance("EC");
+    ecGen.initialize(256);
+    final TestKey ecKeyClaimingMlDsa =
+        new TestKey("ML-DSA-44", ecGen.generateKeyPair().getPublic().getEncoded());
+
+    final byte[] message = new byte[256];
+    Arrays.fill(message, (byte) 0x41);
+
+    TestUtil.assertThrows(
+        IllegalArgumentException.class,
+        "Not an ML-DSA public key",
+        () -> MlDsaUtils.computeMu(ecKeyClaimingMlDsa, message));
+  }
 }

--- a/tst/com/amazon/corretto/crypto/provider/test/MlDsaUtilsTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/MlDsaUtilsTest.java
@@ -7,7 +7,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.amazon.corretto.crypto.provider.AmazonCorrettoCryptoProvider;
+import com.amazon.corretto.crypto.provider.RuntimeCryptoException;
 import com.amazon.corretto.crypto.utils.MlDsaUtils;
+import java.security.GeneralSecurityException;
 import java.security.KeyFactory;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
@@ -178,10 +180,8 @@ public class MlDsaUtilsTest {
   @Test
   @DisabledIf("mlDsaDisabled")
   public void testNonMlDsaSpkiIsRejected() throws Exception {
-    final KeyPairGenerator ecGen = KeyPairGenerator.getInstance("EC");
-    ecGen.initialize(256);
     final TestKey ecKeyClaimingMlDsa =
-        new TestKey("ML-DSA-44", ecGen.generateKeyPair().getPublic().getEncoded());
+        new TestKey("ML-DSA-44", generateEcKeyPair().getPublic().getEncoded());
 
     final byte[] message = new byte[256];
     Arrays.fill(message, (byte) 0x41);
@@ -190,5 +190,25 @@ public class MlDsaUtilsTest {
         IllegalArgumentException.class,
         "Not an ML-DSA public key",
         () -> MlDsaUtils.computeMu(ecKeyClaimingMlDsa, message));
+  }
+
+  // The private-key half of the same discrimination: a well-formed PKCS8 for another algorithm gets
+  // past every Java-side check and is refused by der2EvpPrivateKey's EVP_PKEY_PQDSA check. The
+  // exception type differs from computeMu's above, as the two javadocs document: this path reports
+  // an unusable encoding as RuntimeCryptoException.
+  @Test
+  @DisabledIf("mlDsaDisabled")
+  public void testNonMlDsaPkcs8IsRejected() throws Exception {
+    final TestKey ecKeyClaimingMlDsa =
+        new TestKey("ML-DSA-44", generateEcKeyPair().getPrivate().getEncoded());
+
+    TestUtil.assertThrows(
+        RuntimeCryptoException.class, () -> MlDsaUtils.expandPrivateKey(ecKeyClaimingMlDsa));
+  }
+
+  private static KeyPair generateEcKeyPair() throws GeneralSecurityException {
+    final KeyPairGenerator ecGen = KeyPairGenerator.getInstance("EC");
+    ecGen.initialize(256);
+    return ecGen.generateKeyPair();
   }
 }


### PR DESCRIPTION
Follow-ups to review comments on #574 and #575, both now merged, plus the fixes a review of this branch turned up. No new functionality.

## Changes

- `generateSecret(String)` resolved the requested algorithm only after `engineGenerateSecret()` had `reset()` the object, so every rejection destroyed the agreed secret and a caller's fallback to another name got `IllegalStateException` ([justsmth](https://github.com/corretto/amazon-corretto-crypto-provider/pull/574#discussion_r3874003310), [detail](https://github.com/corretto/amazon-corretto-crypto-provider/pull/574#issuecomment-5441393772)).
- Both `generateSecret` overloads now take the secret from a new private `pendingSecret()` and `reset()` only once the request is known satisfiable, the ordering SunJCE's DH uses and comments on.
- An unsupported output algorithm name is now `NoSuchAlgorithmException`, which `KeyAgreement.generateSecret(String)` documents and this method already declared but never threw ([justsmth](https://github.com/corretto/amazon-corretto-crypto-provider/pull/574#discussion_r3874116221)).
- A null algorithm name is `NoSuchAlgorithmException("Algorithm must not be null")` as SunEC does, rather than an NPE out of `equalsIgnoreCase` with the secret already gone.
- The AES key size is checked against `pendingSecret().length`, so `"AES[32]"` on a 28-byte agreement (P-224) leaves the object usable for the shorter-key retry `DIFFERENCES.md` promises.
- The secret is read before any size validation, so a bad size on an incomplete agreement reports `IllegalStateException` instead of letting the size outrank the state check.
- `generateSecret(byte[], int)` validated the buffer after resetting, so the `ShortBufferException` retry SunJCE deliberately preserves got `IllegalStateException`; it also NPE'd on a null buffer, now `ShortBufferException("No buffer provided for shared secret")` as SunJCE's DH reports it, and called `reset()` twice.
- The bracket group admits anything but a `]`, so `"AES[]"` and `"AES[+16]"` are invalid key lengths rather than `NoSuchAlgorithmException` naming an algorithm that does not exist, and an `int`-overflowing size is an `InvalidKeyException` rather than an unchecked `NumberFormatException`.
- The one recoverable rejection, a secret too short for the size asked for, carries its own message instead of sharing `"Invalid key length"` with two unrecoverable causes.
- `"AES"` is matched case-insensitively, as JCA names are and SunJCE's DH is.
- `DIFFERENCES.md` called the bracketed size bits; it is bytes and has been since the feature was added, and BouncyCastle's identical-looking syntax really is bits, so both are documented as divergences rather than changed.
- Cited the jtreg test that surfaced the `Generic` gap, `sun/security/ssl/HybridKeyExchange/TestHybrid.java` ([mine](https://github.com/corretto/amazon-corretto-crypto-provider/pull/574#discussion_r3872921311)); the `EvpKeyAgreementSpecificTest` case requested there is not worth adding, since the hybrid group name never reaches a provider and `params()` already covers the classical half of both standardized hybrids.
- `MlKemGen.setParameterSet`'s comment now gives the real reason the setter exists, keeping one writer of the volatile field, since the access it claimed to work around partly compiles ([justsmth](https://github.com/corretto/amazon-corretto-crypto-provider/pull/575#discussion_r3874469850)).
- `MlKemGen.initialize`'s javadoc now mentions that a foreign spec naming its parameter set through a public `String getName()` is accepted, which is how BouncyCastle's `MLKEMParameterSpec` is honored ([justsmth](https://github.com/corretto/amazon-corretto-crypto-provider/pull/575#discussion_r3874478792)).
- Added `testNonMlDsaSpkiIsRejected` and `testNonMlDsaPkcs8IsRejected`, the first cases to reach the native type checks; every case in `testUnusableKeysAreRejected` is refused in Java before JNI ([justsmth](https://github.com/corretto/amazon-corretto-crypto-provider/pull/575#discussion_r3874536568)).

One consequence of resolving the name first is worth stating: on an agreement that was never initialized or completed, an unusable output algorithm name still surfaces as `NoSuchAlgorithmException` rather than `IllegalStateException`. SunEC orders those two the same way, and every other request, including one with a bad key size, now gets `IllegalStateException` there.

## Compatibility

- The `NoSuchAlgorithmException` switch is an observable behavior change for anyone catching `InvalidKeyException` from `generateSecret(String)` on an unsupported name. It moves ACCP onto the JCA-specified exception, so it is a convergence rather than a new divergence.
- The ordering fixes only widen what a caller can do after a rejected request: every request that used to succeed still succeeds with the same output, and the exception types for rejected requests are unchanged apart from the null-buffer case, which was an NPE.
- `DIFFERENCES.md` is corrected rather than extended: the exception behavior it documents is unchanged, but its description of the bracketed key size (bits, and matching BouncyCastle) never matched the implementation.
