### PR TITLE
Document module-path native access and check it in CI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -961,6 +961,29 @@ add_custom_target(check-install-via-properties
 
     DEPENDS accp-jar tests-jar)
 
+# JEP 472 grants native access per module, so a module-path deployment must name
+# ACCP's module rather than ALL-UNNAMED. --illegal-native-access=deny makes an
+# unmatched grant fatal, which is the JDK's future default.
+if (TEST_JAVA_MAJOR_VERSION VERSION_GREATER_EQUAL 24)
+    add_custom_target(check-native-access-module-path
+        COMMAND ${TEST_JAVA_EXECUTABLE}
+            ${COVERAGE_ARGUMENTS}
+            ${TEST_FIPS_PROPERTY}
+            --module-path $<TARGET_PROPERTY:accp-jar,JAR_FILE>
+            --add-modules com.amazon.corretto.crypto.provider
+            --enable-native-access=com.amazon.corretto.crypto.provider
+            --illegal-native-access=deny
+            -cp $<TARGET_PROPERTY:tests-jar,JAR_FILE>:${TEST_CLASSPATH}
+            ${EXTERNAL_LIB_PROPERTY}
+            -Dcom.amazon.corretto.crypto.provider.inTestSuite=hunter2
+            -Dtest.data.dir=${TEST_DATA_DIR}
+            -Djava.security.properties=${INSTALL_PROPERTY_FILE}
+            ${TEST_JAVA_ARGS}
+            com.amazon.corretto.crypto.provider.test.SecurityPropertyTester
+
+        DEPENDS accp-jar tests-jar)
+endif()
+
 add_custom_target(check-external-lib
     # Unfortunately we do not have a way to know where the library is loaded from.
     # So this test just proves that requesting the external lib does not break things
@@ -1031,6 +1054,10 @@ set(check_targets
     check-junit-DifferentTempDir
     check-junit-edKeyFactory
     check-junit-FipsStatus)
+
+if(TARGET check-native-access-module-path)
+  set(check_targets ${check_targets} check-native-access-module-path)
+endif()
 
 if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
   set(check_targets ${check_targets} check-with-jni-flag)

--- a/README.md
+++ b/README.md
@@ -213,17 +213,27 @@ ACCP has the following requirements:
 * JDK8 or newer (This includes both OracleJDK and [Amazon Corretto](https://aws.amazon.com/corretto/))
 * Linux (x86-64 or arm64) or MacOs running on x86_64 (also known as x64 or AMD64)
 
-## JDK 25+ Native Access
-Starting with JDK 25, the JVM [warns](https://openjdk.org/jeps/472) when native libraries are loaded without explicit native access enabled.
-To suppress these warnings when using ACCP, add the following JVM argument as described [here](https://docs.oracle.com/en/java/javase/25/core/restricted-methods.html):
+## JDK 24+ Native Access
+Starting with JDK 24, the JVM [warns](https://openjdk.org/jeps/472) when native libraries are loaded without explicit native access enabled.
+To suppress these warnings when using ACCP, grant native access to the module ACCP is loaded into, as described [here](https://docs.oracle.com/en/java/javase/25/core/restricted-methods.html):
+
+| ACCP is on the | JVM argument |
+| --- | --- |
+| class path | `--enable-native-access=ALL-UNNAMED` |
+| module path | `--enable-native-access=com.amazon.corretto.crypto.provider` |
+
+`ALL-UNNAMED` names the unnamed module only, so a module-path deployment must name ACCP's module.
+
+If you are producing an executable JAR, `Enable-Native-Access: ALL-UNNAMED` in its manifest replaces the class-path argument, as described [here](https://docs.oracle.com/en/java/javase/25/docs/specs/jar/jar.html#jar-manifest). The JVM reads that attribute from the JAR it launches, so adding it to a library JAR has no effect.
+
+Native access will be denied by default in a future JDK release, at which point a missing grant stops ACCP from initializing:
 
 ```
---enable-native-access=ALL-UNNAMED
+com.amazon.corretto.crypto.provider.RuntimeCryptoException: Unable to load native library
+Caused by: java.lang.IllegalCallerException: Illegal native access from module com.amazon.corretto.crypto.provider
 ```
 
-Or, if you're producing an executable JAR, you can update the JAR manifest as described [here](https://docs.oracle.com/en/java/javase/25/docs/specs/jar/jar.html#jar-manifest).
-
-This flag/manifest update will become required in a future JDK release when native access is denied by default.
+Add `--illegal-native-access=deny` to get that behavior today and confirm your grant is correct.
 
 # Using the provider
 ## Installation


### PR DESCRIPTION
## Description

- Documents the module-name form of the JEP 472 grant, `--enable-native-access=com.amazon.corretto.crypto.provider`, alongside the `ALL-UNNAMED` form that only covers class-path deployments.
- Corrects the requirement to JDK 24, where the warning starts, and quotes the initialization failure a missing grant produces once access is denied.
- Notes that the JVM reads `Enable-Native-Access` from the JAR it launches, so ACCP cannot set it for consumers.
- Adds a CI check that installs ACCP from the module path under `--illegal-native-access=deny`, so the targeted grant cannot silently break.
- Closes #544.

## Testing / verification

- The new check runs on Corretto 25 and passes; dropping the grant, or substituting `ALL-UNNAMED`, fails it with `IllegalCallerException: Illegal native access from module com.amazon.corretto.crypto.provider`, so the check tests the grant rather than the flag.
- Configuring with a JDK 17 test runtime omits the target entirely, since `--illegal-native-access=deny` does not exist before JDK 24.
- Costs 1.4 s per run on a dev box, and the check suite runs twice per job, so the JDK 25 jobs get about 3 s longer and every other job is untouched.
- Passes with the JaCoCo agent attached, which is the form the coverage build runs, and matters because the deny flag applies to the whole JVM.
- `ALL-UNNAMED` on the class path under `--illegal-native-access=deny` still passes on Corretto 25, which is the advice the README keeps for class-path users.
