### PR TITLE
Add a macOS JDK 25 runtime CI job

### DIFF
--- a/.github/workflows/macos_ci_jobs.yml
+++ b/.github/workflows/macos_ci_jobs.yml
@@ -322,3 +322,49 @@ jobs:
       run: |
         ./tests/ci/run_accp_basic_tests.sh --lcov-ignore inconsistent --target-jdk-version 21
         ./tests/ci/run_accp_test_integration.sh
+  # JDK 25 Arm64 job. Corretto 25 is the runtime under test; the build runs on
+  # Corretto 21 because this repo's Gradle wrapper (8.11.1) cannot execute on
+  # JDK 25 -- that needs Gradle 9.1+. TARGET_JDK_VERSION therefore stays at 21,
+  # the newest bytecode level javac 21 can emit.
+  macOS25ArmTarget21:
+    name: JDK25ARM-TARGET-JDK21
+    runs-on: macos-latest-xlarge
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+    - name: Install lcov dependencies from brew
+      run: |
+        env HOMEBREW_NO_AUTO_UPDATE=1 brew install lcov golang
+    - name: Setup pip
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.12'
+        cache: 'pip'
+    - name: Install gcovr
+      run: |
+        pip install gcovr
+
+    # Set up Corretto 25 (the runtime we test against), saving its path, then
+    # Corretto 21 as the build JDK. JAVA_HOME ends up as Corretto 21.
+    - name: Set up corretto 25
+      uses: actions/setup-java@v3
+      with:
+        java-version: '25'
+        distribution: 'corretto'
+    - name: Get JAVA_HOME variable for corretto 25
+      run: |
+        echo "JAVA25_HOME=${{ env.JAVA_HOME }}" >> $GITHUB_ENV
+    - name: Set up corretto 21
+      uses: actions/setup-java@v3
+      with:
+        java-version: '21'
+        distribution: 'corretto'
+
+    # Test on Corretto 25. Built with JDK21 targeting JDK 21, but tested with JDK25.
+    - name: Build and run tests for ${{ env.PACKAGE_NAME }} in corretto 25
+      env:
+        TEST_JAVA_HOME: ${{ env.JAVA25_HOME }}
+      run: |
+        ./tests/ci/run_accp_basic_tests.sh --lcov-ignore inconsistent --target-jdk-version 21
+        ./tests/ci/run_accp_test_integration.sh


### PR DESCRIPTION
**Stack 1/4** -- bottom of the JDK 25 series. Targets `main`, no dependencies, mergeable on its own.

| # | Branch | Contents |
|---|---|---|
| **#583 (this PR)** | `accp-mac-jdk25-interim` | JDK 25 runtime job, builds/targets 21 |
| #580 | `accp-gradle9-compat` | `build.gradle` Gradle 9 compatibility |
| #581 | `accp-gradle9-wrapper` | Wrapper 8.11.1 -> 9.7.1 |
| #582 | `accp-jdk25-ci` | JDK 25 build/target job |

## What changed

`.github/workflows/macos_ci_jobs.yml` only, one new job (`JDK25ARM-TARGET-JDK21`). 46 added lines, nothing else touched.

Corretto 25 is the runtime under test. The build stays on Corretto 21 because this repo's Gradle wrapper (8.11.1) cannot execute on JDK 25 -- that needs Gradle 9.1+ -- so `TARGET_JDK_VERSION` stays at 21, the newest bytecode level javac 21 can emit. The job follows the same save-JAVA_HOME-then-install-build-JDK shape as the existing JDK 8 and JDK 11 jobs.

## Verification

Locally, with the unmodified 8.11.1 wrapper: build JDK Corretto 21, `--target-jdk-version 21`, `TEST_JAVA_HOME` Corretto 25. `./gradlew release` succeeded, exit 0.

## Why this is first in the stack

It gives JDK 25 signal without waiting on the Gradle 9 work, and it is the only one of the four with no prerequisites -- #581 additionally needs the internal CI Docker images rebuilt first.

#582 adds a `JDK25ARM-TARGET-JDK25` job that builds and targets 25 natively. Both jobs are kept: this one covers older bytecode running on the 25 runtime, the same way `JDK17ARM` and `JDK17ARM-TARGET-JDK17` coexist today. Since #582 sits above this PR in the stack, it also reworks this job's comment, which explains itself in terms of the wrapper being unable to run on 25 -- true here, but not after #581.

If you would rather not carry both jobs, say so and I will drop this PR and rebase the rest onto `main`.

Supersedes #539.