### PR TITLE
Add a macOS JDK 25 CI job

### DIFF
--- a/.github/workflows/macos_ci_jobs.yml
+++ b/.github/workflows/macos_ci_jobs.yml
@@ -322,10 +322,10 @@ jobs:
       run: |
         ./tests/ci/run_accp_basic_tests.sh --lcov-ignore inconsistent --target-jdk-version 21
         ./tests/ci/run_accp_test_integration.sh
-  # JDK 25 Arm64 job. Corretto 25 is the runtime under test; the build runs on
-  # Corretto 21 because this repo's Gradle wrapper (8.11.1) cannot execute on
-  # JDK 25 -- that needs Gradle 9.1+. TARGET_JDK_VERSION therefore stays at 21,
-  # the newest bytecode level javac 21 can emit.
+  # JDK 25 Arm64 job. Corretto 25 is the runtime under test, but the build runs
+  # on Corretto 21 and TARGET_JDK_VERSION stays at 21, so this covers JDK 21
+  # bytecode executing on the 25 runtime. The companion JDK25ARM-TARGET-JDK25
+  # job below covers building and targeting 25 natively.
   macOS25ArmTarget21:
     name: JDK25ARM-TARGET-JDK21
     runs-on: macos-latest-xlarge
@@ -367,4 +367,35 @@ jobs:
         TEST_JAVA_HOME: ${{ env.JAVA25_HOME }}
       run: |
         ./tests/ci/run_accp_basic_tests.sh --lcov-ignore inconsistent --target-jdk-version 21
+        ./tests/ci/run_accp_test_integration.sh
+  macOS25ArmTarget25:
+    name: JDK25ARM-TARGET-JDK25
+    runs-on: macos-latest-xlarge
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+    - name: Install lcov dependencies from brew
+      run: |
+        env HOMEBREW_NO_AUTO_UPDATE=1 brew install lcov golang
+    - name: Setup pip
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.12'
+        cache: 'pip'
+    - name: Install gcovr
+      run: |
+        pip install gcovr
+    # Set up Corretto 25.
+    - name: Set up corretto 25
+      uses: actions/setup-java@v3
+      with:
+        java-version: '25'
+        distribution: 'corretto'
+    # Test on Corretto 25 build targeting JDK 25 .
+    - name: Build and run tests for ${{ env.PACKAGE_NAME }} in corretto 25 targeting JDK 25 to include the jdk17plus folder
+      env:
+        TEST_JAVA_HOME: ${{ env.JAVA_HOME }}
+      run: |
+        ./tests/ci/run_accp_basic_tests.sh --lcov-ignore inconsistent --target-jdk-version 25
         ./tests/ci/run_accp_test_integration.sh

--- a/.github/workflows/macos_ci_jobs.yml
+++ b/.github/workflows/macos_ci_jobs.yml
@@ -260,6 +260,7 @@ jobs:
       run: |
         ./tests/ci/run_accp_basic_tests.sh --lcov-ignore inconsistent
         ./tests/ci/run_accp_test_integration.sh
+  # JDK 17 Arm64 job targeting JDK 17.
   macOS17ArmTarget17:
     name: JDK17ARM-TARGET-JDK17
     runs-on: macos-latest-xlarge
@@ -291,6 +292,7 @@ jobs:
       run: |
         ./tests/ci/run_accp_basic_tests.sh --lcov-ignore inconsistent --target-jdk-version 17
         ./tests/ci/run_accp_test_integration.sh
+  # JDK 21 Arm64 job targeting JDK 21.
   macOS21ArmTarget21:
     name: JDK21ARM-TARGET-JDK21
     runs-on: macos-latest-xlarge
@@ -322,10 +324,7 @@ jobs:
       run: |
         ./tests/ci/run_accp_basic_tests.sh --lcov-ignore inconsistent --target-jdk-version 21
         ./tests/ci/run_accp_test_integration.sh
-  # JDK 25 Arm64 job. Corretto 25 is the runtime under test, but the build runs
-  # on Corretto 21 and TARGET_JDK_VERSION stays at 21, so this covers JDK 21
-  # bytecode executing on the 25 runtime. The companion JDK25ARM-TARGET-JDK25
-  # job below covers building and targeting 25 natively.
+  # JDK 25 Arm64 job targeting JDK 21.
   macOS25ArmTarget21:
     name: JDK25ARM-TARGET-JDK21
     runs-on: macos-latest-xlarge
@@ -345,8 +344,8 @@ jobs:
       run: |
         pip install gcovr
 
-    # Set up Corretto 25 (the runtime we test against), saving its path, then
-    # Corretto 21 as the build JDK. JAVA_HOME ends up as Corretto 21.
+    # Set up Corretto 25 (the runtime we test against), then Corretto 21 as the
+    # build JDK, so JAVA_HOME ends up as Corretto 21.
     - name: Set up corretto 25
       uses: actions/setup-java@v3
       with:
@@ -368,6 +367,7 @@ jobs:
       run: |
         ./tests/ci/run_accp_basic_tests.sh --lcov-ignore inconsistent --target-jdk-version 21
         ./tests/ci/run_accp_test_integration.sh
+  # JDK 25 Arm64 job targeting JDK 25.
   macOS25ArmTarget25:
     name: JDK25ARM-TARGET-JDK25
     runs-on: macos-latest-xlarge

--- a/bin/run-benchmarks.sh
+++ b/bin/run-benchmarks.sh
@@ -20,6 +20,8 @@ while getopts "a:p:h" opt; do
     esac
 done
 
+# Corretto 17, not 11: the Gradle wrapper needs a JVM 17 or newer, and the build
+# needs javax.crypto.KEM to compile the ML-KEM overlay. See Dockerfile.dev.
 _install_dependencies() {
     if [[ $CURRENT_PLATFORM == "Linux" ]]; then
         sudo yum update -y
@@ -27,7 +29,7 @@ _install_dependencies() {
             git \
             cmake3 \
             gradle \
-            java-11-amazon-corretto \
+            java-17-amazon-corretto \
             clang
     elif [[ $CURRENT_PLATFORM == "Darwin" ]]; then
         if ! command -v brew &>/dev/null; then
@@ -41,8 +43,7 @@ _install_dependencies() {
             git \
             cmake \
             gradle
-        brew install --cask corretto11
-                local java_version='11'
+        local java_version='17'
         brew install --cask "corretto${java_version}"
         export JAVA_HOME="/Library/Java/JavaVirtualMachines/amazon-corretto-${java_version}.jdk/Contents/Home/"
     fi

--- a/bin/run-benchmarks.sh
+++ b/bin/run-benchmarks.sh
@@ -20,8 +20,7 @@ while getopts "a:p:h" opt; do
     esac
 done
 
-# Corretto 17, not 11: the Gradle wrapper needs a JVM 17 or newer, and the build
-# needs javax.crypto.KEM to compile the ML-KEM overlay. See Dockerfile.dev.
+# Gradle's wrapper needs a JVM 17 or newer; the ML-KEM overlay needs javax.crypto.KEM.
 _install_dependencies() {
     if [[ $CURRENT_PLATFORM == "Linux" ]]; then
         sudo yum update -y

--- a/build.gradle
+++ b/build.gradle
@@ -94,7 +94,13 @@ spotless {
   java {
     target 'src/**/*.java', 'tst/**/*.java'
     licenseHeaderFile 'build-tools/license-headers/LicenseHeader.java'
-    googleJavaFormat().reflowLongStrings()
+    // Pin google-java-format instead of taking spotless' default (1.24.0), which
+    // calls Log$DeferredDiagnosticHandler.getDiagnostics(); that signature changed
+    // in JDK 25, so the default throws NoSuchMethodError once the build JDK is 25.
+    // 1.28.0 is the newest release that still runs on a JDK 17 build JDK -- 1.29.0
+    // needs JCTree$JCAnyPattern, which does not exist before JDK 21 -- and it
+    // formats this codebase identically to 1.24.0.
+    googleJavaFormat('1.28.0').reflowLongStrings()
   }
 
   // clang-format is difficult to configure across all of our platforms so we

--- a/build.gradle
+++ b/build.gradle
@@ -191,7 +191,10 @@ repositories {
 
 dependencies {
     // Separate so we can extract the jar for the agent specifically
-    jacocoAgent 'org.jacoco:org.jacoco.agent:0.8.13:runtime'
+    // 0.8.13 only supports Java 25 class files experimentally; 0.8.14 made 25
+    // official and 0.8.15 does the same for 26. The agent, core and report jars
+    // are still Java 5 bytecode, so this stays usable on the JDK 8 test runtime.
+    jacocoAgent 'org.jacoco:org.jacoco.agent:0.8.15:runtime'
 
     // Separate so we can extract the jar for the runner specifically
     testRunner 'org.junit.platform:junit-platform-console-standalone:1.10.3'
@@ -209,8 +212,8 @@ dependencies {
     testImplementation 'org.bouncycastle:bctls-jdk18on:1.85'
     testImplementation 'commons-codec:commons-codec:1.18.0'
     testImplementation 'org.hamcrest:hamcrest:3.0'
-    testImplementation 'org.jacoco:org.jacoco.core:0.8.13'
-    testImplementation 'org.jacoco:org.jacoco.report:0.8.13'
+    testImplementation 'org.jacoco:org.jacoco.core:0.8.15'
+    testImplementation 'org.jacoco:org.jacoco.report:0.8.15'
 }
 
 defaultTasks 'release'

--- a/build.gradle
+++ b/build.gradle
@@ -94,12 +94,8 @@ spotless {
   java {
     target 'src/**/*.java', 'tst/**/*.java'
     licenseHeaderFile 'build-tools/license-headers/LicenseHeader.java'
-    // Pin google-java-format instead of taking spotless' default (1.24.0), which
-    // calls Log$DeferredDiagnosticHandler.getDiagnostics(); that signature changed
-    // in JDK 25, so the default throws NoSuchMethodError once the build JDK is 25.
-    // 1.28.0 is the newest release that still runs on a JDK 17 build JDK -- 1.29.0
-    // needs JCTree$JCAnyPattern, which does not exist before JDK 21 -- and it
-    // formats this codebase identically to 1.24.0.
+    // Both bounds bind: 1.29.0 needs JDK 21+ to run, and spotless' default 1.24.0
+    // throws NoSuchMethodError on a JDK 25 build JDK.
     googleJavaFormat('1.28.0').reflowLongStrings()
   }
 
@@ -197,9 +193,6 @@ repositories {
 
 dependencies {
     // Separate so we can extract the jar for the agent specifically
-    // 0.8.13 only supports Java 25 class files experimentally; 0.8.14 made 25
-    // official and 0.8.15 does the same for 26. The agent, core and report jars
-    // are still Java 5 bytecode, so this stays usable on the JDK 8 test runtime.
     jacocoAgent 'org.jacoco:org.jacoco.agent:0.8.15:runtime'
 
     // Separate so we can extract the jar for the runner specifically


### PR DESCRIPTION
## Description

- Adds a macOS Arm64 CI job that builds, targets and tests on Corretto 25, so the `jdk17plus` ML-KEM overlay runs on the newest LTS runtime.
- Gives every macOS Arm64 target-variant job a one-line header comment, so the four jobs read as a coverage matrix (17->17, 21->21, 25->21, 25->25) instead of near-duplicates.
- Bumps JaCoCo to 0.8.15: `release` depends on `coverage`, so the agent instruments the class-file 69 output of a JDK 25 target build, which 0.8.13 supports only experimentally.
- Pins google-java-format to 1.28.0. Spotless' default 1.24.0 throws `NoSuchMethodError` on a JDK 25 build JDK, and 1.29.0 will not run on JDK 17.
- Moves the benchmark script off Corretto 11, which can no longer run the Gradle 9 wrapper.

## Testing / verification

- Full `./gradlew release` with build JDK Corretto 25.0.4.1, `--target-jdk-version 25` and test JDK Corretto 25: 18636 tests, no failures, emitted classes at class-file major 69.
- `spotlessJavaCheck` passes on an unmodified tree with a Corretto 25 build JDK, so the pinned formatter both runs on 25 and agrees with the formatting already in the repo.
- JaCoCo 0.8.15's agent, core and report jars are still class-file major 49, which keeps the JDK 8 test jobs working.
