### PR TITLE
Give the ML-KEM and ML-DSA key spec tests a real reference provider

### DIFF
--- a/tst/com/amazon/corretto/crypto/provider/test/EvpKeyFactoryTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/EvpKeyFactoryTest.java
@@ -258,11 +258,29 @@ public class EvpKeyFactoryTest {
             ? KeyFactory.getInstance(algorithm)
             : KeyFactory.getInstance(algorithm, getAlternateProvider(algorithm));
 
+    // As in testPKCS8Encoding, ACCP hands back an already-X.509-encoded key's own bytes, so the
+    // spec has to come from a key ACCP owns for the comparison to measure ACCP's encoder.
+    final PublicKey nativePubKey =
+        isMlKemOrMlDsa(algorithm) ? (PublicKey) nativeFactory.translateKey(pubKey) : pubKey;
     final X509EncodedKeySpec nativeSpec =
-        nativeFactory.getKeySpec(pubKey, X509EncodedKeySpec.class);
-    final X509EncodedKeySpec jceSpec = jceFactory.getKeySpec(pubKey, X509EncodedKeySpec.class);
+        nativeFactory.getKeySpec(nativePubKey, X509EncodedKeySpec.class);
 
-    assertArrayEquals(jceSpec.getEncoded(), nativeSpec.getEncoded(), "X.509 encodings match");
+    if (isMlKemOrMlDsa(algorithm) && getAlternateProvider(algorithm) != null) {
+      // Before JDK 24 no JDK provider has ML-KEM or ML-DSA, so jceFactory is ACCP itself and
+      // comparing against it proves nothing. BouncyCastle agrees with ACCP on SPKI, so make it
+      // the reference: it has to accept ACCP's bytes and reproduce them. testPKCS8Encoding has
+      // no equivalent because BouncyCastle's private key encodings differ; see
+      // getAlternateProvider.
+      final KeyFactory bcFactory = KeyFactory.getInstance(algorithm, TestUtil.BC_PROVIDER);
+      final PublicKey bcKey = bcFactory.generatePublic(nativeSpec);
+      assertArrayEquals(
+          nativeSpec.getEncoded(),
+          bcFactory.getKeySpec(bcKey, X509EncodedKeySpec.class).getEncoded(),
+          "X.509 encodings match");
+    } else {
+      final X509EncodedKeySpec jceSpec = jceFactory.getKeySpec(pubKey, X509EncodedKeySpec.class);
+      assertArrayEquals(jceSpec.getEncoded(), nativeSpec.getEncoded(), "X.509 encodings match");
+    }
 
     // Get a spec with extra data
     final byte[] validSpec = nativeSpec.getEncoded();
@@ -332,10 +350,10 @@ public class EvpKeyFactoryTest {
 
     // ACCP hands back an already-PKCS#8-encoded key's own bytes, so a spec taken straight from a
     // key another provider generated is that provider's encoding, not ACCP's. JDK 24 and later
-    // generate the ML-KEM pairs themselves, so translate those into ACCP first; otherwise the
-    // assertions below measure the JDK's encoding instead of ACCP's.
+    // generate the ML-KEM and ML-DSA pairs themselves, so translate those into ACCP first;
+    // otherwise the assertions below measure the JDK's encoding instead of ACCP's.
     final PrivateKey nativePrivKey =
-        isMlKem(algorithm) ? (PrivateKey) nativeFactory.translateKey(privKey) : privKey;
+        isMlKemOrMlDsa(algorithm) ? (PrivateKey) nativeFactory.translateKey(privKey) : privKey;
     final PKCS8EncodedKeySpec nativeSpec =
         nativeFactory.getKeySpec(nativePrivKey, PKCS8EncodedKeySpec.class);
 
@@ -778,13 +796,21 @@ public class EvpKeyFactoryTest {
     return algorithm.toUpperCase().startsWith("ML-KEM");
   }
 
+  // The two algorithms whose keys ACCP encodes with its own DER writers and which no JDK provider
+  // has before JDK 24.
+  private static boolean isMlKemOrMlDsa(final String algorithm) {
+    return isMlKem(algorithm) || algorithm.toUpperCase().startsWith("ML-DSA");
+  }
+
   // This method is used to determine whether tests should use an alternate provider for a given
   // algorithm. In cases where JCE doesn't support the requested algorithm, the alternate provider
   // will be returned. In cases where JCE does support the requested algorithm, null will be
   // returned.
   private static Provider getAlternateProvider(String algorithm) {
     // JCE doesn't support ML-DSA until JDK24, and BouncyCastle currently serializes ML-DSA private
-    // keys via seeds.
+    // keys via seeds. Its ML-KEM private keys carry the seed and the expanded key together, a form
+    // AWS-LC rejects outright, so below JDK 24 there is no cross-provider reference for either
+    // algorithm's PKCS#8 encoding. Public keys are another matter; see testX509Encoding.
     // TODO: switch to BouncyCastle once BC supports CHOICE-encoded private keys
     // Similarly, JDK doesn't support EdDSA/Ed25519 until JDK15, and XDH/X25519 until JDK11
     Map<Integer, List<String>> jdkAlgorithmSupport = new HashMap<>();

--- a/tst/com/amazon/corretto/crypto/provider/test/EvpKeyFactoryTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/EvpKeyFactoryTest.java
@@ -330,8 +330,14 @@ public class EvpKeyFactoryTest {
             ? KeyFactory.getInstance(algorithm)
             : KeyFactory.getInstance(algorithm, getAlternateProvider(algorithm));
 
+    // ACCP hands back an already-PKCS#8-encoded key's own bytes, so a spec taken straight from a
+    // key another provider generated is that provider's encoding, not ACCP's. JDK 24 and later
+    // generate the ML-KEM pairs themselves, so translate those into ACCP first; otherwise both
+    // assertions below compare the JDK's bytes against themselves.
+    final PrivateKey nativePrivKey =
+        isMlKem(algorithm) ? (PrivateKey) nativeFactory.translateKey(privKey) : privKey;
     final PKCS8EncodedKeySpec nativeSpec =
-        nativeFactory.getKeySpec(privKey, PKCS8EncodedKeySpec.class);
+        nativeFactory.getKeySpec(nativePrivKey, PKCS8EncodedKeySpec.class);
 
     if (isMlKemWithExpandedOnlyEncoding(algorithm)) {
       // Against an AWS-LC that retains no keygen seed, such as the AWS-LC-FIPS 3.1.0 regular FIPS
@@ -765,7 +771,11 @@ public class EvpKeyFactoryTest {
   // coverage from any FIPS build whose AWS-LC does retain the seed; see
   // TestUtil.mlKemEmitsSeedEncoding.
   private static boolean isMlKemWithExpandedOnlyEncoding(final String algorithm) {
-    return algorithm.toUpperCase().startsWith("ML-KEM") && !TestUtil.mlKemEmitsSeedEncoding();
+    return isMlKem(algorithm) && !TestUtil.mlKemEmitsSeedEncoding();
+  }
+
+  private static boolean isMlKem(final String algorithm) {
+    return algorithm.toUpperCase().startsWith("ML-KEM");
   }
 
   // This method is used to determine whether tests should use an alternate provider for a given

--- a/tst/com/amazon/corretto/crypto/provider/test/EvpKeyFactoryTest.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/EvpKeyFactoryTest.java
@@ -332,8 +332,8 @@ public class EvpKeyFactoryTest {
 
     // ACCP hands back an already-PKCS#8-encoded key's own bytes, so a spec taken straight from a
     // key another provider generated is that provider's encoding, not ACCP's. JDK 24 and later
-    // generate the ML-KEM pairs themselves, so translate those into ACCP first; otherwise both
-    // assertions below compare the JDK's bytes against themselves.
+    // generate the ML-KEM pairs themselves, so translate those into ACCP first; otherwise the
+    // assertions below measure the JDK's encoding instead of ACCP's.
     final PrivateKey nativePrivKey =
         isMlKem(algorithm) ? (PrivateKey) nativeFactory.translateKey(privKey) : privKey;
     final PKCS8EncodedKeySpec nativeSpec =


### PR DESCRIPTION
### Description

- Stacked on #585, which fixes the JDK 25 FIPS break; the first two commits are that PR. Review the third.
- Extends the PKCS#8 fix to ML-DSA, which the JDK also ships from 24, so its comparison no longer measures the JDK's own encoding.
- Applies the same fix to `testX509Encoding`, which had the defect for both algorithms: ACCP returns an already-X.509-encoded key's own bytes, so the spec has to come from a key ACCP owns.
- Below JDK 24 no JDK provider has either algorithm, so the pairs come from ACCP and comparing against ACCP proves nothing. BouncyCastle reproduces ACCP's SPKI byte for byte, so it becomes the reference for public keys, giving ACCP's ML-KEM and ML-DSA encoders their first cross-provider check on JDK 17 and 21.
- Private keys get no such reference, and the comment above `getAlternateProvider` now says why: BouncyCastle emits ML-DSA seeds and ML-KEM seed-plus-expanded keys, a form AWS-LC rejects outright.

### Testing / verification

- Ran both tests across JDK 17, 21 and 25 against ACCP linked to four AWS-LC pins: v5.8.0, v5.8.0 experimental FIPS, v5.7.0 FIPS and AWS-LC-FIPS 3.1.0. Every ML-KEM and ML-DSA parameter set agrees on SPKI with BouncyCastle, including the seedless FIPS 3.1.0 pin, whose ML-KEM public keys ACCP encodes with its own DER writer.
- Confirmed the ML-DSA private key case on JDK 25: ACCP's re-encoding of a SunJCE ML-DSA key matches SunJCE's 54-byte seed encoding for all three parameter sets.
- Checked the new public key assertion has teeth: BouncyCastle rejects an ACCP SPKI whose parameter-set OID is perturbed, and rejects a truncated one.
- Established that BouncyCastle cannot serve as the private key reference: AWS-LC fails to decode its ML-KEM PKCS#8 outright, and its ML-DSA PKCS#8 carries the expanded key where ACCP emits a seed.
