### PR TITLE
Bump AWS-LC to v5.8.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ version = '2.6.0'
 // private-key encoding on the AWS-LC version linked. A stale value there does not fail the build; it
 // silently downgrades those assertions to the tolerant branch. Both go away once the two pins name
 // AWS-LC versions that retain the ML-KEM keygen seed and implement priv_decode for it.
-ext.awsLcMainTag = 'v1.72.0'
+ext.awsLcMainTag = 'v5.8.0'
 ext.awsLcFipsTag = 'AWS-LC-FIPS-3.1.0'
 ext.isExperimentalFips = Boolean.getBoolean('EXPERIMENTAL_FIPS')
 ext.isFips = ext.isExperimentalFips || Boolean.getBoolean('FIPS')

--- a/tst/com/amazon/corretto/crypto/provider/test/TestUtil.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/TestUtil.java
@@ -116,7 +116,7 @@ public class TestUtil {
   //
   // CMake prefixes the configured id with "AWS-LC " on its way into version.properties, so match
   // these as substrings rather than anchoring either end.
-  private static final String AWSLC_MAIN_PIN = "v1.72.0";
+  private static final String AWSLC_MAIN_PIN = "v5.8.0";
   private static final String AWSLC_FIPS_RELEASE_BRANCH = "AWS-LC-FIPS-3.";
 
   private static String awsLcVersionStr() {


### PR DESCRIPTION
Latest AWS-LC mainline release. Non-FIPS and experimental FIPS both track `awsLcMainTag`, so both pick this up; `AWSLC_MAIN_PIN` moves in lockstep per the comment on the pins.

Requires CI images with Go >= 1.20 (`cmake/go.cmake` gate); internal image bump is in flight.

Validated locally on JDK17: non-FIPS and `-DEXPERIMENTAL_FIPS` both green.