### PR TITLE
Compare ACCP's own ML-KEM PKCS#8 bytes on JDK 24 and later

### DIFF
--- a/tst/com/amazon/corretto/crypto/provider/test/EvpKeyFactoryTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/EvpKeyFactoryTest.java
@@ -330,8 +330,14 @@ public class EvpKeyFactoryTest {
             ? KeyFactory.getInstance(algorithm)
             : KeyFactory.getInstance(algorithm, getAlternateProvider(algorithm));
 
+    // ACCP hands back an already-PKCS#8-encoded key's own bytes, so a spec taken straight from a
+    // key another provider generated is that provider's encoding, not ACCP's. JDK 24 and later
+    // generate the ML-KEM pairs themselves, so translate those into ACCP first; otherwise both
+    // assertions below compare the JDK's bytes against themselves.
+    final PrivateKey nativePrivKey =
+        isMlKem(algorithm) ? (PrivateKey) nativeFactory.translateKey(privKey) : privKey;
     final PKCS8EncodedKeySpec nativeSpec =
-        nativeFactory.getKeySpec(privKey, PKCS8EncodedKeySpec.class);
+        nativeFactory.getKeySpec(nativePrivKey, PKCS8EncodedKeySpec.class);
 
     if (isMlKemWithExpandedOnlyEncoding(algorithm)) {
       // Against an AWS-LC that retains no keygen seed, such as the AWS-LC-FIPS 3.1.0 regular FIPS
@@ -765,7 +771,11 @@ public class EvpKeyFactoryTest {
   // coverage from any FIPS build whose AWS-LC does retain the seed; see
   // TestUtil.mlKemEmitsSeedEncoding.
   private static boolean isMlKemWithExpandedOnlyEncoding(final String algorithm) {
-    return algorithm.toUpperCase().startsWith("ML-KEM") && !TestUtil.mlKemEmitsSeedEncoding();
+    return isMlKem(algorithm) && !TestUtil.mlKemEmitsSeedEncoding();
+  }
+
+  private static boolean isMlKem(final String algorithm) {
+    return algorithm.toUpperCase().startsWith("ML-KEM");
   }
 
   // This method is used to determine whether tests should use an alternate provider for a given

--- a/tst/com/amazon/corretto/crypto/provider/test/EvpKeyFactoryTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/EvpKeyFactoryTest.java
@@ -332,8 +332,8 @@ public class EvpKeyFactoryTest {
 
     // ACCP hands back an already-PKCS#8-encoded key's own bytes, so a spec taken straight from a
     // key another provider generated is that provider's encoding, not ACCP's. JDK 24 and later
-    // generate the ML-KEM pairs themselves, so translate those into ACCP first; otherwise both
-    // assertions below compare the JDK's bytes against themselves.
+    // generate the ML-KEM pairs themselves, so translate those into ACCP first; otherwise the
+    // assertions below measure the JDK's encoding instead of ACCP's.
     final PrivateKey nativePrivKey =
         isMlKem(algorithm) ? (PrivateKey) nativeFactory.translateKey(privKey) : privKey;
     final PKCS8EncodedKeySpec nativeSpec =


### PR DESCRIPTION
### Description

- ACCP's `KeyFactory` returns an already-PKCS#8-encoded key's own bytes instead of re-encoding, so a spec taken from a key another provider generated is that provider's encoding.
- From JDK 24 the JDK ships ML-KEM, so the test generates those pairs itself and the spec under test was never ACCP's.
- Where ACCP can emit only the RFC 9935 expanded-key form, the round-trip compared the JDK's 86-byte seed encoding against ACCP's expanded re-encoding and failed. On builds that do emit seeds, it compared the JDK's bytes against themselves.
- Translate ML-KEM keys into ACCP before taking the spec: the round-trip now measures ACCP's encoding, and on JDK 24 and later the comparison against the JDK's own encoding is real again.
- Test-only change; no provider behavior changes.

### Testing / verification

- Ran `EvpKeyFactoryTest.testPKCS8Encoding` on JDK 25 against an ACCP linked to AWS-LC-FIPS 3.1.0, which retains no keygen seed: the four ML-KEM cases that fail today (86 vs 1660/2428/2428/3196 bytes) pass, and the remaining eight stay green.
- Ran the same test on JDK 25 against a seed-retaining ACCP, where the restored comparison now really runs: ACCP's re-encoding of a SunJCE ML-KEM private key is byte-identical to SunJCE's for every parameter set.
- Checked the reverse direction outside the test as well: SunJCE re-encodes an ACCP-generated ML-KEM private key to the same bytes ACCP emits.
- Both runs cover the generic `ML-KEM` service alias as well as the three named parameter sets.
